### PR TITLE
poc: content-creator #2 — post image+caption to FB page

### DIFF
--- a/scripts/poc-fb-post.ts
+++ b/scripts/poc-fb-post.ts
@@ -46,7 +46,8 @@ async function main() {
   form.append("message", caption);
   form.append("published", "false");
   form.append("access_token", PAGE_TOKEN);
-  form.append("source", new Blob([image.uint8Array], { type: "image/png" }), "tarot.png");
+  // wrap ใน new Uint8Array(...) → Uint8Array<ArrayBuffer> (BlobPart ที่ TS strict ยอมรับ)
+  form.append("source", new Blob([new Uint8Array(image.uint8Array)], { type: "image/png" }), "tarot.png");
 
   const res = await fetch(`https://graph.facebook.com/${V}/${PAGE_ID}/photos`, {
     method: "POST",

--- a/scripts/poc-fb-post.ts
+++ b/scripts/poc-fb-post.ts
@@ -1,0 +1,71 @@
+/**
+ * POC #2 — content-creator: พิสูจน์ post ภาพ+caption ขึ้น FB page ผ่าน Graph API
+ *
+ * lab-first end-to-end: gen ภาพ+caption (Gemini, จาก POC #1) → upload ขึ้นเพจแบบ UNPUBLISHED
+ * (published=false) — ไม่ขึ้น feed สาธารณะ เพราะเพจ MimiVibe เป็น production
+ *
+ * รัน: node --env-file=.env.local --import tsx scripts/poc-fb-post.ts
+ * ต้องมี: GOOGLE_GENERATIVE_AI_API_KEY, CONTENT_FB_PAGE_ID, CONTENT_FB_PAGE_ACCESS_TOKEN
+ */
+import { google } from "@ai-sdk/google";
+import { generateText, experimental_generateImage as generateImage } from "ai";
+
+const V = "v23.0";
+const PAGE_ID = process.env.CONTENT_FB_PAGE_ID!;
+const PAGE_TOKEN = process.env.CONTENT_FB_PAGE_ACCESS_TOKEN!;
+const TEXT_MODEL = process.env.MODEL_NAME || "gemini-2.5-flash";
+const IMAGE_MODEL = process.env.IMAGE_MODEL_NAME || "imagen-4.0-generate-001";
+
+const MOCK = {
+  card: "Ace of Coins",
+  meaning: "วันศุกร์ได้ไพ่ 1 เหรียญ โอกาสจับเงินก้อนใหญ่ มีโชคลาภ รายได้ช่องทางใหม่",
+};
+
+async function main() {
+  console.log("🔮 POC #2 — gen → post (UNPUBLISHED) ขึ้นเพจ MimiVibe\n");
+
+  // 1) caption + image (reuse POC #1)
+  const { text: caption } = await generateText({
+    model: google(TEXT_MODEL),
+    temperature: 0.8, // ตู๋ nit (b): คุม tone caption
+    system:
+      'คุณคือ "หมอมี่" หมอดูไพ่ยิปซีสายฟีลกู้ด ใช้คำ พี่หมี่/ปังมาก/แม่. แคปชั่นดวงการเงิน Facebook สั้น 2-3 ประโยค จบด้วย #ดูดวงการเงิน #หมอมี่',
+    prompt: `ไพ่: ${MOCK.card}\nความหมาย: ${MOCK.meaning}\nเขียนแคปชั่น:`,
+  });
+  console.log("── CAPTION ──\n" + caption + "\n");
+
+  const { image } = await generateImage({
+    model: google.image(IMAGE_MODEL),
+    prompt: `ภาพไพ่ยิปซี ${MOCK.card} สไตล์โมเดิร์น สื่อโชคลาภการเงิน เงินก้อนใหญ่ โทนทองอบอุ่นมงคล`,
+    aspectRatio: "1:1",
+  });
+  console.log(`── IMAGE ── gen แล้ว (${image.uint8Array.length} bytes)\n`);
+
+  // 2) upload ขึ้นเพจ — published=false (unpublished, ไม่ขึ้น feed สาธารณะ)
+  const form = new FormData();
+  form.append("message", caption);
+  form.append("published", "false");
+  form.append("access_token", PAGE_TOKEN);
+  form.append("source", new Blob([image.uint8Array], { type: "image/png" }), "tarot.png");
+
+  const res = await fetch(`https://graph.facebook.com/${V}/${PAGE_ID}/photos`, {
+    method: "POST",
+    body: form,
+  });
+  const data = await res.json();
+  if (data.error) throw new Error(`FB post fail: ${data.error.message} (code ${data.error.code})`);
+
+  console.log("── FB RESULT ──");
+  console.log(`✅ โพสต์ unpublished สำเร็จ — photo id: ${data.id}${data.post_id ? `, post_id: ${data.post_id}` : ""}`);
+
+  // 3) verify รูปอยู่จริงบนเพจ (ยัง unpublished)
+  const chk = await fetch(`https://graph.facebook.com/${V}/${data.id}?fields=id,created_time,published&access_token=${PAGE_TOKEN}`).then((r) => r.json());
+  console.log(`── VERIFY ── id=${chk.id} created=${chk.created_time} published=${chk.published}`);
+  console.log("\n✅ POC #2 ผ่าน — gen → post ขึ้นเพจได้จริง (unpublished, ปลอดภัยกับเพจ production)");
+  console.log(`💡 ลบรูปเทสต์: DELETE /${data.id} (หรือลบใน Meta Business Suite > Content)`);
+}
+
+main().catch((err) => {
+  console.error("\n❌ POC #2 ล้มเหลว:", err?.message || err);
+  process.exit(1);
+});


### PR DESCRIPTION
## POC #2 — พิสูจน์ FB posting (lab-first)
ก้าวที่สองของ feature **content-creator**. ต่อจาก POC #1 (Gemini gen) — POC นี้พิสูจน์ว่า **post ภาพ+caption ขึ้นเพจ Facebook** ผ่าน Graph API ได้จริง

`scripts/poc-fb-post.ts` — gen ภาพ+caption (Gemini) → upload ขึ้นเพจ

## ผล ✅
- **gen**: caption (gemini-2.5-flash, temp 0.8) + image (imagen-4.0-generate-001) — reuse POC #1
- **post**: `POST /{page-id}/photos` แบบ **`published=false` (UNPUBLISHED)** ผ่าน multipart `FormData` (Node 22 built-in, ไม่ต้อง dep เพิ่ม)
- **verified**: photo สร้างจริง (id `1221...787`, created 2026-06-12) + **ไม่อยู่ใน `published_posts`** → ไม่ขึ้น feed สาธารณะ

## ⚠️ ความปลอดภัยกับเพจ production
เพจเป้าหมาย **"แม่หมอมีมี่ - MimiVibe" เป็นเพจจริง** — POC ใช้ `published=false` เด็ดขาด เพื่อไม่ให้รูปเทสต์ขึ้น feed ของผู้ติดตาม (verify แล้วว่าไม่ขึ้นจริง)

## token
long-lived **page token (ไม่หมดอายุ)** ได้จาก `fb_exchange_token` (short→long user) → `/me/accounts`. token เดิมที่ใส่มาเป็น short-lived หมดอายุไปแล้ว — verify ก่อนช่วยจับได้ก่อนเขียน POC

## carry-forward (ตู๋ gate จาก PR#84)
- (b) temperature: ✅ ใส่ 0.8 ใน POC นี้แล้ว
- (a) return bytes / (c) env แยก: ยัง carry ไปทำตอน `lib/gemini.ts` + `lib/facebook.ts` จริง (POC ยังโพสต์ตรง)

## วิธีรัน
```
node --env-file=.env.local --import tsx scripts/poc-fb-post.ts
```
ต้องมี `CONTENT_FB_PAGE_ID`, `CONTENT_FB_PAGE_ACCESS_TOKEN`, `GOOGLE_GENERATIVE_AI_API_KEY`

## ตรงไหนควรตรวจ
- ใช้ `published=false` ถูกต้องสำหรับ "post แล้วรอ approve" ไหม (จริงๆ flow เราคือ approve ก่อนค่อย post — lib จริงจะ post published หลัง approve)
- multipart upload via `source` (Blob) เหมาะ reuse เป็น `lib/facebook.ts` ไหม
- รูปเทสต์ unpublished ยังค้างใน photo library ของเพจ (ลบได้: `DELETE /{photo-id}`)

🤖 ตอบโดย goo จาก [ฟีม] → goo-oracle