### PR TITLE
feat(content-creator): S3 — approve UI + middleware guard

### DIFF
--- a/app/content-creator/api/approve/route.ts
+++ b/app/content-creator/api/approve/route.ts
@@ -1,0 +1,43 @@
+/**
+ * POST /content-creator/api/approve — ฟีม approve/cancel โพสต์ที่ gen เสร็จ [S3]
+ * body: { id, action: "approve" | "cancel" }
+ *   approve → GENERATED → APPROVED (เข้าคิวรอ publish — S4)
+ *   cancel  → GENERATED → CANCELED (terminal)
+ * ใช้ tryTransition (atomic conditional) → ถ้า row ไม่ใช่ GENERATED แล้ว (จัดการไปแล้ว/race) คืน 409
+ */
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getContentDb } from "@/content-creator/db/client";
+import { tryTransition } from "@/content-creator/db/transition";
+import { isContentCreatorEnabled } from "@/content-creator/lib/enabled";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const BodySchema = z.object({
+  id: z.string().min(1),
+  action: z.enum(["approve", "cancel"]),
+});
+
+export async function POST(request: Request) {
+  if (!isContentCreatorEnabled()) return new NextResponse(null, { status: 404 });
+
+  let body: z.infer<typeof BodySchema>;
+  try {
+    body = BodySchema.parse(await request.json());
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid body (ต้องมี id + action)" }, { status: 400 });
+  }
+
+  const to = body.action === "approve" ? "APPROVED" : "CANCELED";
+  const db = getContentDb();
+  // atomic: เปลี่ยนเฉพาะถ้ายังเป็น GENERATED จริง — กัน double-approve / จัดการชน
+  const ok = tryTransition(db, body.id, "GENERATED", to);
+  if (!ok) {
+    return NextResponse.json(
+      { ok: false, error: "โพสต์ไม่อยู่สถานะ GENERATED (อาจถูกจัดการไปแล้ว หรือไม่พบ id)" },
+      { status: 409 },
+    );
+  }
+  return NextResponse.json({ ok: true, id: body.id, status: to });
+}

--- a/app/content-creator/api/media/[name]/route.ts
+++ b/app/content-creator/api/media/[name]/route.ts
@@ -7,7 +7,7 @@
  * ไม่ leak fs path ออกไป ; ปิดเมื่อ feature ไม่ enabled (middleware + เช็คซ้ำที่นี่)
  */
 import { NextResponse } from "next/server";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, lstatSync, readFileSync, realpathSync } from "node:fs";
 import { basename, join, resolve, sep } from "node:path";
 import { isContentCreatorEnabled } from "@/content-creator/lib/enabled";
 
@@ -16,19 +16,35 @@ export const dynamic = "force-dynamic";
 
 const mediaDir = () => process.env.CONTENT_MEDIA_DIR || "content-creator/media";
 
+/**
+ * คืน absolute path ที่ปลอดภัยจริง หรือ null. กัน traversal 2 ชั้น [ตู๋ P1/P2]:
+ *   1. lexical: basename ตัด ../, บังคับ .png
+ *   2. symlink: reject ไฟล์ที่เป็น symlink + realpath ต้องยังอยู่ใต้ media root จริง
+ *      (lexical resolve อย่างเดียวไม่พอ — symlink ใน media dir ชี้ออกนอกได้)
+ */
+function safeMediaPath(name: string): string | null {
+  const safe = basename(name);
+  if (!safe.endsWith(".png")) return null;
+  try {
+    const root = realpathSync(resolve(mediaDir())); // realpath root (กัน symlink ใน path เช่น /tmp→/private/tmp)
+    const candidate = join(root, safe);
+    if (!existsSync(candidate)) return null;
+    if (lstatSync(candidate).isSymbolicLink()) return null; // ไม่ follow symlink ออกนอก root
+    const real = realpathSync(candidate);
+    if (real !== candidate) return null; // มี symlink component กลางทาง
+    if (real !== root && !real.startsWith(root + sep)) return null; // belt: ยังอยู่ใต้ root
+    return real;
+  } catch {
+    return null; // media dir ไม่มี / stat ล้ม → ถือว่าไม่พบ
+  }
+}
+
 export async function GET(_request: Request, ctx: { params: Promise<{ name: string }> }) {
   if (!isContentCreatorEnabled()) return new NextResponse(null, { status: 404 });
 
   const { name } = await ctx.params;
-  const safe = basename(name); // ตัด ../ และ path component ใด ๆ ทิ้ง
-  if (!safe.endsWith(".png")) return new NextResponse(null, { status: 404 });
-
-  const root = resolve(mediaDir());
-  const full = resolve(join(root, safe));
-  if (full !== join(root, safe) || !full.startsWith(root + sep)) {
-    return new NextResponse(null, { status: 404 }); // หลุด media root → ปฏิเสธ
-  }
-  if (!existsSync(full)) return new NextResponse(null, { status: 404 });
+  const full = safeMediaPath(name);
+  if (!full) return new NextResponse(null, { status: 404 });
 
   const bytes = readFileSync(full);
   return new NextResponse(new Uint8Array(bytes), {

--- a/app/content-creator/api/media/[name]/route.ts
+++ b/app/content-creator/api/media/[name]/route.ts
@@ -1,0 +1,38 @@
+/**
+ * GET /content-creator/api/media/[name] — serve ภาพ gen จาก CONTENT_MEDIA_DIR [S3]
+ *
+ * ⚠️ path traversal (บทเรียน S2 P2): name มาจาก client เชื่อไม่ได้.
+ *   - basename() ตัด path component ทิ้ง (../ หาย) + บังคับ .png
+ *   - assert resolved path อยู่ใต้ media root จริง (belt-and-suspenders)
+ * ไม่ leak fs path ออกไป ; ปิดเมื่อ feature ไม่ enabled (middleware + เช็คซ้ำที่นี่)
+ */
+import { NextResponse } from "next/server";
+import { existsSync, readFileSync } from "node:fs";
+import { basename, join, resolve, sep } from "node:path";
+import { isContentCreatorEnabled } from "@/content-creator/lib/enabled";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const mediaDir = () => process.env.CONTENT_MEDIA_DIR || "content-creator/media";
+
+export async function GET(_request: Request, ctx: { params: Promise<{ name: string }> }) {
+  if (!isContentCreatorEnabled()) return new NextResponse(null, { status: 404 });
+
+  const { name } = await ctx.params;
+  const safe = basename(name); // ตัด ../ และ path component ใด ๆ ทิ้ง
+  if (!safe.endsWith(".png")) return new NextResponse(null, { status: 404 });
+
+  const root = resolve(mediaDir());
+  const full = resolve(join(root, safe));
+  if (full !== join(root, safe) || !full.startsWith(root + sep)) {
+    return new NextResponse(null, { status: 404 }); // หลุด media root → ปฏิเสธ
+  }
+  if (!existsSync(full)) return new NextResponse(null, { status: 404 });
+
+  const bytes = readFileSync(full);
+  return new NextResponse(new Uint8Array(bytes), {
+    status: 200,
+    headers: { "Content-Type": "image/png", "Cache-Control": "no-store" },
+  });
+}

--- a/app/content-creator/api/posts/route.ts
+++ b/app/content-creator/api/posts/route.ts
@@ -1,0 +1,34 @@
+/**
+ * GET /content-creator/api/posts — list โพสต์ล่าสุด (approve queue + สถานะอื่นเพื่อ context) [S3]
+ * อยู่ใต้ prefix /content-creator → middleware guard ครอบ ; เช็ค enabled ซ้ำ (defense-in-depth)
+ */
+import { NextResponse } from "next/server";
+import { basename } from "node:path";
+import { desc } from "drizzle-orm";
+import { getContentDb } from "@/content-creator/db/client";
+import { contentPosts } from "@/content-creator/db/schema";
+import { isContentCreatorEnabled } from "@/content-creator/lib/enabled";
+
+export const runtime = "nodejs"; // better-sqlite3 = native (ต้อง node ไม่ใช่ edge)
+export const dynamic = "force-dynamic"; // อ่าน DB ทุก request — ห้าม static cache
+
+export async function GET() {
+  if (!isContentCreatorEnabled()) return new NextResponse(null, { status: 404 });
+
+  const db = getContentDb();
+  const rows = db.select().from(contentPosts).orderBy(desc(contentPosts.updatedAt)).limit(50).all();
+
+  // imagePath (path บนเครื่อง) → media URL ผ่าน route ที่ serve อย่างปลอดภัย (ไม่ leak fs path)
+  const posts = rows.map((r) => ({
+    id: r.id,
+    templateId: r.templateId,
+    status: r.status,
+    caption: r.caption,
+    inputData: r.inputData,
+    imageUrl: r.imagePath ? `/content-creator/api/media/${basename(r.imagePath)}` : null,
+    createdAt: r.createdAt,
+    updatedAt: r.updatedAt,
+  }));
+
+  return NextResponse.json({ posts });
+}

--- a/app/content-creator/page.tsx
+++ b/app/content-creator/page.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+/**
+ * /content-creator — approve UI (admin tool ของฟีม) [S3]
+ * แสดงโพสต์ที่ gen เสร็จ (GENERATED) → ฟีมกด approve/cancel.
+ * route ถูก guard ด้วย middleware (404 ถ้า CONTENT_CREATOR_ENABLED ไม่เปิด/บน production)
+ */
+import { useCallback, useEffect, useState } from "react";
+
+type Post = {
+  id: string;
+  templateId: string;
+  status: string;
+  caption: string | null;
+  inputData: Record<string, unknown>;
+  imageUrl: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+const STATUS_STYLE: Record<string, string> = {
+  PENDING: "bg-gray-200 text-gray-700",
+  GENERATING: "bg-amber-100 text-amber-800",
+  GENERATED: "bg-blue-100 text-blue-800",
+  APPROVED: "bg-emerald-100 text-emerald-800",
+  PUBLISHING: "bg-amber-100 text-amber-800",
+  POSTED: "bg-green-600 text-white",
+  CANCELED: "bg-gray-300 text-gray-600",
+  FAILED: "bg-red-100 text-red-800",
+};
+
+export default function ContentCreatorPage() {
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      const res = await fetch("/content-creator/api/posts", { cache: "no-store" });
+      if (!res.ok) throw new Error(`โหลดไม่สำเร็จ (${res.status})`);
+      const data = await res.json();
+      setPosts(data.posts ?? []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "เกิดข้อผิดพลาด");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const act = useCallback(
+    async (id: string, action: "approve" | "cancel") => {
+      setBusyId(id);
+      setError(null);
+      try {
+        const res = await fetch("/content-creator/api/approve", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id, action }),
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) throw new Error(data.error ?? `${action} ไม่สำเร็จ (${res.status})`);
+        await load(); // refresh หลัง transition
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "เกิดข้อผิดพลาด");
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [load],
+  );
+
+  const pending = posts.filter((p) => p.status === "GENERATED");
+  const others = posts.filter((p) => p.status !== "GENERATED");
+
+  return (
+    <main className="mx-auto max-w-3xl px-4 py-8">
+      <header className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Content Creator</h1>
+          <p className="text-sm text-gray-500">รอ approve {pending.length} โพสต์</p>
+        </div>
+        <button
+          onClick={load}
+          className="rounded-lg border px-3 py-1.5 text-sm hover:bg-gray-50"
+          disabled={loading}
+        >
+          รีเฟรช
+        </button>
+      </header>
+
+      {error && (
+        <div className="mb-4 rounded-lg bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
+      )}
+      {loading && <p className="text-gray-500">กำลังโหลด…</p>}
+
+      {!loading && pending.length === 0 && (
+        <p className="rounded-lg bg-gray-50 px-4 py-8 text-center text-gray-500">
+          ไม่มีโพสต์รอ approve
+        </p>
+      )}
+
+      <section className="space-y-4">
+        {pending.map((p) => (
+          <article key={p.id} className="overflow-hidden rounded-xl border shadow-sm">
+            {p.imageUrl && (
+              // eslint-disable-next-line @next/next/no-img-element -- admin tool, local fs media
+              <img src={p.imageUrl} alt="generated" className="aspect-square w-full bg-gray-100 object-cover" />
+            )}
+            <div className="space-y-3 p-4">
+              <div className="flex items-center gap-2">
+                <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_STYLE[p.status] ?? ""}`}>
+                  {p.status}
+                </span>
+                <span className="text-xs text-gray-400">{p.templateId}</span>
+              </div>
+              <p className="whitespace-pre-wrap text-sm">{p.caption}</p>
+              <div className="flex gap-2 pt-1">
+                <button
+                  onClick={() => act(p.id, "approve")}
+                  disabled={busyId === p.id}
+                  className="flex-1 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+                >
+                  {busyId === p.id ? "…" : "Approve"}
+                </button>
+                <button
+                  onClick={() => act(p.id, "cancel")}
+                  disabled={busyId === p.id}
+                  className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          </article>
+        ))}
+      </section>
+
+      {others.length > 0 && (
+        <section className="mt-8">
+          <h2 className="mb-2 text-sm font-semibold text-gray-500">โพสต์อื่น</h2>
+          <ul className="divide-y rounded-xl border text-sm">
+            {others.map((p) => (
+              <li key={p.id} className="flex items-center justify-between px-4 py-2">
+                <span className="truncate text-gray-600">{p.caption ?? p.templateId}</span>
+                <span className={`ml-2 shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_STYLE[p.status] ?? ""}`}>
+                  {p.status}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/content-creator/README.md
+++ b/content-creator/README.md
@@ -8,6 +8,15 @@ feature นี้ **รันบนเครื่อง local เท่าน�
 - DB เป็น **file SQLite** (better-sqlite3) — Vercel serverless fs เป็น ephemeral/แยก instance → data หาย
 - `createContentDb()` จะ **throw บน Vercel** (`process.env.VERCEL`) โดยตั้งใจ — กัน data loss
 - route `/content-creator` ปิดบน production ด้วย env guard `CONTENT_CREATOR_ENABLED` (middleware → 404)
+- gate = **fail-closed** (`content-creator/lib/enabled.ts`): ปิดเป็น default, เปิดเฉพาะ `CONTENT_CREATOR_ENABLED=true` บน local, **ปิดเสมอบน Vercel** แม้เผลอ set env. middleware + ทุก route handler เช็คซ้ำ (defense-in-depth)
+
+## 🖥️ Approve UI (S3)
+
+- หน้า `/content-creator` (client) → list โพสต์, โพสต์ `GENERATED` มีปุ่ม **Approve/Cancel**
+- API (อยู่ใต้ `/content-creator/api/*` → middleware guard ครอบ):
+  - `GET  /content-creator/api/posts` — list 50 ล่าสุด (imagePath → media URL, ไม่ leak fs path)
+  - `POST /content-creator/api/approve` — `{id, action: approve|cancel}` → `tryTransition` GENERATED→APPROVED/CANCELED (atomic, double-approve → 409)
+  - `GET  /content-creator/api/media/[name]` — serve ภาพจาก `CONTENT_MEDIA_DIR` ; **path-safe** (`basename` + assert ใต้ media root + บังคับ `.png` — กัน traversal เหมือน S2 P2)
 
 ## ▶️ วิธีรัน (runnable target)
 

--- a/content-creator/__tests__/enabled.test.ts
+++ b/content-creator/__tests__/enabled.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { isContentCreatorEnabled } from "../lib/enabled";
+
+const SAVED = {
+  enabled: process.env.CONTENT_CREATOR_ENABLED,
+  vercel: process.env.VERCEL,
+};
+function setEnv(enabled?: string, vercel?: string) {
+  if (enabled === undefined) delete process.env.CONTENT_CREATOR_ENABLED;
+  else process.env.CONTENT_CREATOR_ENABLED = enabled;
+  if (vercel === undefined) delete process.env.VERCEL;
+  else process.env.VERCEL = vercel;
+}
+afterEach(() => setEnv(SAVED.enabled, SAVED.vercel));
+
+describe("isContentCreatorEnabled — fail-closed gate [S3]", () => {
+  it("default (ไม่ set อะไร) → false (ปิดเป็น default)", () => {
+    setEnv(undefined, undefined);
+    expect(isContentCreatorEnabled()).toBe(false);
+  });
+
+  it("CONTENT_CREATOR_ENABLED=true + local → true", () => {
+    setEnv("true", undefined);
+    expect(isContentCreatorEnabled()).toBe(true);
+  });
+
+  it("บน Vercel → false เสมอ แม้ตั้ง enabled=true (hard off กัน expose)", () => {
+    setEnv("true", "1");
+    expect(isContentCreatorEnabled()).toBe(false);
+  });
+
+  it("ค่าที่ไม่ใช่ 'true' เป๊ะ ๆ → false (เช่น '1', 'yes')", () => {
+    setEnv("1", undefined);
+    expect(isContentCreatorEnabled()).toBe(false);
+    setEnv("yes", undefined);
+    expect(isContentCreatorEnabled()).toBe(false);
+  });
+});

--- a/content-creator/__tests__/enabled.test.ts
+++ b/content-creator/__tests__/enabled.test.ts
@@ -4,14 +4,18 @@ import { isContentCreatorEnabled } from "../lib/enabled";
 const SAVED = {
   enabled: process.env.CONTENT_CREATOR_ENABLED,
   vercel: process.env.VERCEL,
+  nodeEnv: process.env.NODE_ENV,
 };
-function setEnv(enabled?: string, vercel?: string) {
+function setEnv(enabled?: string, vercel?: string, nodeEnv: string = "development") {
   if (enabled === undefined) delete process.env.CONTENT_CREATOR_ENABLED;
   else process.env.CONTENT_CREATOR_ENABLED = enabled;
   if (vercel === undefined) delete process.env.VERCEL;
   else process.env.VERCEL = vercel;
+  (process.env as Record<string, string>).NODE_ENV = nodeEnv;
 }
-afterEach(() => setEnv(SAVED.enabled, SAVED.vercel));
+afterEach(() => {
+  setEnv(SAVED.enabled, SAVED.vercel, SAVED.nodeEnv ?? "test");
+});
 
 describe("isContentCreatorEnabled — fail-closed gate [S3]", () => {
   it("default (ไม่ set อะไร) → false (ปิดเป็น default)", () => {
@@ -19,13 +23,18 @@ describe("isContentCreatorEnabled — fail-closed gate [S3]", () => {
     expect(isContentCreatorEnabled()).toBe(false);
   });
 
-  it("CONTENT_CREATOR_ENABLED=true + local → true", () => {
-    setEnv("true", undefined);
+  it("CONTENT_CREATOR_ENABLED=true + local dev → true", () => {
+    setEnv("true", undefined, "development");
     expect(isContentCreatorEnabled()).toBe(true);
   });
 
+  it("NODE_ENV=production + enabled=true (self-host/docker non-Vercel) → false [ตู๋ P1]", () => {
+    setEnv("true", undefined, "production");
+    expect(isContentCreatorEnabled()).toBe(false);
+  });
+
   it("บน Vercel → false เสมอ แม้ตั้ง enabled=true (hard off กัน expose)", () => {
-    setEnv("true", "1");
+    setEnv("true", "1", "production");
     expect(isContentCreatorEnabled()).toBe(false);
   });
 

--- a/content-creator/__tests__/s3-routes.test.ts
+++ b/content-creator/__tests__/s3-routes.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, afterAll, beforeEach } from "vitest";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { describe, it, expect, afterAll, afterEach, beforeEach } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { eq } from "drizzle-orm";
+import { NextRequest } from "next/server";
 
 // ตั้ง env ก่อนเรียก route (getContentDb/mediaDir อ่านตอน request ไม่ใช่ตอน import)
 const TMP = mkdtempSync(join(tmpdir(), "cc-s3-"));
@@ -16,6 +17,7 @@ import { contentPosts } from "../db/schema";
 import { GET as postsGET } from "@/app/content-creator/api/posts/route";
 import { POST as approvePOST } from "@/app/content-creator/api/approve/route";
 import { GET as mediaGET } from "@/app/content-creator/api/media/[name]/route";
+import { middleware } from "@/middleware";
 
 const enable = () => (process.env.CONTENT_CREATOR_ENABLED = "true");
 const disable = () => delete process.env.CONTENT_CREATOR_ENABLED;
@@ -28,8 +30,39 @@ function approveReq(body: unknown) {
   });
 }
 const mediaCtx = (name: string) => ({ params: Promise.resolve({ name }) });
+const mwReq = (path: string) => new NextRequest(new URL(`http://localhost${path}`));
 
 afterAll(() => rmSync(TMP, { recursive: true, force: true }));
+
+describe("[S3] middleware guard — 404 จริงเมื่อปิด (page + nested API)", () => {
+  it("disabled → /content-creator + /content-creator/api/* = 404", () => {
+    disable();
+    expect(middleware(mwReq("/content-creator")).status).toBe(404);
+    expect(middleware(mwReq("/content-creator/api/posts")).status).toBe(404);
+    expect(middleware(mwReq("/content-creator/api/media/x.png")).status).toBe(404);
+  });
+  it("enabled → ผ่าน (ไม่ 404)", () => {
+    enable();
+    expect(middleware(mwReq("/content-creator")).status).not.toBe(404);
+  });
+});
+
+describe("[S3] production hard-off — NODE_ENV=production → ปิดทุกทางแม้ enabled=true [ตู๋ P1]", () => {
+  const saved = process.env.NODE_ENV;
+  beforeEach(() => {
+    enable();
+    (process.env as Record<string, string>).NODE_ENV = "production";
+  });
+  afterEach(() => {
+    (process.env as Record<string, string>).NODE_ENV = saved ?? "test";
+  });
+  it("middleware + posts + approve + media → 404 ใน production", async () => {
+    expect(middleware(mwReq("/content-creator")).status).toBe(404);
+    expect((await postsGET()).status).toBe(404);
+    expect((await approvePOST(approveReq({ id: "x", action: "approve" }))).status).toBe(404);
+    expect((await mediaGET(new Request("http://t"), mediaCtx("a.png"))).status).toBe(404);
+  });
+});
 
 describe("[S3] route disabled-gate — ปิดแล้วต้อง 404 จริงทุก route (กัน expose)", () => {
   beforeEach(disable);
@@ -94,6 +127,13 @@ describe("[S3] media route — path traversal กันหลุด media root (
     writeFileSync(join(TMP, "evil.png"), Buffer.from([1, 2, 3])); // วางไว้ "นอก" media dir
     const res = await mediaGET(new Request("http://t"), mediaCtx("../evil.png"));
     expect(res.status).toBe(404); // basename → "evil.png" → หาใน media dir → ไม่เจอ → 404 (ไม่หลุดไปอ่าน ../evil.png)
+  });
+
+  it("symlink ใน media dir ชี้ออกนอก → 404 (ไม่ follow, lexical resolve ไม่พอ) [ตู๋ P2]", async () => {
+    writeFileSync(join(TMP, "outside-secret.png"), Buffer.from("OUTSIDE_SECRET"));
+    symlinkSync(join(TMP, "outside-secret.png"), join(MEDIA, "linked.png")); // media/linked.png -> ../outside-secret.png
+    const res = await mediaGET(new Request("http://t"), mediaCtx("linked.png"));
+    expect(res.status).toBe(404); // reject symlink — ไม่ leak ไฟล์นอก root
   });
 
   it("ไม่ใช่ .png → 404", async () => {

--- a/content-creator/__tests__/s3-routes.test.ts
+++ b/content-creator/__tests__/s3-routes.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, afterAll, beforeEach } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { eq } from "drizzle-orm";
+
+// ตั้ง env ก่อนเรียก route (getContentDb/mediaDir อ่านตอน request ไม่ใช่ตอน import)
+const TMP = mkdtempSync(join(tmpdir(), "cc-s3-"));
+const MEDIA = join(TMP, "media");
+process.env.CONTENT_DB_PATH = join(TMP, "test.db");
+process.env.CONTENT_MEDIA_DIR = MEDIA;
+mkdirSync(MEDIA, { recursive: true });
+
+import { getContentDb } from "../db/client";
+import { contentPosts } from "../db/schema";
+import { GET as postsGET } from "@/app/content-creator/api/posts/route";
+import { POST as approvePOST } from "@/app/content-creator/api/approve/route";
+import { GET as mediaGET } from "@/app/content-creator/api/media/[name]/route";
+
+const enable = () => (process.env.CONTENT_CREATOR_ENABLED = "true");
+const disable = () => delete process.env.CONTENT_CREATOR_ENABLED;
+
+function approveReq(body: unknown) {
+  return new Request("http://t/content-creator/api/approve", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+const mediaCtx = (name: string) => ({ params: Promise.resolve({ name }) });
+
+afterAll(() => rmSync(TMP, { recursive: true, force: true }));
+
+describe("[S3] route disabled-gate — ปิดแล้วต้อง 404 จริงทุก route (กัน expose)", () => {
+  beforeEach(disable);
+  it("posts GET → 404 เมื่อ feature ปิด", async () => {
+    expect((await postsGET()).status).toBe(404);
+  });
+  it("approve POST → 404 เมื่อ feature ปิด (ไม่แตะ DB)", async () => {
+    expect((await approvePOST(approveReq({ id: "x", action: "approve" }))).status).toBe(404);
+  });
+  it("media GET → 404 เมื่อ feature ปิด", async () => {
+    expect((await mediaGET(new Request("http://t"), mediaCtx("a.png"))).status).toBe(404);
+  });
+});
+
+describe("[S3] approve route — GENERATED → APPROVED/CANCELED (atomic)", () => {
+  beforeEach(enable);
+
+  it("approve โพสต์ GENERATED → 200 + DB เป็น APPROVED", async () => {
+    const db = getContentDb();
+    db.insert(contentPosts).values({ id: "ap1", templateId: "finance-daily", inputData: {}, status: "GENERATED" }).run();
+    const res = await approvePOST(approveReq({ id: "ap1", action: "approve" }));
+    expect(res.status).toBe(200);
+    expect((await res.json()).status).toBe("APPROVED");
+    expect(db.select().from(contentPosts).where(eq(contentPosts.id, "ap1")).get()!.status).toBe("APPROVED");
+  });
+
+  it("approve ซ้ำ (ไม่ใช่ GENERATED แล้ว) → 409 (กัน double-approve)", async () => {
+    const res = await approvePOST(approveReq({ id: "ap1", action: "approve" })); // ap1 เป็น APPROVED แล้ว
+    expect(res.status).toBe(409);
+    expect((await res.json()).ok).toBe(false);
+  });
+
+  it("cancel โพสต์ GENERATED → 200 + CANCELED", async () => {
+    const db = getContentDb();
+    db.insert(contentPosts).values({ id: "cn1", templateId: "t", inputData: {}, status: "GENERATED" }).run();
+    const res = await approvePOST(approveReq({ id: "cn1", action: "cancel" }));
+    expect(res.status).toBe(200);
+    expect(db.select().from(contentPosts).where(eq(contentPosts.id, "cn1")).get()!.status).toBe("CANCELED");
+  });
+
+  it("ghost id → 409", async () => {
+    expect((await approvePOST(approveReq({ id: "nope", action: "approve" }))).status).toBe(409);
+  });
+
+  it("body ผิด schema → 400", async () => {
+    expect((await approvePOST(approveReq({ id: "" }))).status).toBe(400);
+    expect((await approvePOST(approveReq({ id: "x", action: "delete" }))).status).toBe(400);
+  });
+});
+
+describe("[S3] media route — path traversal กันหลุด media root (บทเรียน S2 P2)", () => {
+  beforeEach(enable);
+
+  it("ไฟล์ใน media dir + .png → 200 image/png", async () => {
+    writeFileSync(join(MEDIA, "good-1.png"), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+    const res = await mediaGET(new Request("http://t"), mediaCtx("good-1.png"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("image/png");
+  });
+
+  it("../ escape → 404 (basename ตัด path, ไม่อ่านไฟล์นอก root)", async () => {
+    writeFileSync(join(TMP, "evil.png"), Buffer.from([1, 2, 3])); // วางไว้ "นอก" media dir
+    const res = await mediaGET(new Request("http://t"), mediaCtx("../evil.png"));
+    expect(res.status).toBe(404); // basename → "evil.png" → หาใน media dir → ไม่เจอ → 404 (ไม่หลุดไปอ่าน ../evil.png)
+  });
+
+  it("ไม่ใช่ .png → 404", async () => {
+    expect((await mediaGET(new Request("http://t"), mediaCtx("notes.txt"))).status).toBe(404);
+  });
+
+  it("ไฟล์ไม่มีอยู่ → 404", async () => {
+    expect((await mediaGET(new Request("http://t"), mediaCtx("missing.png"))).status).toBe(404);
+  });
+});

--- a/content-creator/lib/enabled.ts
+++ b/content-creator/lib/enabled.ts
@@ -1,0 +1,13 @@
+/**
+ * content-creator runtime gate — เปิด/ปิด feature [S3]
+ *
+ * โมดูลนี้ตั้งใจให้ **zero import** (อ่าน process.env อย่างเดียว) → edge-safe:
+ * ใช้ได้ทั้ง middleware (edge runtime) และ route handler (node) แบบ single source.
+ *
+ * fail-closed: ปิดเป็น default. เปิดเฉพาะ local dev ที่ตั้ง CONTENT_CREATOR_ENABLED=true.
+ * บน Vercel/serverless ปิดเสมอ (admin tool รัน local เท่านั้น — ดู README runtime contract).
+ */
+export function isContentCreatorEnabled(): boolean {
+  if (process.env.VERCEL) return false; // hard off บน Vercel เสมอ (กัน expose แม้เผลอ set env)
+  return process.env.CONTENT_CREATOR_ENABLED === "true";
+}

--- a/content-creator/lib/enabled.ts
+++ b/content-creator/lib/enabled.ts
@@ -8,6 +8,10 @@
  * บน Vercel/serverless ปิดเสมอ (admin tool รัน local เท่านั้น — ดู README runtime contract).
  */
 export function isContentCreatorEnabled(): boolean {
-  if (process.env.VERCEL) return false; // hard off บน Vercel เสมอ (กัน expose แม้เผลอ set env)
+  // hard-off ทุก production — รวม self-host/docker (non-Vercel) ที่ NODE_ENV=production.
+  // admin tool รัน local dev เท่านั้น (script content-creator:dev → next dev → NODE_ENV=development)
+  // API ไม่มี user auth → production ห้ามเปิดเด็ดขาด แม้ตั้ง CONTENT_CREATOR_ENABLED=true [ตู๋ P1]
+  if (process.env.NODE_ENV === "production") return false;
+  if (process.env.VERCEL) return false; // belt: preview/serverless บน Vercel ก็ปิด
   return process.env.CONTENT_CREATOR_ENABLED === "true";
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,9 +1,18 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { getSessionCookie } from 'better-auth/cookies';
+import { isContentCreatorEnabled } from '@/content-creator/lib/enabled';
 
 export function middleware(request: NextRequest) {
   const { pathname, searchParams } = request.nextUrl;
+
+  // 0. content-creator gate — admin tool รัน local เท่านั้น. ปิด = 404 จริง (ดูเหมือนไม่มี route)
+  //    ครอบทั้ง page /content-creator และ api /content-creator/api/* (อยู่ใต้ prefix เดียว)
+  if (pathname === '/content-creator' || pathname.startsWith('/content-creator/')) {
+    if (!isContentCreatorEnabled()) {
+      return new NextResponse(null, { status: 404 });
+    }
+  }
 
   const response = NextResponse.next();
 


### PR DESCRIPTION
## S3 — Approve UI + middleware guard

ต่อจาก S1 (DB #87) + S2 (generate engine #88). S3 คือ **หน้า approve ของฟีม** + **guard ปิด feature บน production**.

### สร้างอะไร
- **fail-closed gate** `content-creator/lib/enabled.ts` (edge-safe, zero-import): ปิดเป็น default, เปิดเฉพาะ `CONTENT_CREATOR_ENABLED=true` บน local, **ปิดเสมอบน Vercel** แม้เผลอ set env
- **middleware guard**: `/content-creator` + `/content-creator/api/*` → **404 จริง** เมื่อไม่ enabled (carry-forward gate ของตู๋)
- **API** (วางใต้ `/content-creator/api/*` ตั้งใจ — ไม่ใช่ `/api/*` ที่ middleware matcher exclude → guard ครอบถึง; + เช็ค enabled ใน route เองด้วย = defense-in-depth):
  - `GET posts` — list 50 ล่าสุด, `imagePath → media URL` (ไม่ leak fs path)
  - `POST approve` — `{id, action: approve|cancel}` → `tryTransition` GENERATED→APPROVED/CANCELED (atomic; double-approve/stale → 409)
  - `GET media/[name]` — serve png จาก `CONTENT_MEDIA_DIR`, **path-safe**: `basename` + assert ใต้ media root + บังคับ `.png` (กัน traversal ตรงตามบทเรียน S2 P2)
- **approve UI** `app/content-creator/page.tsx` (client, Tailwind self-contained — ไม่ผูก design system หลัก)

### จุดที่อยากให้ตู๋ตรวจเป็นพิเศษ
1. **middleware guard ครอบ API ไหม** — เพราะ matcher เดิม exclude top-level `/api` เลยวาง API ใต้ `/content-creator/api/*` (ไม่ขึ้นต้น `/api`). มี test ยืนยัน disabled→404 ทั้ง 3 route
2. **media path traversal** — basename + assert media root; test `../evil.png` (วางไฟล์นอก media dir) → 404 ไม่หลุดไปอ่าน
3. **fail-closed** — Vercel off เสมอ + default off

### Verify
- `npx tsc --noEmit` → **0 errors**
- `npx vitest run content-creator` → **64 passed** (+12 S3: enabled fail-closed ×4, route disabled-gate ×3, approve/cancel/409/400, media traversal ×4)
- `CONTENT_CREATOR_ENABLED=true npx next build` → **ผ่าน** (middleware + routes compile, edge import ของ enabled.ts ทำงาน)
- ไม่มี schema/migration เปลี่ยน

### Scope note
ไม่ใส่ user auth บน route (admin tool รัน local-only, guard ด้วย env + Vercel-off แล้ว). publish จริง (APPROVED→PUBLISHING→POSTED) เป็น S4.

🤖 ตอบโดย goo จาก [ฟีม] → goo-oracle