### PR TITLE
feat: content-creator lib — gemini + facebook (POC #3, Gate A+B)

### DIFF
--- a/content-creator/__tests__/config.test.ts
+++ b/content-creator/__tests__/config.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { GRAPH_VERSION, graphUrl, TEXT_MODEL, IMAGE_MODEL } from "../lib/config";
+
+describe("config", () => {
+  it("GRAPH_VERSION มีรูปแบบ vNN (default v23.0)", () => {
+    expect(GRAPH_VERSION).toMatch(/^v\d+(\.\d+)?$/);
+  });
+
+  it("graphUrl ประกอบ URL ถูก + ตัด leading slash", () => {
+    expect(graphUrl("123/photos")).toBe(`https://graph.facebook.com/${GRAPH_VERSION}/123/photos`);
+    expect(graphUrl("/123/feed")).toBe(`https://graph.facebook.com/${GRAPH_VERSION}/123/feed`);
+  });
+
+  it("graphUrl ไม่มี access_token ใน URL", () => {
+    expect(graphUrl("123/photos")).not.toContain("access_token");
+  });
+
+  it("model defaults (POC verified)", () => {
+    expect(TEXT_MODEL).toBeTruthy();
+    expect(IMAGE_MODEL).toBeTruthy();
+  });
+});

--- a/content-creator/__tests__/facebook.test.ts
+++ b/content-creator/__tests__/facebook.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fbFetch, uploadUnpublishedPhoto, publishToFeed } from "../lib/facebook";
+
+const okJson = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("fbFetch — security & robustness (Gate B)", () => {
+  it("[SEC] ส่ง token ใน Authorization header ไม่ใช่ใน URL", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValue(okJson({ id: "1" }));
+    await fbFetch("123/photos", { token: "SECRET", method: "POST" });
+
+    const [url, init] = spy.mock.calls[0];
+    expect(String(url)).not.toContain("SECRET"); // token ไม่อยู่ใน URL
+    expect(String(url)).not.toContain("access_token");
+    expect((init as RequestInit).headers).toMatchObject({ Authorization: "Bearer SECRET" });
+  });
+
+  it("ใช้ GRAPH_VERSION จาก config ใน URL", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValue(okJson({ id: "1" }));
+    await fbFetch("123/feed", { token: "t" });
+    expect(String(spy.mock.calls[0][0])).toMatch(/graph\.facebook\.com\/v\d+/);
+  });
+
+  it("retry เมื่อเจอ 429 แล้วสำเร็จ", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(okJson({ error: "rate" }, 429))
+      .mockResolvedValueOnce(okJson({ id: "ok" }));
+    const out = await fbFetch<{ id: string }>("123/feed", { token: "t", maxRetries: 2 });
+    expect(out.id).toBe("ok");
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it("throw ทันทีเมื่อ 400 (non-retryable) — ไม่ retry", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValue(okJson({ error: "bad" }, 400));
+    await expect(fbFetch("123/feed", { token: "t" })).rejects.toThrow(/FB Graph 400/);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("throw เมื่อ res.ok=false (ไม่เรียก .json() กำกวม)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("<!DOCTYPE html>500", { status: 500 }));
+    await expect(fbFetch("x", { token: "t", maxRetries: 0 })).rejects.toThrow(/FB Graph 500/);
+  });
+});
+
+describe("uploadUnpublishedPhoto — เตรียม media (publish-on-approve)", () => {
+  it("ส่ง published=false + ไม่มี access_token ใน body, คืน media_fbid", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValue(okJson({ id: "media_99" }));
+    const id = await uploadUnpublishedPhoto({ pageId: "P", token: "t", bytes: new Uint8Array([1, 2, 3]) });
+
+    expect(id).toBe("media_99");
+    const form = (spy.mock.calls[0][1] as RequestInit).body as FormData;
+    expect(form.get("published")).toBe("false");
+    expect(form.get("access_token")).toBeNull(); // token ไม่อยู่ใน body (อยู่ header)
+    expect(String(spy.mock.calls[0][0])).toContain("P/photos");
+  });
+});
+
+describe("publishToFeed — publish ตอน approve", () => {
+  it("แนบ attached_media[0] ด้วย media_fbid, คืน post id", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValue(okJson({ id: "post_1" }));
+    const id = await publishToFeed({ pageId: "P", token: "t", mediaFbid: "media_99", message: "hi" });
+
+    expect(id).toBe("post_1");
+    const form = (spy.mock.calls[0][1] as RequestInit).body as FormData;
+    expect(form.get("message")).toBe("hi");
+    expect(JSON.parse(String(form.get("attached_media[0]")))).toEqual({ media_fbid: "media_99" });
+    expect(String(spy.mock.calls[0][0])).toContain("P/feed");
+  });
+});

--- a/content-creator/__tests__/facebook.test.ts
+++ b/content-creator/__tests__/facebook.test.ts
@@ -69,4 +69,34 @@ describe("publishToFeed — publish ตอน approve", () => {
     expect(JSON.parse(String(form.get("attached_media[0]")))).toEqual({ media_fbid: "media_99" });
     expect(String(spy.mock.calls[0][0])).toContain("P/feed");
   });
+
+  it("[P1] ไม่ retry เมื่อ 503 — กันโพสต์ซ้ำ (POST /feed ไม่ idempotent)", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValue(okJson({ error: "down" }, 503));
+    await expect(
+      publishToFeed({ pageId: "P", token: "t", mediaFbid: "m", message: "hi" }),
+    ).rejects.toThrow(/FB Graph 503/);
+    expect(spy).toHaveBeenCalledTimes(1); // ไม่ retry แม้ 503 (retryable status) — กันโพสต์ซ้ำ
+  });
+});
+
+describe("[P2] timeout ครอบการอ่าน response body", () => {
+  it("abort เมื่อ body ค้างเกิน timeout (ไม่ใช่แค่ headers)", async () => {
+    // fetch resolve headers ทันที แต่ .json() ค้าง — ยกเลิกเมื่อ signal abort เท่านั้น
+    vi.spyOn(globalThis, "fetch").mockImplementation((_url, init) => {
+      const signal = (init as RequestInit).signal as AbortSignal | undefined;
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          new Promise((_resolve, reject) => {
+            if (signal?.aborted) return reject(new DOMException("aborted", "AbortError"));
+            signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")));
+          }),
+        text: () => Promise.resolve(""),
+      } as unknown as Response);
+    });
+
+    // timer ต้องยัง active ตอนอ่าน body → abort fire → throw
+    // (ถ้า clear timer ก่อนอ่าน body แบบเก่า test นี้จะ hang)
+    await expect(fbFetch("x/feed", { token: "t", timeoutMs: 50, maxRetries: 0 })).rejects.toThrow();
+  });
 });

--- a/content-creator/__tests__/gemini.test.ts
+++ b/content-creator/__tests__/gemini.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// mock ai + @ai-sdk/google (ไม่ยิง API จริง — live พิสูจน์แล้วใน POC #1)
+const { mockGenerateText, mockGenerateImage } = vi.hoisted(() => ({
+  mockGenerateText: vi.fn(),
+  mockGenerateImage: vi.fn(),
+}));
+vi.mock("ai", () => ({
+  generateText: mockGenerateText,
+  experimental_generateImage: mockGenerateImage,
+}));
+vi.mock("@ai-sdk/google", () => ({
+  google: Object.assign((id: string) => ({ modelId: id }), { image: (id: string) => ({ imageId: id }) }),
+}));
+
+import { genCaption, genImage } from "../lib/gemini";
+import { DEFAULT_CAPTION_TEMPERATURE } from "../lib/config";
+
+beforeEach(() => {
+  mockGenerateText.mockReset();
+  mockGenerateImage.mockReset();
+});
+
+describe("genCaption (Gate A)", () => {
+  it("คืน text จาก generateText", async () => {
+    mockGenerateText.mockResolvedValue({ text: "ปังมากแม่!" });
+    const out = await genCaption({ system: "หมอมี่", prompt: "ไพ่ 8 ไม้เท้า" });
+    expect(out).toBe("ปังมากแม่!");
+  });
+
+  it("ใช้ temperature default เมื่อไม่ระบุ + ส่ง system/prompt", async () => {
+    mockGenerateText.mockResolvedValue({ text: "x" });
+    await genCaption({ system: "S", prompt: "P" });
+    expect(mockGenerateText).toHaveBeenCalledWith(
+      expect.objectContaining({ system: "S", prompt: "P", temperature: DEFAULT_CAPTION_TEMPERATURE }),
+    );
+  });
+
+  it("ใช้ temperature ที่ override มา", async () => {
+    mockGenerateText.mockResolvedValue({ text: "x" });
+    await genCaption({ system: "S", prompt: "P", temperature: 0.2 });
+    expect(mockGenerateText).toHaveBeenCalledWith(expect.objectContaining({ temperature: 0.2 }));
+  });
+});
+
+describe("genImage (Gate A — return bytes)", () => {
+  it("คืน Uint8Array จาก generateImage (ไม่ write file)", async () => {
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    mockGenerateImage.mockResolvedValue({ image: { uint8Array: bytes } });
+    const out = await genImage({ prompt: "ไพ่" });
+    expect(out).toBeInstanceOf(Uint8Array);
+    expect(Array.from(out)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("default aspectRatio = 1:1", async () => {
+    mockGenerateImage.mockResolvedValue({ image: { uint8Array: new Uint8Array() } });
+    await genImage({ prompt: "ไพ่" });
+    expect(mockGenerateImage).toHaveBeenCalledWith(expect.objectContaining({ aspectRatio: "1:1" }));
+  });
+});

--- a/content-creator/lib/config.ts
+++ b/content-creator/lib/config.ts
@@ -1,0 +1,19 @@
+/**
+ * content-creator config — env/version แยกจาก mmv core (Gate A: env แยก, Gate B: version ไม่ hardcode)
+ */
+
+/** Graph API version — config ไม่ hardcode ในแต่ละ call (Meta deprecate ~2 ปี) */
+export const GRAPH_VERSION = process.env.FB_GRAPH_VERSION || "v23.0";
+
+/** สร้าง Graph API URL จาก path (ไม่มี access_token ใน URL — token ไป header, ดู facebook.ts) */
+export const graphUrl = (path: string): string =>
+  `https://graph.facebook.com/${GRAPH_VERSION}/${path.replace(/^\//, "")}`;
+
+/** model สำหรับ caption — env แยก ไม่ reuse MODEL_NAME ของ mystic (Gate A) */
+export const TEXT_MODEL = process.env.CONTENT_TEXT_MODEL || "gemini-2.5-flash";
+
+/** model สำหรับภาพ — env แยก */
+export const IMAGE_MODEL = process.env.CONTENT_IMAGE_MODEL || "imagen-4.0-generate-001";
+
+/** caption temperature เริ่มต้น (คุม tone — override ได้ต่อ call) */
+export const DEFAULT_CAPTION_TEMPERATURE = 0.8;

--- a/content-creator/lib/facebook.ts
+++ b/content-creator/lib/facebook.ts
@@ -41,8 +41,8 @@ export async function fbFetch<T = unknown>(path: string, opts: FbFetchOptions): 
         body,
         signal: controller.signal,
       });
-      clearTimeout(timer);
-
+      // P2: อ่าน body "ก่อน" clear timer — timeout จึงครอบการอ่าน body ที่อาจค้างด้วย
+      // (clear timer ใน finally หลังอ่านเสร็จ/พังเสมอ)
       if (!res.ok) {
         const text = await res.text().catch(() => "");
         if (RETRYABLE_STATUS.has(res.status) && attempt < maxRetries) {
@@ -54,7 +54,6 @@ export async function fbFetch<T = unknown>(path: string, opts: FbFetchOptions): 
       }
       return (await res.json()) as T;
     } catch (err) {
-      clearTimeout(timer);
       const isAbort = err instanceof Error && err.name === "AbortError";
       if (isAbort && attempt < maxRetries) {
         lastError = err as Error;
@@ -62,6 +61,8 @@ export async function fbFetch<T = unknown>(path: string, opts: FbFetchOptions): 
         continue;
       }
       throw err;
+    } finally {
+      clearTimeout(timer); // P2: clear หลัง body read เสมอ (ไม่ clear ก่อนอ่าน body)
     }
   }
   throw lastError ?? new Error("fbFetch: exhausted retries");
@@ -108,10 +109,14 @@ export async function publishToFeed(input: PublishInput): Promise<string> {
   form.append("message", input.message);
   form.append("attached_media[0]", JSON.stringify({ media_fbid: input.mediaFbid }));
 
+  // P1: ปิด auto-retry — POST /feed ไม่ idempotent. ถ้า FB สร้าง public post สำเร็จแล้ว
+  // แต่ response หาย/5xx การ retry จะโพสต์ซ้ำ. fail ชัด ๆ ให้ caller ตัดสิน (reconcile/แจ้งคน)
+  // ดีกว่าโพสต์ซ้ำบนเพจ
   const data = await fbFetch<{ id: string }>(`${input.pageId}/feed`, {
     token: input.token,
     method: "POST",
     body: form,
+    maxRetries: 0,
   });
   return data.id; // post id
 }

--- a/content-creator/lib/facebook.ts
+++ b/content-creator/lib/facebook.ts
@@ -1,0 +1,117 @@
+/**
+ * content-creator/lib/facebook.ts — post ขึ้น FB page ผ่าน Graph API (Gate B)
+ *
+ * Gate B (จาก ตู๋ review PR#85):
+ *  - [SEC] token ไป header Authorization: Bearer (ไม่ใส่ URL query — กัน log/history leak)
+ *  - Graph version จาก config (ไม่ hardcode)
+ *  - res.ok check ก่อน .json() + timeout + retry 429/5xx
+ *  - publish-on-approve: upload unpublished (เก็บ media_fbid) → publishToFeed ตอน approve
+ */
+import { graphUrl } from "./config";
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_MAX_RETRIES = 2;
+const RETRYABLE_STATUS = new Set([429, 500, 502, 503, 504]);
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+export interface FbFetchOptions {
+  token: string;
+  method?: "GET" | "POST" | "DELETE";
+  body?: BodyInit;
+  timeoutMs?: number;
+  maxRetries?: number;
+}
+
+/**
+ * Graph API fetch wrapper — token ใน header, ตรวจ res.ok, timeout, retry.
+ * @throws Error ถ้า non-2xx (non-retryable หรือ retry หมด) หรือ network/timeout
+ */
+export async function fbFetch<T = unknown>(path: string, opts: FbFetchOptions): Promise<T> {
+  const { token, method = "GET", body, timeoutMs = DEFAULT_TIMEOUT_MS, maxRetries = DEFAULT_MAX_RETRIES } = opts;
+  let lastError: Error | undefined;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetch(graphUrl(path), {
+        method,
+        headers: { Authorization: `Bearer ${token}` }, // [SEC] token ใน header ไม่ใช่ URL
+        body,
+        signal: controller.signal,
+      });
+      clearTimeout(timer);
+
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        if (RETRYABLE_STATUS.has(res.status) && attempt < maxRetries) {
+          lastError = new Error(`FB ${res.status}: ${text.slice(0, 200)}`);
+          await sleep(2 ** attempt * 500);
+          continue;
+        }
+        throw new Error(`FB Graph ${res.status}: ${text.slice(0, 300)}`);
+      }
+      return (await res.json()) as T;
+    } catch (err) {
+      clearTimeout(timer);
+      const isAbort = err instanceof Error && err.name === "AbortError";
+      if (isAbort && attempt < maxRetries) {
+        lastError = err as Error;
+        await sleep(2 ** attempt * 500);
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw lastError ?? new Error("fbFetch: exhausted retries");
+}
+
+export interface UploadInput {
+  pageId: string;
+  token: string;
+  bytes: Uint8Array;
+  filename?: string;
+}
+
+/**
+ * upload ภาพแบบ unpublished (published=false) — ยังไม่ขึ้น feed, คืน media_fbid ไว้ publish ทีหลัง.
+ * นี่คือขั้น "เตรียม media" ของ flow publish-on-approve.
+ */
+export async function uploadUnpublishedPhoto(input: UploadInput): Promise<string> {
+  const form = new FormData();
+  form.append("published", "false");
+  // wrap new Uint8Array(...) → Uint8Array<ArrayBuffer> (BlobPart ที่ TS strict ยอมรับ — บทเรียน PR#85)
+  form.append("source", new Blob([new Uint8Array(input.bytes)], { type: "image/png" }), input.filename ?? "image.png");
+
+  const data = await fbFetch<{ id: string }>(`${input.pageId}/photos`, {
+    token: input.token,
+    method: "POST",
+    body: form,
+  });
+  return data.id; // media_fbid
+}
+
+export interface PublishInput {
+  pageId: string;
+  token: string;
+  mediaFbid: string;
+  message: string;
+}
+
+/**
+ * publish โพสต์ขึ้น feed โดยแนบรูปที่ upload ไว้ — เรียกตอน "approve" แล้ว.
+ * publish-on-approve: POST /{page}/feed + attached_media[{media_fbid}]
+ */
+export async function publishToFeed(input: PublishInput): Promise<string> {
+  const form = new FormData();
+  form.append("message", input.message);
+  form.append("attached_media[0]", JSON.stringify({ media_fbid: input.mediaFbid }));
+
+  const data = await fbFetch<{ id: string }>(`${input.pageId}/feed`, {
+    token: input.token,
+    method: "POST",
+    body: form,
+  });
+  return data.id; // post id
+}

--- a/content-creator/lib/gemini.ts
+++ b/content-creator/lib/gemini.ts
@@ -1,0 +1,49 @@
+/**
+ * content-creator/lib/gemini.ts — gen caption + image ผ่าน Gemini (Gate A)
+ *
+ * Gate A (จาก ตู๋ review PR#84):
+ *  - genImage คืน Uint8Array ให้ caller จัดการ persist เอง (ไม่ writeFileSync ในนี้)
+ *  - temperature เป็น param (คุม tone)
+ *  - model จาก env แยก (CONTENT_TEXT_MODEL / CONTENT_IMAGE_MODEL) ไม่ reuse MODEL_NAME
+ *
+ * พิสูจน์ feasibility แล้วใน POC #1 (gemini-2.5-flash + imagen-4.0-generate-001)
+ */
+import { google } from "@ai-sdk/google";
+import { generateText, experimental_generateImage as generateImage } from "ai";
+import { TEXT_MODEL, IMAGE_MODEL, DEFAULT_CAPTION_TEMPERATURE } from "./config";
+
+export interface CaptionInput {
+  /** system prompt — กำหนด persona/รูปแบบ (เช่น tone หมอมี่) */
+  system: string;
+  /** user prompt — ข้อมูล content ที่จะเขียนถึง */
+  prompt: string;
+  /** คุม tone; default DEFAULT_CAPTION_TEMPERATURE */
+  temperature?: number;
+}
+
+/** gen caption → ข้อความ */
+export async function genCaption(input: CaptionInput): Promise<string> {
+  const { text } = await generateText({
+    model: google(TEXT_MODEL),
+    system: input.system,
+    prompt: input.prompt,
+    temperature: input.temperature ?? DEFAULT_CAPTION_TEMPERATURE,
+  });
+  return text;
+}
+
+export interface ImageInput {
+  prompt: string;
+  /** สัดส่วนภาพ; default "1:1" (เหมาะ FB square) */
+  aspectRatio?: "1:1" | "16:9" | "9:16" | "4:3" | "3:4";
+}
+
+/** gen ภาพ → Uint8Array (caller จัดการ persist/upload เอง — Gate A) */
+export async function genImage(input: ImageInput): Promise<Uint8Array> {
+  const { image } = await generateImage({
+    model: google.image(IMAGE_MODEL),
+    prompt: input.prompt,
+    aspectRatio: input.aspectRatio ?? "1:1",
+  });
+  return image.uint8Array;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     globals: true,
     include: [
       '__tests__/**/*.{test,spec}.{js,ts,tsx}',
+      'content-creator/**/*.{test,spec}.{js,ts,tsx}',
     ],
   },
   resolve: {


### PR DESCRIPTION
## POC #3 — POC → production lib
ก้าวที่ POC 1-2 (scripts ทดลอง) กลายเป็น **lib จริง** สำหรับ feature content-creator. scope: **2 lib + test** (lab-first — DB/UI/scheduler เป็น step ถัดไป)

`content-creator/lib/` — `config.ts` · `gemini.ts` · `facebook.ts` + 16 vitest tests

## Gate A — `gemini.ts` (ตู๋ตั้งจาก PR#84)
- ✅ `genImage()` คืน **`Uint8Array`** (ไม่ writeFileSync — caller จัดการ persist)
- ✅ `genCaption()` มี **`temperature`** param (default 0.8)
- ✅ model จาก **env แยก** `CONTENT_TEXT_MODEL` / `CONTENT_IMAGE_MODEL` (ไม่ reuse `MODEL_NAME` ของ mystic; มี default = ค่าที่ POC verify)

## Gate B — `facebook.ts` (ตู๋ตั้งจาก PR#85)
- ✅ 🔒 token ใน **header `Authorization: Bearer`** (ไม่ใช่ URL query) — มี test ยืนยัน token ไม่อยู่ใน URL
- ✅ Graph **version จาก config** (`FB_GRAPH_VERSION`, default v23.0) ไม่ hardcode
- ✅ `res.ok` check ก่อน `.json()` + **timeout** (AbortController) + **retry** 429/5xx (exponential backoff)
- ✅ **publish-on-approve**: `uploadUnpublishedPhoto()→media_fbid` (published=false) → `publishToFeed()` (`POST /feed` + `attached_media`)

## verified (บทเรียน tsc-ก่อน-push จาก PR#85)
- `tsc --noEmit` = **0 error** (จับ `.ts`-extension import ตั้งแต่ก่อน push — moduleResolution bundler ไม่รับ)
- `vitest run content-creator` = **16/16 pass** (config 4 · gemini 5 · facebook 7; unit + mock fetch, ไม่ยิง API จริง — live พิสูจน์แล้ว POC 1-2)

## ตรงไหนควรตรวจเป็นพิเศษ
- **`vitest.config.ts`** เพิ่ม include `'content-creator/**'` — ไม่งั้น `npm test`/CI ไม่เห็น test feature นี้ (แตะ config ร่วม — ฝากดู)
- `fbFetch` token ใน header + retry/timeout logic robust พอ reuse ต่อไหม
- env `CONTENT_*_MODEL` ยังไม่มีใน .env (lib มี default fallback) — จะเพิ่มตอน wire จริง

## ยังค้าง (carry-forward, ไม่ใช่ PR นี้)
- design: exclude `scripts/` จาก build tsconfig (POC throwaway ไม่ควรเป็นภาระ build) — ค้างจาก PR#85

🤖 ตอบโดย goo จาก [ฟีม] → goo-oracle