### PR TITLE
feat: content-creator S2 — generate engine + Template Registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ next-env.d.ts
 
 # Oracle Framework
 content-creator/*.db*
+content-creator/media/

--- a/content-creator/README.md
+++ b/content-creator/README.md
@@ -32,7 +32,14 @@ npm run content-creator:dev      # = CONTENT_CREATOR_ENABLED=true next dev
 ## 🔄 State machine
 
 ```
-PENDING ─gen→ GENERATED ─approve(คน)→ APPROVED ─claim→ PUBLISHING ─post สำเร็จ→ POSTED
-  PUBLISHING ─recovery→ FAILED / APPROVED       (active) ─→ CANCELED ; ─error→ FAILED ─retry→ PENDING
+PENDING ─claim→ GENERATING ─gen สำเร็จ→ GENERATED ─approve(คน)→ APPROVED ─claim→ PUBLISHING ─post สำเร็จ→ POSTED
+  GENERATING ─gen ล้ม→ FAILED                    PUBLISHING ─recovery→ FAILED / APPROVED
+  (active) ─→ CANCELED ; ─error→ FAILED ─retry→ PENDING
 ```
-**PUBLISHING = claim lease**: worker ต้อง `claimForPublish()` (APPROVED→PUBLISHING atomic) ก่อนยิง Facebook — กัน scheduler concurrent โพสต์ซ้ำ
+
+**GENERATING = claim lease (S2)**: worker ต้อง `claimForGenerate()` (PENDING→GENERATING atomic) ก่อนเรียก Gemini — กัน concurrent gen ซ้ำ/เปลือง cost
+- claim คืน **ownership token** (`generationToken`) — `markGenerated()`/`releaseGenerate()` ต้องส่ง token คืน, conditional update ทำงานเฉพาะ token ตรง → stale worker (ที่โดน reclaim) ทับ attempt ใหม่ไม่ได้ (คืน `SUPERSEDED`)
+- `generatingAt` บันทึกเวลา claim ไว้สำหรับ **expiry-based reclaim** ในอนาคต
+- **ข้อจำกัดปัจจุบัน**: ยัง**ไม่มี** auto-reclaim ของ GENERATING ที่ค้าง — ถอด transition `GENERATING→PENDING` ออกแล้ว (reclaim ที่ปลอดภัยต้องเช็ค expiry + ออก token ใหม่ก่อน ซึ่งยังไม่ทำ). gen ล้มไปทาง `FAILED` แล้ว retry ผ่าน `FAILED→PENDING`. row ที่ค้าง GENERATING (เช่น process ตายกลางคัน) ต้อง reconcile มือ — ดู [ตู๋ P1] / S4 reconciliation
+
+**PUBLISHING = claim lease (S4)**: worker ต้อง `claimForPublish()` (APPROVED→PUBLISHING atomic) ก่อนยิง Facebook — กัน scheduler concurrent โพสต์ซ้ำ

--- a/content-creator/README.md
+++ b/content-creator/README.md
@@ -39,6 +39,7 @@ PENDING ─claim→ GENERATING ─gen สำเร็จ→ GENERATED ─approve
 
 **GENERATING = claim lease (S2)**: worker ต้อง `claimForGenerate()` (PENDING→GENERATING atomic) ก่อนเรียก Gemini — กัน concurrent gen ซ้ำ/เปลือง cost
 - claim คืน **ownership token** (`generationToken`) — `markGenerated()`/`releaseGenerate()` ต้องส่ง token คืน, conditional update ทำงานเฉพาะ token ตรง → stale worker (ที่โดน reclaim) ทับ attempt ใหม่ไม่ได้ (คืน `SUPERSEDED`)
+- ไฟล์ภาพเขียนลง path **ผูกกับ token** (`<id>-<token>.png`, 1 attempt = 1 ไฟล์ immutable) → stale worker overwrite ไฟล์ของ attempt ที่ชนะไม่ได้ ; เก็บ `imagePath` ใน DB เฉพาะตอน `markGenerated` สำเร็จ, ถ้า `SUPERSEDED`/ล้ม → ลบ artifact ของตัวเองทิ้ง
 - `generatingAt` บันทึกเวลา claim ไว้สำหรับ **expiry-based reclaim** ในอนาคต
 - **ข้อจำกัดปัจจุบัน**: ยัง**ไม่มี** auto-reclaim ของ GENERATING ที่ค้าง — ถอด transition `GENERATING→PENDING` ออกแล้ว (reclaim ที่ปลอดภัยต้องเช็ค expiry + ออก token ใหม่ก่อน ซึ่งยังไม่ทำ). gen ล้มไปทาง `FAILED` แล้ว retry ผ่าน `FAILED→PENDING`. row ที่ค้าง GENERATING (เช่น process ตายกลางคัน) ต้อง reconcile มือ — ดู [ตู๋ P1] / S4 reconciliation
 

--- a/content-creator/__tests__/db.test.ts
+++ b/content-creator/__tests__/db.test.ts
@@ -29,12 +29,12 @@ describe("[P1.1] public client บน fresh DB — migration apply ให้ tab
 });
 
 describe("[P1.2] atomic conditional transition", () => {
-  it("transition PENDING→GENERATED สำเร็จ + set patch", () => {
+  it("transition PENDING→GENERATING สำเร็จ + set patch", () => {
     const db = createContentDb(":memory:");
     db.insert(contentPosts).values({ id: "x", templateId: "t", inputData: {} }).run();
-    transition(db, "x", "PENDING", "GENERATED", { caption: "ปังมากแม่" });
+    transition(db, "x", "PENDING", "GENERATING", { caption: "ปังมากแม่" });
     const row = db.select().from(contentPosts).where(eq(contentPosts.id, "x")).get();
-    expect(row!.status).toBe("GENERATED");
+    expect(row!.status).toBe("GENERATING");
     expect(row!.caption).toBe("ปังมากแม่");
   });
 
@@ -47,9 +47,9 @@ describe("[P1.2] atomic conditional transition", () => {
   it("reject stale/concurrent + ghost id", () => {
     const db = createContentDb(":memory:");
     db.insert(contentPosts).values({ id: "z", templateId: "t", inputData: {} }).run();
-    transition(db, "z", "PENDING", "GENERATED");
-    expect(() => transition(db, "z", "PENDING", "GENERATED")).toThrow(/stale\/concurrent/);
-    expect(() => transition(db, "ghost", "PENDING", "GENERATED")).toThrow(/stale\/concurrent/);
+    transition(db, "z", "PENDING", "GENERATING");
+    expect(() => transition(db, "z", "PENDING", "GENERATING")).toThrow(/stale\/concurrent/);
+    expect(() => transition(db, "ghost", "PENDING", "GENERATING")).toThrow(/stale\/concurrent/);
   });
 });
 

--- a/content-creator/__tests__/engine.test.ts
+++ b/content-creator/__tests__/engine.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, rmSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve, sep } from "node:path";
 import { eq } from "drizzle-orm";
 
 // mock gemini lib (ไม่ยิง API จริง — live พิสูจน์แล้ว POC #1)
@@ -78,5 +78,40 @@ describe("generate engine [S2]", () => {
     expect(res.status).toBe("FAILED");
     expect(mockGenCaption).not.toHaveBeenCalled();
     expect(db.select().from(contentPosts).where(eq(contentPosts.id, "d")).get()!.status).toBe("FAILED");
+  });
+
+  // [P1] ownership token — stale worker ที่โดน reclaim ระหว่าง gen ห้ามทับ attempt ใหม่
+  it("race: A claim+ค้าง → reclaim ให้ B → A เสร็จต้องไม่ทับ B (SUPERSEDED)", async () => {
+    const { db } = setup();
+    insertPending(db, "race", { card: "The Star", meaning: "ความหวัง" });
+    // genImage ของ A ค้างไว้ (deterministic deferred) — A claim ได้ token แล้วแต่ยัง gen ไม่เสร็จ
+    let releaseA!: (b: Uint8Array) => void;
+    let signalGenImageCalled!: () => void;
+    const genImageCalled = new Promise<void>((r) => { signalGenImageCalled = r; });
+    mockGenImage.mockImplementationOnce(() => {
+      signalGenImageCalled(); // บอก test ว่า A ผ่าน claim+caption มาถึง genImage แล้ว
+      return new Promise<Uint8Array>((r) => { releaseA = r; });
+    });
+    const aPromise = generate(db, "race"); // A: PENDING→GENERATING (tokenA), await genImage
+    await genImageCalled; // แน่ใจว่า A claim เสร็จและค้างที่ genImage (deterministic)
+    // จำลอง reclaim: B เข้ามาแทน (token ใหม่ ยังเป็น GENERATING) — เช่น reconciliation/worker ใหม่
+    db.update(contentPosts).set({ generationToken: "tokenB" }).where(eq(contentPosts.id, "race")).run();
+    releaseA(new Uint8Array([9, 9, 9])); // A gen เสร็จ → markGenerated(tokenA) ต้อง false
+    const aRes = await aPromise;
+    expect(aRes.status).toBe("SUPERSEDED"); // A รู้ตัวว่าโดน supersede
+    const row = db.select().from(contentPosts).where(eq(contentPosts.id, "race")).get()!;
+    expect(row.status).toBe("GENERATING"); // ยังเป็น attempt ของ B (A ทับไม่ได้)
+    expect(row.generationToken).toBe("tokenB"); // token ของ B ยังอยู่ครบ
+  });
+
+  // [P2] path traversal — id ที่มี ../ ต้องไม่หลุดออกนอก media root
+  it("path traversal: id มี ../ → ไฟล์ถูก sanitize อยู่ใน media dir เสมอ", async () => {
+    const { db, dir } = setup();
+    insertPending(db, "../../../etc/evil", { card: "The Moon", meaning: "ลวง" });
+    const res = await generate(db, "../../../etc/evil");
+    expect(res.status).toBe("GENERATED");
+    const mediaRoot = resolve(join(dir, "media"));
+    expect(resolve(res.imagePath!).startsWith(mediaRoot + sep)).toBe(true); // อยู่ใต้ media root
+    expect(existsSync(res.imagePath!)).toBe(true);
   });
 });

--- a/content-creator/__tests__/engine.test.ts
+++ b/content-creator/__tests__/engine.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, readFileSync, readdirSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve, sep } from "node:path";
+import { join, resolve, sep, basename } from "node:path";
 import { eq } from "drizzle-orm";
 
 // mock gemini lib (ไม่ยิง API จริง — live พิสูจน์แล้ว POC #1)
@@ -80,28 +80,48 @@ describe("generate engine [S2]", () => {
     expect(db.select().from(contentPosts).where(eq(contentPosts.id, "d")).get()!.status).toBe("FAILED");
   });
 
-  // [P1] ownership token — stale worker ที่โดน reclaim ระหว่าง gen ห้ามทับ attempt ใหม่
-  it("race: A claim+ค้าง → reclaim ให้ B → A เสร็จต้องไม่ทับ B (SUPERSEDED)", async () => {
-    const { db } = setup();
+  // [P1] ownership token + filesystem fence — stale worker ห้ามทับไฟล์ของ attempt ที่ชนะ
+  // ลำดับที่ ตู๋ ขอ: A ค้าง → reclaim → B complete (bytes รู้ค่า) → A complete ทีหลัง → B ต้องไม่เปลี่ยน, A ถูกลบ
+  it("race: B complete ก่อน, A complete ทีหลัง → B's file/path คงเดิม + A's stale artifact ถูกลบ", async () => {
+    const { db, dir } = setup();
+    const mediaDir = join(dir, "media");
     insertPending(db, "race", { card: "The Star", meaning: "ความหวัง" });
-    // genImage ของ A ค้างไว้ (deterministic deferred) — A claim ได้ token แล้วแต่ยัง gen ไม่เสร็จ
+
+    // A claim ก่อน แล้วค้างที่ genImage (deterministic deferred)
     let releaseA!: (b: Uint8Array) => void;
-    let signalGenImageCalled!: () => void;
-    const genImageCalled = new Promise<void>((r) => { signalGenImageCalled = r; });
+    let signalAAtGenImage!: () => void;
+    const aAtGenImage = new Promise<void>((r) => { signalAAtGenImage = r; });
     mockGenImage.mockImplementationOnce(() => {
-      signalGenImageCalled(); // บอก test ว่า A ผ่าน claim+caption มาถึง genImage แล้ว
+      signalAAtGenImage(); // A ผ่าน claim(tokenA)+caption มาถึง genImage แล้ว
       return new Promise<Uint8Array>((r) => { releaseA = r; });
     });
-    const aPromise = generate(db, "race"); // A: PENDING→GENERATING (tokenA), await genImage
-    await genImageCalled; // แน่ใจว่า A claim เสร็จและค้างที่ genImage (deterministic)
-    // จำลอง reclaim: B เข้ามาแทน (token ใหม่ ยังเป็น GENERATING) — เช่น reconciliation/worker ใหม่
-    db.update(contentPosts).set({ generationToken: "tokenB" }).where(eq(contentPosts.id, "race")).run();
-    releaseA(new Uint8Array([9, 9, 9])); // A gen เสร็จ → markGenerated(tokenA) ต้อง false
+    const aPromise = generate(db, "race"); // A: PENDING→GENERATING(tokenA), ค้างที่ genImage
+    await aAtGenImage;
+
+    // จำลอง reclaim หลัง expiry: reset เป็น PENDING ให้ B claim token ใหม่ได้
+    db.update(contentPosts).set({ status: "PENDING", generationToken: null, generatingAt: null }).where(eq(contentPosts.id, "race")).run();
+
+    // B run เต็ม → GENERATED ด้วย bytes ที่รู้ค่า
+    const bBytes = new Uint8Array([66, 66, 66]);
+    mockGenImage.mockResolvedValueOnce(bBytes);
+    const bRes = await generate(db, "race");
+    expect(bRes.status).toBe("GENERATED");
+    const bPath = bRes.imagePath!;
+    const bRow = db.select().from(contentPosts).where(eq(contentPosts.id, "race")).get()!;
+    expect(bRow.status).toBe("GENERATED");
+    expect(bRow.imagePath).toBe(bPath);
+    expect(Array.from(readFileSync(bPath))).toEqual([66, 66, 66]);
+
+    // A กลับมาทีหลัง พยายาม complete ด้วย stale bytes
+    releaseA(new Uint8Array([1, 1, 1]));
     const aRes = await aPromise;
-    expect(aRes.status).toBe("SUPERSEDED"); // A รู้ตัวว่าโดน supersede
-    const row = db.select().from(contentPosts).where(eq(contentPosts.id, "race")).get()!;
-    expect(row.status).toBe("GENERATING"); // ยังเป็น attempt ของ B (A ทับไม่ได้)
-    expect(row.generationToken).toBe("tokenB"); // token ของ B ยังอยู่ครบ
+    expect(aRes.status).toBe("SUPERSEDED"); // A รู้ตัวว่าแพ้
+
+    // B ไม่ถูกแตะ: path/contents เดิม (A เขียนคนละไฟล์เพราะ token-scoped)
+    expect(db.select().from(contentPosts).where(eq(contentPosts.id, "race")).get()!.imagePath).toBe(bPath);
+    expect(Array.from(readFileSync(bPath))).toEqual([66, 66, 66]); // bytes ของ B ไม่เปลี่ยน
+    // A's stale artifact ถูก cleanup → เหลือแค่ไฟล์ของ B ใน media dir
+    expect(readdirSync(mediaDir)).toEqual([basename(bPath)]);
   });
 
   // [P2] path traversal — id ที่มี ../ ต้องไม่หลุดออกนอก media root

--- a/content-creator/__tests__/engine.test.ts
+++ b/content-creator/__tests__/engine.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { eq } from "drizzle-orm";
+
+// mock gemini lib (ไม่ยิง API จริง — live พิสูจน์แล้ว POC #1)
+const { mockGenCaption, mockGenImage } = vi.hoisted(() => ({
+  mockGenCaption: vi.fn(),
+  mockGenImage: vi.fn(),
+}));
+vi.mock("../lib/gemini", () => ({
+  genCaption: mockGenCaption,
+  genImage: mockGenImage,
+}));
+
+import { createContentDb } from "../db/client";
+import { contentPosts } from "../db/schema";
+import { generate } from "../engine";
+
+const tmpDirs: string[] = [];
+function setup() {
+  const dir = mkdtempSync(join(tmpdir(), "cc-engine-"));
+  tmpDirs.push(dir);
+  process.env.CONTENT_MEDIA_DIR = join(dir, "media");
+  const db = createContentDb(":memory:");
+  return { db, dir };
+}
+beforeEach(() => {
+  mockGenCaption.mockReset().mockResolvedValue("ปังมากแม่! #ดูดวงการเงิน #หมอมี่");
+  mockGenImage.mockReset().mockResolvedValue(new Uint8Array([1, 2, 3, 4]));
+});
+afterEach(() => {
+  for (const d of tmpDirs.splice(0)) rmSync(d, { recursive: true, force: true });
+  delete process.env.CONTENT_MEDIA_DIR;
+});
+
+function insertPending(db: ReturnType<typeof createContentDb>, id: string, inputData: unknown) {
+  db.insert(contentPosts).values({ id, templateId: "finance-daily", inputData: inputData as Record<string, unknown> }).run();
+}
+
+describe("generate engine [S2]", () => {
+  it("PENDING → GENERATED: caption+ภาพ saved, imagePath file มีจริง", async () => {
+    const { db } = setup();
+    insertPending(db, "a", { card: "8 of Wands", meaning: "ลื่นไหล" });
+    const res = await generate(db, "a");
+    expect(res.status).toBe("GENERATED");
+    expect(res.caption).toContain("หมอมี่");
+    expect(existsSync(res.imagePath!)).toBe(true);
+    const row = db.select().from(contentPosts).where(eq(contentPosts.id, "a")).get();
+    expect(row!.status).toBe("GENERATED");
+    expect(row!.caption).toBeTruthy();
+    expect(row!.imagePath).toBe(res.imagePath);
+  });
+
+  it("claim: generate ซ้ำ row เดิม → SKIPPED (กัน gen ซ้ำ/เปลือง Gemini)", async () => {
+    const { db } = setup();
+    insertPending(db, "b", { card: "Ace of Coins", meaning: "โชคลาภ" });
+    await generate(db, "b"); // GENERATED
+    const again = await generate(db, "b"); // ไม่ใช่ PENDING แล้ว
+    expect(again.status).toBe("SKIPPED");
+    expect(mockGenCaption).toHaveBeenCalledTimes(1); // เรียก Gemini แค่ครั้งเดียว
+  });
+
+  it("Gemini ล้ม → FAILED (release claim, ไม่ค้าง GENERATING)", async () => {
+    const { db } = setup();
+    mockGenImage.mockRejectedValueOnce(new Error("gemini down"));
+    insertPending(db, "c", { card: "The Tower", meaning: "พัง" });
+    const res = await generate(db, "c");
+    expect(res.status).toBe("FAILED");
+    expect(db.select().from(contentPosts).where(eq(contentPosts.id, "c")).get()!.status).toBe("FAILED");
+  });
+
+  it("input ผิด schema → FAILED (ไม่เรียก Gemini)", async () => {
+    const { db } = setup();
+    insertPending(db, "d", { card: "x" }); // ขาด meaning
+    const res = await generate(db, "d");
+    expect(res.status).toBe("FAILED");
+    expect(mockGenCaption).not.toHaveBeenCalled();
+    expect(db.select().from(contentPosts).where(eq(contentPosts.id, "d")).get()!.status).toBe("FAILED");
+  });
+});

--- a/content-creator/__tests__/state.test.ts
+++ b/content-creator/__tests__/state.test.ts
@@ -14,9 +14,9 @@ describe("content state machine", () => {
     expect(canTransition("PENDING", "GENERATED")).toBe(false);
   });
 
-  it("GENERATING recovery: → FAILED / → PENDING (คืน claim)", () => {
+  it("GENERATING recovery: → FAILED เท่านั้น (ถอด →PENDING: reclaim ต้อง expiry+token ก่อน [ตู๋ P1])", () => {
     expect(canTransition("GENERATING", "FAILED")).toBe(true);
-    expect(canTransition("GENERATING", "PENDING")).toBe(true);
+    expect(canTransition("GENERATING", "PENDING")).toBe(false); // กัน stale worker คืนคิวโดยไม่เช็ค token
   });
 
   it("APPROVED→POSTED ตรง ๆ ไม่ได้ (ต้องผ่าน PUBLISHING claim — กัน FB โพสต์ซ้ำ)", () => {

--- a/content-creator/__tests__/state.test.ts
+++ b/content-creator/__tests__/state.test.ts
@@ -2,11 +2,21 @@ import { describe, expect, it } from "vitest";
 import { canTransition, assertTransition, isTerminal } from "../db/state";
 
 describe("content state machine", () => {
-  it("เส้นทางหลัก: PENDING→GENERATED→APPROVED→PUBLISHING→POSTED", () => {
-    expect(canTransition("PENDING", "GENERATED")).toBe(true);
+  it("เส้นทางหลัก: PENDING→GENERATING→GENERATED→APPROVED→PUBLISHING→POSTED", () => {
+    expect(canTransition("PENDING", "GENERATING")).toBe(true); // claim ก่อนเรียก Gemini
+    expect(canTransition("GENERATING", "GENERATED")).toBe(true);
     expect(canTransition("GENERATED", "APPROVED")).toBe(true); // human approve gate
     expect(canTransition("APPROVED", "PUBLISHING")).toBe(true); // claim ก่อนยิง FB
     expect(canTransition("PUBLISHING", "POSTED")).toBe(true);
+  });
+
+  it("PENDING→GENERATED ตรง ๆ ไม่ได้ (ต้องผ่าน GENERATING claim — กัน gen ซ้ำ)", () => {
+    expect(canTransition("PENDING", "GENERATED")).toBe(false);
+  });
+
+  it("GENERATING recovery: → FAILED / → PENDING (คืน claim)", () => {
+    expect(canTransition("GENERATING", "FAILED")).toBe(true);
+    expect(canTransition("GENERATING", "PENDING")).toBe(true);
   });
 
   it("APPROVED→POSTED ตรง ๆ ไม่ได้ (ต้องผ่าน PUBLISHING claim — กัน FB โพสต์ซ้ำ)", () => {

--- a/content-creator/__tests__/templates.test.ts
+++ b/content-creator/__tests__/templates.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { getTemplate, listTemplateIds } from "../templates";
+import { financeDailySchema } from "../templates/finance-daily";
+
+describe("Template Registry", () => {
+  it("getTemplate('finance-daily') คืน template", () => {
+    const t = getTemplate("finance-daily");
+    expect(t.id).toBe("finance-daily");
+    expect(t.name).toBeTruthy();
+  });
+
+  it("getTemplate(unknown) throw", () => {
+    expect(() => getTemplate("nope")).toThrow(/unknown templateId/);
+  });
+
+  it("listTemplateIds มี finance-daily", () => {
+    expect(listTemplateIds()).toContain("finance-daily");
+  });
+});
+
+describe("finance-daily template", () => {
+  const t = getTemplate("finance-daily");
+  const valid = { card: "8 of Wands", meaning: "การเงินลื่นไหล" };
+
+  it("inputSchema: valid ผ่าน, invalid throw", () => {
+    expect(financeDailySchema.parse(valid)).toEqual(valid);
+    expect(() => financeDailySchema.parse({ card: "x" })).toThrow(); // ขาด meaning
+    expect(() => financeDailySchema.parse({ card: "", meaning: "y" })).toThrow(); // card ว่าง
+  });
+
+  it("buildCaptionPrompt: มี card/meaning + tone หมอมี่ + hashtag", () => {
+    const c = t.buildCaptionPrompt(valid);
+    expect(c.prompt).toContain("8 of Wands");
+    expect(c.prompt).toContain("การเงินลื่นไหล");
+    expect(c.system).toContain("หมอมี่");
+    expect(c.system).toContain("#ดูดวงการเงิน");
+  });
+
+  it("buildImagePrompt: มีชื่อไพ่", () => {
+    expect(t.buildImagePrompt(valid)).toContain("8 of Wands");
+  });
+});

--- a/content-creator/db/migrations/0001_brown_scalphunter.sql
+++ b/content-creator/db/migrations/0001_brown_scalphunter.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `content_posts` ADD `generation_token` text;--> statement-breakpoint
+ALTER TABLE `content_posts` ADD `generating_at` integer;

--- a/content-creator/db/migrations/meta/0001_snapshot.json
+++ b/content-creator/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,127 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "5e5c0789-9c11-48b4-b39f-052f41efcffe",
+  "prevId": "7052b794-1a52-46f6-8909-d3bee5340a5a",
+  "tables": {
+    "content_posts": {
+      "name": "content_posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_data": {
+          "name": "input_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'PENDING'"
+        },
+        "generation_token": {
+          "name": "generation_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generating_at": {
+          "name": "generating_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_path": {
+          "name": "image_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_fbid": {
+          "name": "media_fbid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fb_post_id": {
+          "name": "fb_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publish_at": {
+          "name": "publish_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/content-creator/db/migrations/meta/_journal.json
+++ b/content-creator/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1781307825833,
       "tag": "0000_bent_naoko",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1781340137727,
+      "tag": "0001_brown_scalphunter",
+      "breakpoints": true
     }
   ]
 }

--- a/content-creator/db/schema.ts
+++ b/content-creator/db/schema.ts
@@ -9,6 +9,7 @@ import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
 
 export const CONTENT_STATUSES = [
   "PENDING", // เพิ่งกรอก รอ gen
+  "GENERATING", // worker claim แล้ว กำลังเรียก Gemini (lease — 1 worker, กัน gen ซ้ำ/เปลือง cost)
   "GENERATED", // gen caption+ภาพ แล้ว รอ approve
   "APPROVED", // ฟีม approve แล้ว รอ scheduler claim
   "PUBLISHING", // worker claim แล้ว กำลังยิง Facebook (lease — 1 worker เท่านั้น)

--- a/content-creator/db/schema.ts
+++ b/content-creator/db/schema.ts
@@ -29,6 +29,10 @@ export const contentPosts = sqliteTable("content_posts", {
   /** fields ตาม template.inputSchema (card, meaning, …) */
   inputData: text("input_data", { mode: "json" }).notNull().$type<Record<string, unknown>>(),
   status: text("status").$type<ContentStatus>().notNull().default("PENDING"),
+  /** claim ownership token ของ GENERATING lease — completion/release ต้อง token ตรง (กัน stale worker ทับ) [S2 P1] */
+  generationToken: text("generation_token"),
+  /** เวลาเริ่ม claim GENERATING — สำหรับ expiry-based reclaim (future reconciliation) */
+  generatingAt: integer("generating_at", { mode: "timestamp" }),
   /** ผลลัพธ์ gen (S2) */
   caption: text("caption"),
   imagePath: text("image_path"),

--- a/content-creator/db/state.ts
+++ b/content-creator/db/state.ts
@@ -1,18 +1,21 @@
 /**
  * content-creator state machine — transitions ที่อนุญาตของ ContentPost.status
  *
- * PENDING ─gen→ GENERATED ─approve(คน)→ APPROVED ─claim→ PUBLISHING ─post สำเร็จ→ POSTED (terminal)
+ * PENDING ─claim→ GENERATING ─gen สำเร็จ→ GENERATED ─approve(คน)→ APPROVED ─claim→ PUBLISHING ─post→ POSTED (terminal)
+ *   GENERATING ─recovery→ FAILED / PENDING   (gen ล้ม/ปล่อย claim)
  *   PUBLISHING ─recovery→ FAILED / APPROVED   (ยิง FB ล้ม/ปล่อย claim)
  *   (active state) ─→ CANCELED (terminal) ; ─error→ FAILED ─retry→ PENDING
  *
- * PUBLISHING = lease: worker ต้อง claim (APPROVED→PUBLISHING แบบ atomic) ก่อนยิง Facebook
- * → กัน scheduler concurrent โพสต์ซ้ำ (side effect ภายนอก) [ตู๋ P1 altitude]
+ * GENERATING/PUBLISHING = lease: worker ต้อง claim (atomic) ก่อนทำ external side-effect
+ *   - GENERATING: claim ก่อนเรียก Gemini (กัน concurrent gen ซ้ำ/เปลือง cost) [S2]
+ *   - PUBLISHING: claim ก่อนยิง Facebook (กัน post ซ้ำ) [S4 / ตู๋ altitude]
  */
 import type { ContentStatus } from "./schema";
 
 /** transitions ที่อนุญาต: from → [to, ...] */
 const ALLOWED: Record<ContentStatus, readonly ContentStatus[]> = {
-  PENDING: ["GENERATED", "CANCELED", "FAILED"],
+  PENDING: ["GENERATING", "CANCELED", "FAILED"], // GENERATING = claim ก่อนเรียก Gemini
+  GENERATING: ["GENERATED", "FAILED", "PENDING"], // GENERATED=สำเร็จ ; FAILED/PENDING=recovery (ปล่อย claim)
   GENERATED: ["APPROVED", "CANCELED", "FAILED"], // APPROVED = human gate
   APPROVED: ["PUBLISHING", "CANCELED", "FAILED"], // PUBLISHING = claim ก่อนยิง FB
   PUBLISHING: ["POSTED", "FAILED", "APPROVED"], // POSTED=สำเร็จ ; FAILED/APPROVED=recovery (ปล่อย claim)

--- a/content-creator/db/state.ts
+++ b/content-creator/db/state.ts
@@ -15,7 +15,7 @@ import type { ContentStatus } from "./schema";
 /** transitions ที่อนุญาต: from → [to, ...] */
 const ALLOWED: Record<ContentStatus, readonly ContentStatus[]> = {
   PENDING: ["GENERATING", "CANCELED", "FAILED"], // GENERATING = claim ก่อนเรียก Gemini
-  GENERATING: ["GENERATED", "FAILED", "PENDING"], // GENERATED=สำเร็จ ; FAILED/PENDING=recovery (ปล่อย claim)
+  GENERATING: ["GENERATED", "FAILED"], // GENERATED=สำเร็จ ; FAILED=ล้ม. (ถอด →PENDING: reclaim ต้อง expiry+token ก่อน [ตู๋ P1] — ตอนนี้ retry ผ่าน FAILED→PENDING)
   GENERATED: ["APPROVED", "CANCELED", "FAILED"], // APPROVED = human gate
   APPROVED: ["PUBLISHING", "CANCELED", "FAILED"], // PUBLISHING = claim ก่อนยิง FB
   PUBLISHING: ["POSTED", "FAILED", "APPROVED"], // POSTED=สำเร็จ ; FAILED/APPROVED=recovery (ปล่อย claim)

--- a/content-creator/db/transition.ts
+++ b/content-creator/db/transition.ts
@@ -50,6 +50,25 @@ export function transition(
 }
 
 /**
+ * claim โพสต์เพื่อเรียก Gemini gen (PENDING → GENERATING แบบ atomic). [S2]
+ * คืน true = worker นี้ claim ได้ (เรียก Gemini ต่อได้คนเดียว — กัน gen ซ้ำ/เปลือง cost); false = skip.
+ * หลัง gen เสร็จ → markGenerated; ล้ม → releaseGenerate.
+ */
+export function claimForGenerate(db: ContentDb, id: string): boolean {
+  return tryTransition(db, id, "PENDING", "GENERATING");
+}
+
+/** gen สำเร็จ: GENERATING → GENERATED (เก็บ caption + imagePath) */
+export function markGenerated(db: ContentDb, id: string, caption: string, imagePath: string): void {
+  transition(db, id, "GENERATING", "GENERATED", { caption, imagePath });
+}
+
+/** gen ล้ม/ปล่อย claim: GENERATING → FAILED (default) หรือ PENDING (คืนคิว retry) */
+export function releaseGenerate(db: ContentDb, id: string, to: "FAILED" | "PENDING" = "FAILED"): void {
+  transition(db, id, "GENERATING", to);
+}
+
+/**
  * claim โพสต์เพื่อยิง Facebook (APPROVED → PUBLISHING แบบ atomic).
  * คืน true = worker นี้ claim ได้ (ยิง FB ต่อได้คนเดียว); false = worker อื่น claim ไปแล้ว → skip.
  * กัน scheduler concurrent ยิง Facebook ซ้ำ. หลังยิงเสร็จ caller → markPosted/releaseClaim.

--- a/content-creator/db/transition.ts
+++ b/content-creator/db/transition.ts
@@ -71,7 +71,7 @@ export function claimForGenerate(db: ContentDb, id: string): string | null {
 export function markGenerated(db: ContentDb, id: string, token: string, caption: string, imagePath: string): boolean {
   const res = db
     .update(contentPosts)
-    .set({ status: "GENERATED", caption, imagePath, generationToken: null, updatedAt: new Date() })
+    .set({ status: "GENERATED", caption, imagePath, generationToken: null, generatingAt: null, updatedAt: new Date() })
     .where(and(eq(contentPosts.id, id), eq(contentPosts.status, "GENERATING"), eq(contentPosts.generationToken, token)))
     .run();
   return res.changes === 1;
@@ -84,7 +84,7 @@ export function markGenerated(db: ContentDb, id: string, token: string, caption:
 export function releaseGenerate(db: ContentDb, id: string, token: string): boolean {
   const res = db
     .update(contentPosts)
-    .set({ status: "FAILED", generationToken: null, updatedAt: new Date() })
+    .set({ status: "FAILED", generationToken: null, generatingAt: null, updatedAt: new Date() })
     .where(and(eq(contentPosts.id, id), eq(contentPosts.status, "GENERATING"), eq(contentPosts.generationToken, token)))
     .run();
   return res.changes === 1;

--- a/content-creator/db/transition.ts
+++ b/content-creator/db/transition.ts
@@ -50,22 +50,44 @@ export function transition(
 }
 
 /**
- * claim โพสต์เพื่อเรียก Gemini gen (PENDING → GENERATING แบบ atomic). [S2]
- * คืน true = worker นี้ claim ได้ (เรียก Gemini ต่อได้คนเดียว — กัน gen ซ้ำ/เปลือง cost); false = skip.
- * หลัง gen เสร็จ → markGenerated; ล้ม → releaseGenerate.
+ * claim เพื่อเรียก Gemini gen (PENDING → GENERATING แบบ atomic + ออก ownership token). [S2 P1]
+ * คืน **token** ถ้า claim ได้ (worker เดียว) ; null ถ้า skip (ไม่ใช่ PENDING/claim ไปแล้ว).
+ * token ต้องส่งคืนใน markGenerated/releaseGenerate → กัน stale worker (ที่ถูก reclaim) ทับ attempt ใหม่.
  */
-export function claimForGenerate(db: ContentDb, id: string): boolean {
-  return tryTransition(db, id, "PENDING", "GENERATING");
+export function claimForGenerate(db: ContentDb, id: string): string | null {
+  const token = crypto.randomUUID();
+  const res = db
+    .update(contentPosts)
+    .set({ status: "GENERATING", generationToken: token, generatingAt: new Date(), updatedAt: new Date() })
+    .where(and(eq(contentPosts.id, id), eq(contentPosts.status, "PENDING")))
+    .run();
+  return res.changes === 1 ? token : null;
 }
 
-/** gen สำเร็จ: GENERATING → GENERATED (เก็บ caption + imagePath) */
-export function markGenerated(db: ContentDb, id: string, caption: string, imagePath: string): void {
-  transition(db, id, "GENERATING", "GENERATED", { caption, imagePath });
+/**
+ * gen สำเร็จ: GENERATING → GENERATED (เก็บ caption + imagePath), **เฉพาะถ้า token ตรง**.
+ * คืน false = superseded (worker เก่าโดน reclaim — ไม่ทับ attempt ใหม่)
+ */
+export function markGenerated(db: ContentDb, id: string, token: string, caption: string, imagePath: string): boolean {
+  const res = db
+    .update(contentPosts)
+    .set({ status: "GENERATED", caption, imagePath, generationToken: null, updatedAt: new Date() })
+    .where(and(eq(contentPosts.id, id), eq(contentPosts.status, "GENERATING"), eq(contentPosts.generationToken, token)))
+    .run();
+  return res.changes === 1;
 }
 
-/** gen ล้ม/ปล่อย claim: GENERATING → FAILED (default) หรือ PENDING (คืนคิว retry) */
-export function releaseGenerate(db: ContentDb, id: string, to: "FAILED" | "PENDING" = "FAILED"): void {
-  transition(db, id, "GENERATING", to);
+/**
+ * gen ล้ม/ปล่อย claim: GENERATING → FAILED **เฉพาะถ้า token ตรง** (กัน worker เก่าทำ attempt ใหม่ FAILED).
+ * คืน false = superseded (ไม่ทับ)
+ */
+export function releaseGenerate(db: ContentDb, id: string, token: string): boolean {
+  const res = db
+    .update(contentPosts)
+    .set({ status: "FAILED", generationToken: null, updatedAt: new Date() })
+    .where(and(eq(contentPosts.id, id), eq(contentPosts.status, "GENERATING"), eq(contentPosts.generationToken, token)))
+    .run();
+  return res.changes === 1;
 }
 
 /**

--- a/content-creator/engine.ts
+++ b/content-creator/engine.ts
@@ -1,0 +1,63 @@
+/**
+ * content-creator generate engine [S2] — row PENDING → gen caption+ภาพ → GENERATED
+ *
+ * production-readiness:
+ *  - claim PENDING→GENERATING (atomic) ก่อนเรียก Gemini = กัน concurrent gen ซ้ำ/เปลือง cost
+ *  - gen ล้ม → releaseGenerate(FAILED) (recovery)
+ *  - ภาพเก็บเป็น file (CONTENT_MEDIA_DIR) + imagePath ใน DB (รูปไม่ยัดใน sqlite)
+ */
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { eq } from "drizzle-orm";
+import type { ContentDb } from "./db/client";
+import { contentPosts } from "./db/schema";
+import { claimForGenerate, markGenerated, releaseGenerate } from "./db/transition";
+import { genCaption, genImage } from "./lib/gemini";
+import { getTemplate } from "./templates";
+
+const mediaDir = () => process.env.CONTENT_MEDIA_DIR || "content-creator/media";
+
+export interface GenerateResult {
+  ok: boolean;
+  status: "GENERATED" | "FAILED" | "SKIPPED";
+  caption?: string;
+  imagePath?: string;
+  error?: string;
+}
+
+/**
+ * gen content ของ post 1 ตัว (PENDING → GENERATING → GENERATED/FAILED).
+ * SKIPPED = claim ไม่ได้ (ไม่ใช่ PENDING / worker อื่น claim ไปแล้ว) — ปลอดภัยเรียกซ้ำ
+ */
+export async function generate(db: ContentDb, id: string): Promise<GenerateResult> {
+  // claim ก่อนเรียก Gemini (external + cost) — worker เดียวเท่านั้น
+  if (!claimForGenerate(db, id)) {
+    return { ok: false, status: "SKIPPED" };
+  }
+  try {
+    const row = db.select().from(contentPosts).where(eq(contentPosts.id, id)).get();
+    if (!row) throw new Error(`content post not found: ${id}`);
+
+    const template = getTemplate(row.templateId);
+    template.inputSchema.parse(row.inputData); // validate (throw → FAILED)
+
+    const { system, prompt } = template.buildCaptionPrompt(row.inputData);
+    const caption = await genCaption({ system, prompt });
+    const bytes = await genImage({ prompt: template.buildImagePrompt(row.inputData) });
+    const imagePath = persistImage(id, bytes);
+
+    markGenerated(db, id, caption, imagePath);
+    return { ok: true, status: "GENERATED", caption, imagePath };
+  } catch (err) {
+    releaseGenerate(db, id, "FAILED"); // ปล่อย claim → FAILED (retry → PENDING ได้)
+    return { ok: false, status: "FAILED", error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+function persistImage(id: string, bytes: Uint8Array): string {
+  const dir = mediaDir();
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, `${id}.png`);
+  writeFileSync(path, new Uint8Array(bytes)); // wrap → BlobPart-safe / fs ok
+  return path;
+}

--- a/content-creator/engine.ts
+++ b/content-creator/engine.ts
@@ -7,7 +7,7 @@
  *  - ภาพเก็บเป็น file (CONTENT_MEDIA_DIR) + imagePath ใน DB (รูปไม่ยัดใน sqlite)
  */
 import { mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve, sep } from "node:path";
 import { eq } from "drizzle-orm";
 import type { ContentDb } from "./db/client";
 import { contentPosts } from "./db/schema";
@@ -19,7 +19,7 @@ const mediaDir = () => process.env.CONTENT_MEDIA_DIR || "content-creator/media";
 
 export interface GenerateResult {
   ok: boolean;
-  status: "GENERATED" | "FAILED" | "SKIPPED";
+  status: "GENERATED" | "FAILED" | "SKIPPED" | "SUPERSEDED";
   caption?: string;
   imagePath?: string;
   error?: string;
@@ -27,11 +27,12 @@ export interface GenerateResult {
 
 /**
  * gen content ของ post 1 ตัว (PENDING → GENERATING → GENERATED/FAILED).
- * SKIPPED = claim ไม่ได้ (ไม่ใช่ PENDING / worker อื่น claim ไปแล้ว) — ปลอดภัยเรียกซ้ำ
+ * SKIPPED = claim ไม่ได้ (ไม่ใช่ PENDING) · SUPERSEDED = ระหว่าง gen โดน reclaim (token ไม่ตรง) → ไม่ทับ attempt ใหม่
  */
 export async function generate(db: ContentDb, id: string): Promise<GenerateResult> {
-  // claim ก่อนเรียก Gemini (external + cost) — worker เดียวเท่านั้น
-  if (!claimForGenerate(db, id)) {
+  // claim ก่อนเรียก Gemini (external + cost) — ได้ ownership token (worker เดียว)
+  const token = claimForGenerate(db, id);
+  if (!token) {
     return { ok: false, status: "SKIPPED" };
   }
   try {
@@ -46,18 +47,27 @@ export async function generate(db: ContentDb, id: string): Promise<GenerateResul
     const bytes = await genImage({ prompt: template.buildImagePrompt(row.inputData) });
     const imagePath = persistImage(id, bytes);
 
-    markGenerated(db, id, caption, imagePath);
+    // completion เฉพาะถ้า token ยังตรง (กัน stale worker ทับ attempt ที่ reclaim ไปแล้ว)
+    if (!markGenerated(db, id, token, caption, imagePath)) {
+      return { ok: false, status: "SUPERSEDED" };
+    }
     return { ok: true, status: "GENERATED", caption, imagePath };
   } catch (err) {
-    releaseGenerate(db, id, "FAILED"); // ปล่อย claim → FAILED (retry → PENDING ได้)
+    releaseGenerate(db, id, token); // WHERE token ตรง — ไม่ทับ attempt ใหม่ถ้าโดน reclaim
     return { ok: false, status: "FAILED", error: err instanceof Error ? err.message : String(err) };
   }
 }
 
+/** เก็บภาพเป็น file — sanitize id + assert path ไม่หลุดออกนอก media root (กัน path traversal) [P2] */
 function persistImage(id: string, bytes: Uint8Array): string {
   const dir = mediaDir();
   mkdirSync(dir, { recursive: true });
-  const path = join(dir, `${id}.png`);
-  writeFileSync(path, new Uint8Array(bytes)); // wrap → BlobPart-safe / fs ok
+  const safeName = id.replace(/[^A-Za-z0-9_-]/g, "_"); // ../ → _ (กัน escape)
+  const path = join(dir, `${safeName}.png`);
+  const root = resolve(dir);
+  if (!resolve(path).startsWith(root + sep)) {
+    throw new Error(`unsafe media path derived from id: ${id}`);
+  }
+  writeFileSync(path, new Uint8Array(bytes));
   return path;
 }

--- a/content-creator/engine.ts
+++ b/content-creator/engine.ts
@@ -6,7 +6,7 @@
  *  - gen ล้ม → releaseGenerate(FAILED) (recovery)
  *  - ภาพเก็บเป็น file (CONTENT_MEDIA_DIR) + imagePath ใน DB (รูปไม่ยัดใน sqlite)
  */
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join, resolve, sep } from "node:path";
 import { eq } from "drizzle-orm";
 import type { ContentDb } from "./db/client";
@@ -35,6 +35,8 @@ export async function generate(db: ContentDb, id: string): Promise<GenerateResul
   if (!token) {
     return { ok: false, status: "SKIPPED" };
   }
+  // เขียนไฟล์ลง path ผูกกับ token (immutable ต่อ attempt) — attempt อื่นเขียนคนละไฟล์ ทับกันไม่ได้
+  let attemptPath: string | undefined;
   try {
     const row = db.select().from(contentPosts).where(eq(contentPosts.id, id)).get();
     if (!row) throw new Error(`content post not found: ${id}`);
@@ -45,24 +47,32 @@ export async function generate(db: ContentDb, id: string): Promise<GenerateResul
     const { system, prompt } = template.buildCaptionPrompt(row.inputData);
     const caption = await genCaption({ system, prompt });
     const bytes = await genImage({ prompt: template.buildImagePrompt(row.inputData) });
-    const imagePath = persistImage(id, bytes);
+    attemptPath = persistImage(id, token, bytes);
 
-    // completion เฉพาะถ้า token ยังตรง (กัน stale worker ทับ attempt ที่ reclaim ไปแล้ว)
-    if (!markGenerated(db, id, token, caption, imagePath)) {
+    // commit DB เฉพาะถ้า token ยังตรง. ไม่ตรง = โดน reclaim → ลบ artifact ของ attempt เรา (ไม่แตะ winner)
+    if (!markGenerated(db, id, token, caption, attemptPath)) {
+      cleanupArtifact(attemptPath);
       return { ok: false, status: "SUPERSEDED" };
     }
-    return { ok: true, status: "GENERATED", caption, imagePath };
+    return { ok: true, status: "GENERATED", caption, imagePath: attemptPath };
   } catch (err) {
-    releaseGenerate(db, id, token); // WHERE token ตรง — ไม่ทับ attempt ใหม่ถ้าโดน reclaim
+    if (attemptPath) cleanupArtifact(attemptPath); // ลบไฟล์ที่เพิ่งเขียน (ถ้ามี) ก่อนปล่อย claim
+    // ปล่อย claim เฉพาะถ้า token ยังเป็นเจ้าของ ; ไม่ใช่ = โดน reclaim → SUPERSEDED (ไม่ใช่ FAILED)
+    if (!releaseGenerate(db, id, token)) {
+      return { ok: false, status: "SUPERSEDED" };
+    }
     return { ok: false, status: "FAILED", error: err instanceof Error ? err.message : String(err) };
   }
 }
 
-/** เก็บภาพเป็น file — sanitize id + assert path ไม่หลุดออกนอก media root (กัน path traversal) [P2] */
-function persistImage(id: string, bytes: Uint8Array): string {
+/**
+ * เก็บภาพเป็น file ที่ path ผูกกับ token (1 attempt = 1 ไฟล์, immutable) — กัน stale worker overwrite ไฟล์ winner.
+ * sanitize id+token + assert path ไม่หลุดออกนอก media root (กัน path traversal) [ตู๋ P1/P2]
+ */
+function persistImage(id: string, token: string, bytes: Uint8Array): string {
   const dir = mediaDir();
   mkdirSync(dir, { recursive: true });
-  const safeName = id.replace(/[^A-Za-z0-9_-]/g, "_"); // ../ → _ (กัน escape)
+  const safeName = `${id}-${token}`.replace(/[^A-Za-z0-9_-]/g, "_"); // ../ → _ (กัน escape) ; token → unique ต่อ attempt
   const path = join(dir, `${safeName}.png`);
   const root = resolve(dir);
   if (!resolve(path).startsWith(root + sep)) {
@@ -70,4 +80,9 @@ function persistImage(id: string, bytes: Uint8Array): string {
   }
   writeFileSync(path, new Uint8Array(bytes));
   return path;
+}
+
+/** ลบ artifact ของ attempt ที่แพ้ (token ไม่ owns แล้ว) — best-effort, ไม่ให้ล้มงานหลัก */
+function cleanupArtifact(path: string): void {
+  rmSync(path, { force: true });
 }

--- a/content-creator/engine.ts
+++ b/content-creator/engine.ts
@@ -82,7 +82,15 @@ function persistImage(id: string, token: string, bytes: Uint8Array): string {
   return path;
 }
 
-/** ลบ artifact ของ attempt ที่แพ้ (token ไม่ owns แล้ว) — best-effort, ไม่ให้ล้มงานหลัก */
+/**
+ * ลบ artifact ของ attempt ที่แพ้ (token ไม่ owns แล้ว) — best-effort จริง: swallow error
+ * ห้ามให้ rmSync (permission/EBUSY) throw แล้วข้าม releaseGenerate → ค้าง GENERATING [ตู๋ nit].
+ * stale file ที่ลบไม่ได้ค้างไว้ไม่อันตราย (ไม่ถูก reference ใน DB) — แค่ log ไว้ให้รู้
+ */
 function cleanupArtifact(path: string): void {
-  rmSync(path, { force: true });
+  try {
+    rmSync(path, { force: true });
+  } catch (err) {
+    console.warn(`content-creator: cleanup stale artifact failed (${path}):`, err instanceof Error ? err.message : err);
+  }
 }

--- a/content-creator/templates/finance-daily.ts
+++ b/content-creator/templates/finance-daily.ts
@@ -1,0 +1,31 @@
+/**
+ * template: finance-daily — ดวงการเงินรายวันสไตล์ "หมอมี่" (ไพ่ยิปซี)
+ */
+import { z } from "zod";
+import type { ContentTemplate } from "./types";
+
+export const financeDailySchema = z.object({
+  card: z.string().min(1), // ชื่อไพ่ เช่น "8 of Wands"
+  meaning: z.string().min(1), // ความหมายดวงการเงินวันนั้น
+});
+
+export type FinanceDailyInput = z.infer<typeof financeDailySchema>;
+
+export const financeDaily: ContentTemplate = {
+  id: "finance-daily",
+  name: "ดวงการเงินรายวัน (หมอมี่)",
+  inputSchema: financeDailySchema,
+  buildCaptionPrompt(data) {
+    const d = financeDailySchema.parse(data);
+    return {
+      system:
+        'คุณคือ "หมอมี่" หมอดูไพ่ยิปซีสายฟีลกู้ด พูดน่ารักเป็นกันเอง ใช้คำว่า พี่หมี่, ฟีลลิ่ง, ซัพพอร์ต, ปังมาก, แม่. ' +
+        "เขียนแคปชั่นดวงการเงินลง Facebook สั้น 2-3 ประโยค จบด้วย #ดูดวงการเงิน #หมอมี่",
+      prompt: `ไพ่: ${d.card}\nความหมายวันนี้: ${d.meaning}\nเขียนแคปชั่น:`,
+    };
+  },
+  buildImagePrompt(data) {
+    const d = financeDailySchema.parse(data);
+    return `สร้างภาพสไตล์ไพ่ยิปซีใบ ${d.card} ตีความแบบโมเดิร์น สื่อถึงดวงการเงิน พลังบวก คุมโทนสีอบอุ่นดูมงคล สวยงามเหมาะลงโซเชียล`;
+  },
+};

--- a/content-creator/templates/index.ts
+++ b/content-creator/templates/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Template Registry — map templateId → ContentTemplate
+ * เพิ่มแบบใหม่: import + ใส่ใน TEMPLATES (ไม่แตะ engine)
+ */
+import type { ContentTemplate } from "./types";
+import { financeDaily } from "./finance-daily";
+
+const TEMPLATES: Record<string, ContentTemplate> = {
+  [financeDaily.id]: financeDaily,
+};
+
+/** @throws Error ถ้า templateId ไม่รู้จัก */
+export function getTemplate(id: string): ContentTemplate {
+  const t = TEMPLATES[id];
+  if (!t) {
+    throw new Error(`unknown templateId: ${id} (มี: ${Object.keys(TEMPLATES).join(", ")})`);
+  }
+  return t;
+}
+
+export function listTemplateIds(): string[] {
+  return Object.keys(TEMPLATES);
+}
+
+export type { ContentTemplate } from "./types";

--- a/content-creator/templates/types.ts
+++ b/content-creator/templates/types.ts
@@ -1,0 +1,23 @@
+/**
+ * content-creator Template Registry — engine เดียว, หลาย template
+ * เพิ่ม "แบบ" ใหม่ = เพิ่มไฟล์ template + ลงทะเบียนใน index.ts (ไม่แตะ engine) [open/closed]
+ */
+import type { z } from "zod";
+
+export interface CaptionPrompt {
+  system: string;
+  prompt: string;
+}
+
+export interface ContentTemplate {
+  /** templateId — ผูกกับ ContentPost.templateId */
+  id: string;
+  /** ชื่อให้คนอ่าน (UI) */
+  name: string;
+  /** schema ของ inputData ที่ template นี้ต้องการ (validate ก่อน gen) */
+  inputSchema: z.ZodTypeAny;
+  /** สร้าง prompt สำหรับ caption (gemini genCaption) จาก input */
+  buildCaptionPrompt(data: unknown): CaptionPrompt;
+  /** สร้าง prompt สำหรับภาพ (gemini genImage) จาก input */
+  buildImagePrompt(data: unknown): string;
+}


### PR DESCRIPTION
## S2 — generate engine + Template Registry (lab-first)
ต่อจาก S1 (DB) — engine ที่หยิบ row `PENDING` → gen caption+ภาพ (Gemini lib จาก #86) → `GENERATED`

**Template Registry** (`content-creator/templates/`): `{id, name, inputSchema(zod), buildCaptionPrompt, buildImagePrompt}` + `finance-daily` (หมอมี่ tone) — เพิ่มแบบใหม่ = เพิ่มไฟล์ (open/closed, ไม่แตะ engine)

**engine** (`engine.ts`) `generate(db, id)`:
1. **claim** `PENDING→GENERATING` (atomic) — กัน concurrent gen ซ้ำ/เปลือง Gemini cost
2. validate `inputData` (zod) → throw → FAILED
3. `genCaption` + `genImage` (lib)
4. persist ภาพ file (`CONTENT_MEDIA_DIR`, gitignored) + `imagePath` ใน DB
5. `GENERATED` ; error → `releaseGenerate(FAILED)`

## production-readiness applied (memory `production-readiness-check`)
ข้อ 3 (external side-effect): Gemini = external + cost → **claim lease (GENERATING)** ก่อนเรียก เหมือน PUBLISHING ของ S4 (state machine symmetric)

## state machine เพิ่ม GENERATING
`PENDING→GENERATING→GENERATED` (recovery `GENERATING→FAILED/PENDING`) + `claimForGenerate`/`markGenerated`/`releaseGenerate`. S1 tests อัปเดตตาม (PENDING→GENERATING)

## verified
- `tsc --noEmit` 0 · `vitest run content-creator` **46/46** (templates 6 · engine 4: GENERATED / SKIPPED-claim / FAILED-error / invalid-input ; + S1 อัปเดต)
- engine test mock gemini lib (ไม่ยิง API), DB in-memory, image→temp file

## ตรงไหนควรตรวจ
- GENERATING claim altitude (symmetric กับ PUBLISHING) ถูกไหม — concurrent gen test (2nd → SKIPPED, Gemini เรียกครั้งเดียว)
- error → FAILED (ไม่ค้าง GENERATING) ครบ recovery ไหม
- Template Registry contract (inputSchema validate ก่อน gen)

🤖 ตอบโดย goo จาก [ฟีม] → goo-oracle