### PR TITLE
feat(content-creator): S3.5a — seeding UI (create + generate)

### DIFF
--- a/app/content-creator/api/create/route.ts
+++ b/app/content-creator/api/create/route.ts
@@ -74,7 +74,21 @@ export async function POST(request: Request) {
         { status: 409 },
       );
     }
-    return NextResponse.json({ ok: existing.status !== "FAILED", id: existing.id, status: existing.status, caption: existing.caption ?? undefined, idempotent: true });
+    // outcome ยังไม่ definitive (อีก request กำลัง gen) → 202 in-progress.
+    // client ต้อง "เก็บ key ไว้" (ไม่ clear) → retry ถัดไปยัง idempotent ไม่จ่าย Gemini ซ้ำ [ตู๋ P1]
+    const inProgress = existing.status === "PENDING" || existing.status === "GENERATING";
+    if (inProgress) {
+      return NextResponse.json(
+        { ok: false, inProgress: true, id: existing.id, status: existing.status, idempotent: true },
+        { status: 202 },
+      );
+    }
+    // terminal แล้ว (definitive) → 200 ; ok เฉพาะที่ผ่าน gen สำเร็จ (ไม่ใช่ FAILED/CANCELED)
+    const ok = existing.status !== "FAILED" && existing.status !== "CANCELED";
+    return NextResponse.json(
+      { ok, id: existing.id, status: existing.status, caption: existing.caption ?? undefined, idempotent: true },
+      { status: 200 },
+    );
   }
 
   // เราเป็นคนสร้าง row นี้ → gen (sync, เรียก Gemini)

--- a/app/content-creator/api/create/route.ts
+++ b/app/content-creator/api/create/route.ts
@@ -59,10 +59,20 @@ export async function POST(request: Request) {
     .run();
 
   if (ins.changes === 0) {
-    // requestKey นี้สร้างไปแล้ว (retry/concurrent) — คืน row เดิม ไม่ gen ซ้ำ (ไม่จ่าย Gemini ซ้ำ)
+    // requestKey นี้สร้างไปแล้ว (retry/reload/concurrent) — คืน row เดิม ไม่ gen ซ้ำ (ไม่จ่าย Gemini ซ้ำ)
     const existing = db.select().from(contentPosts).where(eq(contentPosts.requestKey, body.requestKey)).get();
     if (!existing) {
       return NextResponse.json({ ok: false, error: "conflict แต่หา row เดิมไม่เจอ" }, { status: 409 });
+    }
+    // same key ต้อง same payload — ถ้าต่าง = key ชน/reuse ผิด → 409 (ไม่คืน row ที่ payload ไม่ตรง) [ตู๋ P1]
+    const samePayload =
+      existing.templateId === body.templateId &&
+      JSON.stringify(existing.inputData) === JSON.stringify(parsed.data);
+    if (!samePayload) {
+      return NextResponse.json(
+        { ok: false, error: "requestKey ซ้ำแต่ payload ต่าง (key reuse ผิด)" },
+        { status: 409 },
+      );
     }
     return NextResponse.json({ ok: existing.status !== "FAILED", id: existing.id, status: existing.status, caption: existing.caption ?? undefined, idempotent: true });
   }

--- a/app/content-creator/api/create/route.ts
+++ b/app/content-creator/api/create/route.ts
@@ -8,6 +8,7 @@
  * แทน dev script seed-and-gen ด้วยปุ่มจริง — pipeline ครบ input→approve ผ่าน UI
  */
 import { NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { getContentDb } from "@/content-creator/db/client";
 import { contentPosts } from "@/content-creator/db/schema";
@@ -19,6 +20,8 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 const BodySchema = z.object({
+  // idempotency key (client ส่ง 1 อันต่อ submit) — กัน create ซ้ำจาก retry/reload/double-click
+  requestKey: z.string().min(1),
   templateId: z.string().min(1),
   inputData: z.record(z.string(), z.unknown()),
 });
@@ -30,10 +33,10 @@ export async function POST(request: Request) {
   try {
     body = BodySchema.parse(await request.json());
   } catch {
-    return NextResponse.json({ ok: false, error: "invalid body (ต้องมี templateId + inputData)" }, { status: 400 });
+    return NextResponse.json({ ok: false, error: "invalid body (ต้องมี requestKey + templateId + inputData)" }, { status: 400 });
   }
 
-  // validate ก่อน insert → 400 สะอาด ไม่ทิ้ง PENDING row ขยะถ้า input ผิด
+  // validate ก่อน insert → 400 สะอาด ไม่ทิ้ง row ขยะถ้า input ผิด
   let template;
   try {
     template = getTemplate(body.templateId);
@@ -47,9 +50,24 @@ export async function POST(request: Request) {
 
   const db = getContentDb();
   const id = crypto.randomUUID();
-  db.insert(contentPosts).values({ id, templateId: body.templateId, inputData: body.inputData, status: "PENDING" }).run();
+  // atomic get-or-create: insert ผ่านเฉพาะถ้า requestKey ยังไม่มี (unique). retry/concurrent →
+  // changes 0 → ไม่ยิง Gemini ซ้ำ, คืน row เดิม [ตู๋ P1]. ใช้ parsed.data (canonical) ไม่ใช่ raw [ตู๋ P2]
+  const ins = db
+    .insert(contentPosts)
+    .values({ id, requestKey: body.requestKey, templateId: body.templateId, inputData: parsed.data as Record<string, unknown>, status: "PENDING" })
+    .onConflictDoNothing({ target: contentPosts.requestKey })
+    .run();
 
-  // sync gen (เรียก Gemini) — admin tool คนเดียว, รอผลทันที
+  if (ins.changes === 0) {
+    // requestKey นี้สร้างไปแล้ว (retry/concurrent) — คืน row เดิม ไม่ gen ซ้ำ (ไม่จ่าย Gemini ซ้ำ)
+    const existing = db.select().from(contentPosts).where(eq(contentPosts.requestKey, body.requestKey)).get();
+    if (!existing) {
+      return NextResponse.json({ ok: false, error: "conflict แต่หา row เดิมไม่เจอ" }, { status: 409 });
+    }
+    return NextResponse.json({ ok: existing.status !== "FAILED", id: existing.id, status: existing.status, caption: existing.caption ?? undefined, idempotent: true });
+  }
+
+  // เราเป็นคนสร้าง row นี้ → gen (sync, เรียก Gemini)
   const res = await generate(db, id);
   return NextResponse.json(
     { ok: res.ok, id, status: res.status, caption: res.caption, error: res.error },

--- a/app/content-creator/api/create/route.ts
+++ b/app/content-creator/api/create/route.ts
@@ -49,17 +49,20 @@ export async function POST(request: Request) {
   }
 
   const db = getContentDb();
-  const id = crypto.randomUUID();
   // atomic get-or-create: insert ผ่านเฉพาะถ้า requestKey ยังไม่มี (unique). retry/concurrent →
-  // changes 0 → ไม่ยิง Gemini ซ้ำ, คืน row เดิม [ตู๋ P1]. ใช้ parsed.data (canonical) ไม่ใช่ raw [ตู๋ P2]
+  // changes 0 → ไม่สร้าง row ใหม่ [ตู๋ P1]. ใช้ parsed.data (canonical) ไม่ใช่ raw [ตู๋ P2]
+  const id = crypto.randomUUID();
   const ins = db
     .insert(contentPosts)
     .values({ id, requestKey: body.requestKey, templateId: body.templateId, inputData: parsed.data as Record<string, unknown>, status: "PENDING" })
     .onConflictDoNothing({ target: contentPosts.requestKey })
     .run();
 
+  // genId = row ที่จะ gen: ของใหม่ (เราสร้าง) หรือของเดิม (resume)
+  let genId = id;
+
   if (ins.changes === 0) {
-    // requestKey นี้สร้างไปแล้ว (retry/reload/concurrent) — คืน row เดิม ไม่ gen ซ้ำ (ไม่จ่าย Gemini ซ้ำ)
+    // requestKey นี้มี row อยู่แล้ว (retry/reload/concurrent/crash-after-insert)
     const existing = db.select().from(contentPosts).where(eq(contentPosts.requestKey, body.requestKey)).get();
     if (!existing) {
       return NextResponse.json({ ok: false, error: "conflict แต่หา row เดิมไม่เจอ" }, { status: 409 });
@@ -69,32 +72,30 @@ export async function POST(request: Request) {
       existing.templateId === body.templateId &&
       JSON.stringify(existing.inputData) === JSON.stringify(parsed.data);
     if (!samePayload) {
-      return NextResponse.json(
-        { ok: false, error: "requestKey ซ้ำแต่ payload ต่าง (key reuse ผิด)" },
-        { status: 409 },
-      );
+      return NextResponse.json({ ok: false, error: "requestKey ซ้ำแต่ payload ต่าง (key reuse ผิด)" }, { status: 409 });
     }
-    // outcome ยังไม่ definitive (อีก request กำลัง gen) → 202 in-progress.
-    // client ต้อง "เก็บ key ไว้" (ไม่ clear) → retry ถัดไปยัง idempotent ไม่จ่าย Gemini ซ้ำ [ตู๋ P1]
-    const inProgress = existing.status === "PENDING" || existing.status === "GENERATING";
-    if (inProgress) {
-      return NextResponse.json(
-        { ok: false, inProgress: true, id: existing.id, status: existing.status, idempotent: true },
-        { status: 202 },
-      );
+    // terminal (definitive) → ตอบทันที ไม่ gen ซ้ำ
+    if (["GENERATED", "APPROVED", "PUBLISHING", "POSTED"].includes(existing.status)) {
+      return NextResponse.json({ ok: true, id: existing.id, status: existing.status, caption: existing.caption ?? undefined, idempotent: true }, { status: 200 });
     }
-    // terminal แล้ว (definitive) → 200 ; ok เฉพาะที่ผ่าน gen สำเร็จ (ไม่ใช่ FAILED/CANCELED)
-    const ok = existing.status !== "FAILED" && existing.status !== "CANCELED";
-    return NextResponse.json(
-      { ok, id: existing.id, status: existing.status, caption: existing.caption ?? undefined, idempotent: true },
-      { status: 200 },
-    );
+    if (existing.status === "FAILED" || existing.status === "CANCELED") {
+      return NextResponse.json({ ok: false, id: existing.id, status: existing.status, idempotent: true }, { status: 200 });
+    }
+    // PENDING/GENERATING → resume ผ่าน generate() (atomic claim):
+    //   PENDING (เช่น process เดิม crash หลัง insert ก่อน claim) → claim ได้ → gen ต่อ (resume) [ตู๋ P1]
+    //   GENERATING (อีก request กำลังทำ) → claim ไม่ได้ → SKIPPED → 202
+    genId = existing.id;
   }
 
-  // เราเป็นคนสร้าง row นี้ → gen (sync, เรียก Gemini)
-  const res = await generate(db, id);
+  // gen (เราสร้างใหม่ หรือ resume PENDING ที่ค้าง) — generate() claim atomic ภายใน
+  const res = await generate(db, genId);
+  if (res.status === "SKIPPED") {
+    // claim ไม่ได้ = อีก request กำลัง gen (GENERATING) — ยังไม่ definitive, client เก็บ key ไว้
+    const cur = db.select().from(contentPosts).where(eq(contentPosts.id, genId)).get();
+    return NextResponse.json({ ok: false, inProgress: true, id: genId, status: cur?.status ?? "GENERATING", idempotent: true }, { status: 202 });
+  }
   return NextResponse.json(
-    { ok: res.ok, id, status: res.status, caption: res.caption, error: res.error },
+    { ok: res.ok, id: genId, status: res.status, caption: res.caption, error: res.error },
     { status: res.ok ? 200 : 502 }, // 502 = gen ล้ม (upstream Gemini) ; row จะเป็น FAILED
   );
 }

--- a/app/content-creator/api/create/route.ts
+++ b/app/content-creator/api/create/route.ts
@@ -1,0 +1,58 @@
+/**
+ * POST /content-creator/api/create — สร้าง content + gen (sync) [S3.5a]
+ * body: { templateId, inputData }
+ *   1. validate template + input (clean 400 ก่อน — ไม่ทิ้ง row ขยะ)
+ *   2. insert PENDING
+ *   3. generate() sync (เรียก Gemini, ~10s) → GENERATED/FAILED
+ *   4. คืนผล (ฟีมเด้งกลับไปคิว approve)
+ * แทน dev script seed-and-gen ด้วยปุ่มจริง — pipeline ครบ input→approve ผ่าน UI
+ */
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getContentDb } from "@/content-creator/db/client";
+import { contentPosts } from "@/content-creator/db/schema";
+import { getTemplate } from "@/content-creator/templates";
+import { generate } from "@/content-creator/engine";
+import { isContentCreatorEnabled } from "@/content-creator/lib/enabled";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const BodySchema = z.object({
+  templateId: z.string().min(1),
+  inputData: z.record(z.string(), z.unknown()),
+});
+
+export async function POST(request: Request) {
+  if (!isContentCreatorEnabled()) return new NextResponse(null, { status: 404 });
+
+  let body: z.infer<typeof BodySchema>;
+  try {
+    body = BodySchema.parse(await request.json());
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid body (ต้องมี templateId + inputData)" }, { status: 400 });
+  }
+
+  // validate ก่อน insert → 400 สะอาด ไม่ทิ้ง PENDING row ขยะถ้า input ผิด
+  let template;
+  try {
+    template = getTemplate(body.templateId);
+  } catch {
+    return NextResponse.json({ ok: false, error: `unknown template: ${body.templateId}` }, { status: 400 });
+  }
+  const parsed = template.inputSchema.safeParse(body.inputData);
+  if (!parsed.success) {
+    return NextResponse.json({ ok: false, error: "input ไม่ตรง schema ของ template" }, { status: 400 });
+  }
+
+  const db = getContentDb();
+  const id = crypto.randomUUID();
+  db.insert(contentPosts).values({ id, templateId: body.templateId, inputData: body.inputData, status: "PENDING" }).run();
+
+  // sync gen (เรียก Gemini) — admin tool คนเดียว, รอผลทันที
+  const res = await generate(db, id);
+  return NextResponse.json(
+    { ok: res.ok, id, status: res.status, caption: res.caption, error: res.error },
+    { status: res.ok ? 200 : 502 }, // 502 = gen ล้ม (upstream Gemini) ; row จะเป็น FAILED
+  );
+}

--- a/app/content-creator/api/create/route.ts
+++ b/app/content-creator/api/create/route.ts
@@ -74,12 +74,12 @@ export async function POST(request: Request) {
     if (!samePayload) {
       return NextResponse.json({ ok: false, error: "requestKey ซ้ำแต่ payload ต่าง (key reuse ผิด)" }, { status: 409 });
     }
-    // terminal (definitive) → ตอบทันที ไม่ gen ซ้ำ
+    // terminal (definitive) → ตอบทันที ไม่ gen ซ้ำ. definitive:true → client clear key ได้ทุกกรณี [ตู๋ P1]
     if (["GENERATED", "APPROVED", "PUBLISHING", "POSTED"].includes(existing.status)) {
-      return NextResponse.json({ ok: true, id: existing.id, status: existing.status, caption: existing.caption ?? undefined, idempotent: true }, { status: 200 });
+      return NextResponse.json({ ok: true, definitive: true, id: existing.id, status: existing.status, caption: existing.caption ?? undefined, idempotent: true }, { status: 200 });
     }
     if (existing.status === "FAILED" || existing.status === "CANCELED") {
-      return NextResponse.json({ ok: false, id: existing.id, status: existing.status, idempotent: true }, { status: 200 });
+      return NextResponse.json({ ok: false, definitive: true, id: existing.id, status: existing.status, idempotent: true }, { status: 200 });
     }
     // PENDING/GENERATING → resume ผ่าน generate() (atomic claim):
     //   PENDING (เช่น process เดิม crash หลัง insert ก่อน claim) → claim ได้ → gen ต่อ (resume) [ตู๋ P1]
@@ -92,10 +92,11 @@ export async function POST(request: Request) {
   if (res.status === "SKIPPED") {
     // claim ไม่ได้ = อีก request กำลัง gen (GENERATING) — ยังไม่ definitive, client เก็บ key ไว้
     const cur = db.select().from(contentPosts).where(eq(contentPosts.id, genId)).get();
-    return NextResponse.json({ ok: false, inProgress: true, id: genId, status: cur?.status ?? "GENERATING", idempotent: true }, { status: 202 });
+    return NextResponse.json({ ok: false, definitive: false, inProgress: true, id: genId, status: cur?.status ?? "GENERATING", idempotent: true }, { status: 202 });
   }
+  // GENERATED / FAILED = definitive (ผ่าน gen แล้ว) → client clear key
   return NextResponse.json(
-    { ok: res.ok, id: genId, status: res.status, caption: res.caption, error: res.error },
+    { ok: res.ok, definitive: true, id: genId, status: res.status, caption: res.caption, error: res.error },
     { status: res.ok ? 200 : 502 }, // 502 = gen ล้ม (upstream Gemini) ; row จะเป็น FAILED
   );
 }

--- a/app/content-creator/api/preview/route.ts
+++ b/app/content-creator/api/preview/route.ts
@@ -37,9 +37,10 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: false, error: "input ไม่ตรง schema ของ template" }, { status: 400 });
   }
 
+  // ใช้ parsed.data (canonical — strip/defaults/transforms) ให้ preview ตรงกับที่ create จะ gen [ตู๋ P2]
   return NextResponse.json({
     ok: true,
-    captionPrompt: template.buildCaptionPrompt(body.inputData),
-    imagePrompt: template.buildImagePrompt(body.inputData),
+    captionPrompt: template.buildCaptionPrompt(parsed.data),
+    imagePrompt: template.buildImagePrompt(parsed.data),
   });
 }

--- a/app/content-creator/api/preview/route.ts
+++ b/app/content-creator/api/preview/route.ts
@@ -1,0 +1,45 @@
+/**
+ * POST /content-creator/api/preview — build prompt ที่จะส่ง Gemini โดย "ไม่ gen" (ฟรี, cheap) [S3.5a]
+ * body: { templateId, inputData } → { captionPrompt: {system, prompt}, imagePrompt }
+ * ให้ฟีมเห็น prompt จริงก่อนกด generate (ไม่เสีย cost Gemini)
+ */
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getTemplate } from "@/content-creator/templates";
+import { isContentCreatorEnabled } from "@/content-creator/lib/enabled";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const BodySchema = z.object({
+  templateId: z.string().min(1),
+  inputData: z.record(z.string(), z.unknown()),
+});
+
+export async function POST(request: Request) {
+  if (!isContentCreatorEnabled()) return new NextResponse(null, { status: 404 });
+
+  let body: z.infer<typeof BodySchema>;
+  try {
+    body = BodySchema.parse(await request.json());
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid body" }, { status: 400 });
+  }
+
+  let template;
+  try {
+    template = getTemplate(body.templateId);
+  } catch {
+    return NextResponse.json({ ok: false, error: `unknown template: ${body.templateId}` }, { status: 400 });
+  }
+  const parsed = template.inputSchema.safeParse(body.inputData);
+  if (!parsed.success) {
+    return NextResponse.json({ ok: false, error: "input ไม่ตรง schema ของ template" }, { status: 400 });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    captionPrompt: template.buildCaptionPrompt(body.inputData),
+    imagePrompt: template.buildImagePrompt(body.inputData),
+  });
+}

--- a/app/content-creator/api/templates/route.ts
+++ b/app/content-creator/api/templates/route.ts
@@ -1,0 +1,15 @@
+/**
+ * GET /content-creator/api/templates — list template ที่มี (สำหรับ dropdown หน้า /new) [S3.5a]
+ */
+import { NextResponse } from "next/server";
+import { getTemplate, listTemplateIds } from "@/content-creator/templates";
+import { isContentCreatorEnabled } from "@/content-creator/lib/enabled";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  if (!isContentCreatorEnabled()) return new NextResponse(null, { status: 404 });
+  const templates = listTemplateIds().map((id) => ({ id, name: getTemplate(id).name }));
+  return NextResponse.json({ templates });
+}

--- a/app/content-creator/new/page.tsx
+++ b/app/content-creator/new/page.tsx
@@ -9,6 +9,8 @@
  */
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+import { PreviewGuard } from "@/content-creator/lib/preview-guard";
+import { readPending, writePending, clearPending, resolveRequestKey } from "@/content-creator/lib/request-draft";
 
 type TemplateOpt = { id: string; name: string };
 
@@ -21,11 +23,10 @@ export default function NewContentPage() {
   const [preview, setPreview] = useState<{ caption: string; image: string } | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  // idempotency key ต่อ "การกรอกฟอร์ม 1 ครั้ง" — retry/double-click ส่ง key เดิม → server ไม่ gen ซ้ำ [ตู๋ P1]
-  const [requestKey] = useState(() => crypto.randomUUID());
-  // fingerprint ของ preview request ล่าสุด — กัน response เก่ากลับมาทีหลังทับของใหม่ [ตู๋ P2b]
-  const latestPreviewFp = useRef("");
+  // guard preview stale/out-of-order [ตู๋ P2] — sequence, invalidate ตอน input เปลี่ยน
+  const previewGuard = useRef(new PreviewGuard());
 
+  // โหลด template list + restore pending draft (เผื่อ reload ระหว่าง in-flight → คงค่า+ใช้ key เดิม) [ตู๋ P1]
   useEffect(() => {
     fetch("/content-creator/api/templates", { cache: "no-store" })
       .then((r) => (r.ok ? r.json() : { templates: [] }))
@@ -34,20 +35,26 @@ export default function NewContentPage() {
         if (d.templates?.[0]) setTemplateId(d.templates[0].id);
       })
       .catch(() => {});
+    const pending = readPending();
+    if (pending) {
+      setTemplateId(pending.payload.templateId);
+      setCard(pending.payload.card);
+      setMeaning(pending.payload.meaning);
+    }
   }, []);
 
   const inputData = { card, meaning };
   const ready = card.trim() && meaning.trim();
 
-  // preview ที่ค้างจะ stale ทันทีที่ input เปลี่ยน → เคลียร์ (กันแสดง prompt ไม่ตรงกับที่จะ gen) [ตู๋ P2b]
+  // input เปลี่ยน → preview เดิม stale: เคลียร์ + invalidate guard (สำคัญ: ไม่งั้น A กลับมาก่อนกด preview ใหม่จะผ่าน) [ตู๋ P2]
   useEffect(() => {
     setPreview(null);
+    previewGuard.current.invalidate();
   }, [templateId, card, meaning]);
 
   const doPreview = useCallback(async () => {
     setError(null);
-    const fp = JSON.stringify({ templateId, card, meaning });
-    latestPreviewFp.current = fp;
+    const token = previewGuard.current.begin();
     try {
       const res = await fetch("/content-creator/api/preview", {
         method: "POST",
@@ -55,12 +62,11 @@ export default function NewContentPage() {
         body: JSON.stringify({ templateId, inputData }),
       });
       const d = await res.json();
-      // response เก่ากลับมาทีหลัง / input เปลี่ยนไปแล้ว → ทิ้ง (กัน out-of-order แสดง prompt ผิด) [ตู๋ P2b]
-      if (latestPreviewFp.current !== fp) return;
+      if (!previewGuard.current.accepts(token)) return; // มีอะไรใหม่กว่า (input เปลี่ยน/preview ใหม่) → ทิ้ง
       if (!res.ok) throw new Error(d.error ?? "preview ไม่สำเร็จ");
       setPreview({ caption: `${d.captionPrompt.system}\n---\n${d.captionPrompt.prompt}`, image: d.imagePrompt });
     } catch (e) {
-      if (latestPreviewFp.current !== fp) return;
+      if (!previewGuard.current.accepts(token)) return;
       setError(e instanceof Error ? e.message : "preview ล้ม");
     }
   }, [templateId, card, meaning]);
@@ -68,16 +74,22 @@ export default function NewContentPage() {
   const submit = useCallback(async () => {
     setSubmitting(true);
     setError(null);
+    // idempotency key ที่ persist ข้าม reload: payload เดิม→key เดิม (retry idempotent), เปลี่ยน→key ใหม่ [ตู๋ P1]
+    const payload = { templateId, card, meaning };
+    const pending = resolveRequestKey(readPending(), payload, crypto.randomUUID());
+    writePending(pending);
     try {
       const res = await fetch("/content-creator/api/create", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ requestKey, templateId, inputData }),
+        body: JSON.stringify({ requestKey: pending.requestKey, templateId, inputData }),
       });
       const d = await res.json().catch(() => ({}));
       if (!res.ok || !d.ok) throw new Error(d.error ?? `สร้างไม่สำเร็จ (${res.status})`);
+      clearPending(); // สำเร็จแล้ว → submit ครั้งหน้า = attempt ใหม่
       router.push("/content-creator"); // เด้งกลับคิว approve — เห็นโพสต์ใหม่ (GENERATED)
     } catch (e) {
+      // ไม่ clear pending → reload/retry ใช้ key เดิม ไม่จ่าย Gemini ซ้ำ
       setError(e instanceof Error ? e.message : "สร้างล้ม");
       setSubmitting(false);
     }

--- a/app/content-creator/new/page.tsx
+++ b/app/content-creator/new/page.tsx
@@ -11,6 +11,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { PreviewGuard } from "@/content-creator/lib/preview-guard";
 import { readPending, writePending, clearPending, resolveRequestKey } from "@/content-creator/lib/request-draft";
+import { classifyCreateResponse, shouldClearPending } from "@/content-creator/lib/create-outcome";
 
 type TemplateOpt = { id: string; name: string };
 
@@ -86,28 +87,22 @@ export default function NewContentPage() {
         body: JSON.stringify({ requestKey: pending.requestKey, templateId, inputData }),
       });
       const d = await res.json().catch(() => ({}));
+      // server บอก definitive ตรง ๆ → client ไม่ต้องเดาจาก HTTP-code combo [ตู๋ P1]
+      const outcome = classifyCreateResponse(res.status, d);
+      if (shouldClearPending(outcome)) clearPending(); // terminal definitive (สำเร็จ/ล้มจริง) → submit หน้าถัดไป = attempt ใหม่
 
-      // 202 = ยังไม่ terminal (request อื่นกำลัง gen) → เก็บ key ไว้ → retry idempotent [ตู๋ P1]
-      if (res.status === 202 || d.inProgress) {
-        setError("คำขอนี้กำลังประมวลผลอยู่ — รอสักครู่แล้วรีเฟรชคิว/กดใหม่ได้ (ระบบจะไม่สร้าง/จ่ายซ้ำ)");
-        setSubmitting(false);
+      if (outcome === "success") {
+        router.push("/content-creator"); // เด้งกลับคิว approve — เห็นโพสต์ใหม่ (GENERATED)
         return;
       }
-      // สำเร็จ definitive → clear + เด้งกลับคิว
-      if (res.status === 200 && d.ok && d.status === "GENERATED") {
-        clearPending();
-        router.push("/content-creator");
-        return;
-      }
-      // ล้ม definitive (gen FAILED) → clear → retry = attempt ใหม่
-      if (res.status === 502 && d.status === "FAILED") {
-        clearPending();
+      if (outcome === "failed") {
         setError("gen ไม่สำเร็จ (Gemini) — ลองสร้างใหม่ได้");
-        setSubmitting(false);
-        return;
+      } else if (outcome === "in-progress") {
+        setError("คำขอนี้กำลังประมวลผลอยู่ — รอสักครู่แล้วรีเฟรชคิว/กดใหม่ได้ (ระบบจะไม่สร้าง/จ่ายซ้ำ)");
+      } else {
+        // unknown (400/409/500/ผลไม่ชัด) → ไม่ clear (เก็บ key ปลอดภัยกว่า, retry idempotent)
+        setError(d.error ?? `ไม่สำเร็จ (${res.status}) — ลองใหม่ได้ ระบบจะไม่จ่ายซ้ำ`);
       }
-      // อื่น ๆ (500/409/network/ผลไม่ชัด) → ไม่ clear (ไม่รู้ผลแน่ → เก็บ key ปลอดภัยกว่า, retry idempotent) [ตู๋ P1]
-      setError(d.error ?? `ไม่สำเร็จ (${res.status}) — ลองใหม่ได้ ระบบจะไม่จ่ายซ้ำ`);
       setSubmitting(false);
     } catch {
       // network/parse error — ไม่รู้ว่า server ทำสำเร็จไหม → เก็บ key ไว้ (ไม่ clear) retry idempotent

--- a/app/content-creator/new/page.tsx
+++ b/app/content-creator/new/page.tsx
@@ -28,14 +28,15 @@ export default function NewContentPage() {
 
   // โหลด template list + restore pending draft (เผื่อ reload ระหว่าง in-flight → คงค่า+ใช้ key เดิม) [ตู๋ P1]
   useEffect(() => {
+    const pending = readPending();
     fetch("/content-creator/api/templates", { cache: "no-store" })
       .then((r) => (r.ok ? r.json() : { templates: [] }))
       .then((d) => {
         setTemplates(d.templates ?? []);
-        if (d.templates?.[0]) setTemplateId(d.templates[0].id);
+        // อย่า overwrite templateId ที่ restore จาก pending (กัน async fetch ทับ draft) [ตู๋ P2]
+        if (!pending && d.templates?.[0]) setTemplateId(d.templates[0].id);
       })
       .catch(() => {});
-    const pending = readPending();
     if (pending) {
       setTemplateId(pending.payload.templateId);
       setCard(pending.payload.card);
@@ -85,11 +86,16 @@ export default function NewContentPage() {
         body: JSON.stringify({ requestKey: pending.requestKey, templateId, inputData }),
       });
       const d = await res.json().catch(() => ({}));
+      // 202 = ยังไม่ terminal (request อื่นกำลัง gen) → เก็บ key ไว้ (ไม่ clear) → retry idempotent [ตู๋ P1]
+      if (res.status === 202 || d.inProgress) {
+        setError("คำขอนี้กำลังประมวลผลอยู่ — รอสักครู่แล้วรีเฟรชคิว/กดใหม่ได้ (ระบบจะไม่สร้าง/จ่ายซ้ำ)");
+        setSubmitting(false);
+        return;
+      }
+      clearPending(); // terminal (สำเร็จ/ล้ม definitive) → submit ครั้งหน้า = attempt ใหม่
       if (!res.ok || !d.ok) throw new Error(d.error ?? `สร้างไม่สำเร็จ (${res.status})`);
-      clearPending(); // สำเร็จแล้ว → submit ครั้งหน้า = attempt ใหม่
       router.push("/content-creator"); // เด้งกลับคิว approve — เห็นโพสต์ใหม่ (GENERATED)
     } catch (e) {
-      // ไม่ clear pending → reload/retry ใช้ key เดิม ไม่จ่าย Gemini ซ้ำ
       setError(e instanceof Error ? e.message : "สร้างล้ม");
       setSubmitting(false);
     }

--- a/app/content-creator/new/page.tsx
+++ b/app/content-creator/new/page.tsx
@@ -86,17 +86,32 @@ export default function NewContentPage() {
         body: JSON.stringify({ requestKey: pending.requestKey, templateId, inputData }),
       });
       const d = await res.json().catch(() => ({}));
-      // 202 = ยังไม่ terminal (request อื่นกำลัง gen) → เก็บ key ไว้ (ไม่ clear) → retry idempotent [ตู๋ P1]
+
+      // 202 = ยังไม่ terminal (request อื่นกำลัง gen) → เก็บ key ไว้ → retry idempotent [ตู๋ P1]
       if (res.status === 202 || d.inProgress) {
         setError("คำขอนี้กำลังประมวลผลอยู่ — รอสักครู่แล้วรีเฟรชคิว/กดใหม่ได้ (ระบบจะไม่สร้าง/จ่ายซ้ำ)");
         setSubmitting(false);
         return;
       }
-      clearPending(); // terminal (สำเร็จ/ล้ม definitive) → submit ครั้งหน้า = attempt ใหม่
-      if (!res.ok || !d.ok) throw new Error(d.error ?? `สร้างไม่สำเร็จ (${res.status})`);
-      router.push("/content-creator"); // เด้งกลับคิว approve — เห็นโพสต์ใหม่ (GENERATED)
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "สร้างล้ม");
+      // สำเร็จ definitive → clear + เด้งกลับคิว
+      if (res.status === 200 && d.ok && d.status === "GENERATED") {
+        clearPending();
+        router.push("/content-creator");
+        return;
+      }
+      // ล้ม definitive (gen FAILED) → clear → retry = attempt ใหม่
+      if (res.status === 502 && d.status === "FAILED") {
+        clearPending();
+        setError("gen ไม่สำเร็จ (Gemini) — ลองสร้างใหม่ได้");
+        setSubmitting(false);
+        return;
+      }
+      // อื่น ๆ (500/409/network/ผลไม่ชัด) → ไม่ clear (ไม่รู้ผลแน่ → เก็บ key ปลอดภัยกว่า, retry idempotent) [ตู๋ P1]
+      setError(d.error ?? `ไม่สำเร็จ (${res.status}) — ลองใหม่ได้ ระบบจะไม่จ่ายซ้ำ`);
+      setSubmitting(false);
+    } catch {
+      // network/parse error — ไม่รู้ว่า server ทำสำเร็จไหม → เก็บ key ไว้ (ไม่ clear) retry idempotent
+      setError("เชื่อมต่อไม่ได้ — ลองใหม่ได้ ระบบจะไม่สร้าง/จ่ายซ้ำ");
       setSubmitting(false);
     }
   }, [templateId, card, meaning, router]);

--- a/app/content-creator/new/page.tsx
+++ b/app/content-creator/new/page.tsx
@@ -7,7 +7,7 @@
  * NOTE: ตอนนี้มี template เดียว (finance-daily) → form fields hardcode card+meaning.
  *       เมื่อมี template หลายแบบ ค่อยทำ field-render แบบ data-driven จาก schema
  */
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 
 type TemplateOpt = { id: string; name: string };
@@ -21,6 +21,10 @@ export default function NewContentPage() {
   const [preview, setPreview] = useState<{ caption: string; image: string } | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // idempotency key ต่อ "การกรอกฟอร์ม 1 ครั้ง" — retry/double-click ส่ง key เดิม → server ไม่ gen ซ้ำ [ตู๋ P1]
+  const [requestKey] = useState(() => crypto.randomUUID());
+  // fingerprint ของ preview request ล่าสุด — กัน response เก่ากลับมาทีหลังทับของใหม่ [ตู๋ P2b]
+  const latestPreviewFp = useRef("");
 
   useEffect(() => {
     fetch("/content-creator/api/templates", { cache: "no-store" })
@@ -35,8 +39,15 @@ export default function NewContentPage() {
   const inputData = { card, meaning };
   const ready = card.trim() && meaning.trim();
 
+  // preview ที่ค้างจะ stale ทันทีที่ input เปลี่ยน → เคลียร์ (กันแสดง prompt ไม่ตรงกับที่จะ gen) [ตู๋ P2b]
+  useEffect(() => {
+    setPreview(null);
+  }, [templateId, card, meaning]);
+
   const doPreview = useCallback(async () => {
     setError(null);
+    const fp = JSON.stringify({ templateId, card, meaning });
+    latestPreviewFp.current = fp;
     try {
       const res = await fetch("/content-creator/api/preview", {
         method: "POST",
@@ -44,9 +55,12 @@ export default function NewContentPage() {
         body: JSON.stringify({ templateId, inputData }),
       });
       const d = await res.json();
+      // response เก่ากลับมาทีหลัง / input เปลี่ยนไปแล้ว → ทิ้ง (กัน out-of-order แสดง prompt ผิด) [ตู๋ P2b]
+      if (latestPreviewFp.current !== fp) return;
       if (!res.ok) throw new Error(d.error ?? "preview ไม่สำเร็จ");
       setPreview({ caption: `${d.captionPrompt.system}\n---\n${d.captionPrompt.prompt}`, image: d.imagePrompt });
     } catch (e) {
+      if (latestPreviewFp.current !== fp) return;
       setError(e instanceof Error ? e.message : "preview ล้ม");
     }
   }, [templateId, card, meaning]);
@@ -58,7 +72,7 @@ export default function NewContentPage() {
       const res = await fetch("/content-creator/api/create", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ templateId, inputData }),
+        body: JSON.stringify({ requestKey, templateId, inputData }),
       });
       const d = await res.json().catch(() => ({}));
       if (!res.ok || !d.ok) throw new Error(d.error ?? `สร้างไม่สำเร็จ (${res.status})`);

--- a/app/content-creator/new/page.tsx
+++ b/app/content-creator/new/page.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+/**
+ * /content-creator/new — สร้าง content ใหม่ + gen (sync) [S3.5a]
+ * เลือก template → กรอก input → (พรีวิว prompt) → สร้าง+Generate → เด้งกลับคิว approve
+ *
+ * NOTE: ตอนนี้มี template เดียว (finance-daily) → form fields hardcode card+meaning.
+ *       เมื่อมี template หลายแบบ ค่อยทำ field-render แบบ data-driven จาก schema
+ */
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+type TemplateOpt = { id: string; name: string };
+
+export default function NewContentPage() {
+  const router = useRouter();
+  const [templates, setTemplates] = useState<TemplateOpt[]>([]);
+  const [templateId, setTemplateId] = useState("finance-daily");
+  const [card, setCard] = useState("");
+  const [meaning, setMeaning] = useState("");
+  const [preview, setPreview] = useState<{ caption: string; image: string } | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch("/content-creator/api/templates", { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : { templates: [] }))
+      .then((d) => {
+        setTemplates(d.templates ?? []);
+        if (d.templates?.[0]) setTemplateId(d.templates[0].id);
+      })
+      .catch(() => {});
+  }, []);
+
+  const inputData = { card, meaning };
+  const ready = card.trim() && meaning.trim();
+
+  const doPreview = useCallback(async () => {
+    setError(null);
+    try {
+      const res = await fetch("/content-creator/api/preview", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ templateId, inputData }),
+      });
+      const d = await res.json();
+      if (!res.ok) throw new Error(d.error ?? "preview ไม่สำเร็จ");
+      setPreview({ caption: `${d.captionPrompt.system}\n---\n${d.captionPrompt.prompt}`, image: d.imagePrompt });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "preview ล้ม");
+    }
+  }, [templateId, card, meaning]);
+
+  const submit = useCallback(async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/content-creator/api/create", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ templateId, inputData }),
+      });
+      const d = await res.json().catch(() => ({}));
+      if (!res.ok || !d.ok) throw new Error(d.error ?? `สร้างไม่สำเร็จ (${res.status})`);
+      router.push("/content-creator"); // เด้งกลับคิว approve — เห็นโพสต์ใหม่ (GENERATED)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "สร้างล้ม");
+      setSubmitting(false);
+    }
+  }, [templateId, card, meaning, router]);
+
+  return (
+    <main className="mx-auto max-w-2xl px-4 py-8">
+      <header className="mb-6 flex items-center gap-3">
+        <button onClick={() => router.push("/content-creator")} className="text-sm text-gray-500 hover:underline">
+          ← กลับ
+        </button>
+        <h1 className="text-2xl font-bold">สร้าง content ใหม่</h1>
+      </header>
+
+      {error && <div className="mb-4 rounded-lg bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>}
+
+      <div className="space-y-4">
+        <label className="block">
+          <span className="text-sm font-medium text-gray-700">Template</span>
+          <select
+            value={templateId}
+            onChange={(e) => setTemplateId(e.target.value)}
+            className="mt-1 w-full rounded-lg border px-3 py-2"
+          >
+            {templates.length === 0 && <option value="finance-daily">finance-daily</option>}
+            {templates.map((t) => (
+              <option key={t.id} value={t.id}>
+                {t.name} ({t.id})
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="block">
+          <span className="text-sm font-medium text-gray-700">ไพ่ (card)</span>
+          <input
+            value={card}
+            onChange={(e) => setCard(e.target.value)}
+            placeholder="เช่น The Sun"
+            className="mt-1 w-full rounded-lg border px-3 py-2"
+          />
+        </label>
+
+        <label className="block">
+          <span className="text-sm font-medium text-gray-700">ความหมายการเงินวันนี้ (meaning)</span>
+          <textarea
+            value={meaning}
+            onChange={(e) => setMeaning(e.target.value)}
+            rows={3}
+            placeholder="เช่น การเงินสดใส มีโอกาสรายได้ก้อนใหม่เข้ามา"
+            className="mt-1 w-full rounded-lg border px-3 py-2"
+          />
+        </label>
+
+        <div>
+          <button onClick={doPreview} disabled={!ready} className="text-sm text-blue-600 hover:underline disabled:text-gray-300">
+            ▸ พรีวิว prompt ที่จะส่ง Gemini
+          </button>
+          {preview && (
+            <div className="mt-2 space-y-2 rounded-lg bg-gray-50 p-3 text-xs">
+              <div>
+                <div className="font-semibold text-gray-500">caption prompt</div>
+                <pre className="whitespace-pre-wrap text-gray-700">{preview.caption}</pre>
+              </div>
+              <div>
+                <div className="font-semibold text-gray-500">image prompt</div>
+                <pre className="whitespace-pre-wrap text-gray-700">{preview.image}</pre>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            onClick={() => router.push("/content-creator")}
+            className="rounded-lg border px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+          >
+            ยกเลิก
+          </button>
+          <button
+            onClick={submit}
+            disabled={!ready || submitting}
+            className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+          >
+            {submitting ? "กำลัง gen… (~10s)" : "สร้าง + Generate"}
+          </button>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/content-creator/page.tsx
+++ b/app/content-creator/page.tsx
@@ -6,6 +6,7 @@
  * route ถูก guard ด้วย middleware (404 ถ้า CONTENT_CREATOR_ENABLED ไม่เปิด/บน production)
  */
 import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
 
 type Post = {
   id: string;
@@ -85,13 +86,21 @@ export default function ContentCreatorPage() {
           <h1 className="text-2xl font-bold">Content Creator</h1>
           <p className="text-sm text-gray-500">รอ approve {pending.length} โพสต์</p>
         </div>
-        <button
-          onClick={load}
-          className="rounded-lg border px-3 py-1.5 text-sm hover:bg-gray-50"
-          disabled={loading}
-        >
-          รีเฟรช
-        </button>
+        <div className="flex items-center gap-2">
+          <Link
+            href="/content-creator/new"
+            className="rounded-lg bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-700"
+          >
+            + สร้างใหม่
+          </Link>
+          <button
+            onClick={load}
+            className="rounded-lg border px-3 py-1.5 text-sm hover:bg-gray-50"
+            disabled={loading}
+          >
+            รีเฟรช
+          </button>
+        </div>
       </header>
 
       {error && (

--- a/content-creator/README.md
+++ b/content-creator/README.md
@@ -18,6 +18,15 @@ feature นี้ **รันบนเครื่อง local เท่าน�
   - `POST /content-creator/api/approve` — `{id, action: approve|cancel}` → `tryTransition` GENERATED→APPROVED/CANCELED (atomic, double-approve → 409)
   - `GET  /content-creator/api/media/[name]` — serve ภาพจาก `CONTENT_MEDIA_DIR` ; **path-safe** (`basename` + assert ใต้ media root + บังคับ `.png` — กัน traversal เหมือน S2 P2)
 
+## ➕ Seeding UI (S3.5a) — ทางเข้า
+
+หน้า `/content-creator/new` (client) → สร้าง content เอง (แทน dev script) → pipeline ครบ input→approve ผ่าน UI
+- กรอก template + input (finance-daily: card + meaning) → **สร้าง + Generate (sync, ~10s)** → เด้งกลับคิว approve
+- API:
+  - `GET  /content-creator/api/templates` — list template (dropdown)
+  - `POST /content-creator/api/preview` — build prompt ที่จะส่ง Gemini **โดยไม่ gen** (ฟรี — ดูก่อนกด)
+  - `POST /content-creator/api/create` — `{templateId, inputData}` → validate → insert PENDING → `generate()` **sync** → GENERATED (gen ล้ม → 502 + row FAILED)
+
 ## ▶️ วิธีรัน (runnable target)
 
 ```bash

--- a/content-creator/__tests__/create-outcome.test.ts
+++ b/content-creator/__tests__/create-outcome.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { classifyCreateResponse, shouldClearPending } from "../lib/create-outcome";
+
+describe("classifyCreateResponse + shouldClearPending — definitive lifecycle [ตู๋ P1]", () => {
+  it("200 GENERATED definitive → success → clear", () => {
+    const o = classifyCreateResponse(200, { definitive: true, ok: true });
+    expect(o).toBe("success");
+    expect(shouldClearPending(o)).toBe(true);
+  });
+
+  // scenario ที่ ตู๋ ชี้: 502 แรกหาย → retry ได้ 200 FAILED (definitive) → ต้อง clear (ไม่ค้าง stuck FAILED)
+  it("200 FAILED definitive (lost-response retry) → failed → clear → retry = attempt ใหม่", () => {
+    const o = classifyCreateResponse(200, { definitive: true, ok: false });
+    expect(o).toBe("failed");
+    expect(shouldClearPending(o)).toBe(true);
+  });
+
+  it("502 FAILED definitive → failed → clear", () => {
+    const o = classifyCreateResponse(502, { definitive: true, ok: false });
+    expect(o).toBe("failed");
+    expect(shouldClearPending(o)).toBe(true);
+  });
+
+  it("202 in-progress → ไม่ clear (เก็บ key)", () => {
+    const o = classifyCreateResponse(202, { inProgress: true });
+    expect(o).toBe("in-progress");
+    expect(shouldClearPending(o)).toBe(false);
+  });
+
+  it("500/409/ผลไม่ชัด (ไม่มี definitive) → unknown → ไม่ clear", () => {
+    expect(shouldClearPending(classifyCreateResponse(500, {}))).toBe(false);
+    expect(shouldClearPending(classifyCreateResponse(409, { ok: false }))).toBe(false);
+  });
+});

--- a/content-creator/__tests__/preview-guard.test.ts
+++ b/content-creator/__tests__/preview-guard.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { PreviewGuard } from "../lib/preview-guard";
+
+describe("PreviewGuard — stale/out-of-order preview [ตู๋ P2]", () => {
+  it("accept token ของ request ปัจจุบัน", () => {
+    const g = new PreviewGuard();
+    expect(g.accepts(g.begin())).toBe(true);
+  });
+
+  // scenario ที่ ตู๋ ชี้: A ค้าง → input เปลี่ยน (invalidate) → A กลับมา "ก่อน" กด preview ใหม่ → ต้องทิ้ง
+  it("invalidate (input เปลี่ยน) → request ที่ค้างถูกทิ้งแม้กลับมาก่อน request ใหม่", () => {
+    const g = new PreviewGuard();
+    const tA = g.begin();
+    g.invalidate();
+    expect(g.accepts(tA)).toBe(false);
+  });
+
+  it("out-of-order: A ก่อน B → A กลับมาทีหลังถูกทิ้ง, B ผ่าน", () => {
+    const g = new PreviewGuard();
+    const tA = g.begin();
+    const tB = g.begin();
+    expect(g.accepts(tA)).toBe(false);
+    expect(g.accepts(tB)).toBe(true);
+  });
+});

--- a/content-creator/__tests__/request-draft.test.ts
+++ b/content-creator/__tests__/request-draft.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { resolveRequestKey } from "../lib/request-draft";
+
+const payload = { templateId: "finance-daily", card: "The Sun", meaning: "การเงินสดใส" };
+
+describe("resolveRequestKey — idempotency key ข้าม reload [ตู๋ P1]", () => {
+  it("ไม่มี pending → ใช้ newKey + เก็บ payload", () => {
+    const r = resolveRequestKey(null, payload, "new-1");
+    expect(r.requestKey).toBe("new-1");
+    expect(r.payload).toEqual(payload);
+  });
+
+  it("pending payload เดิม (reload/retry) → reuse key เดิม → ไม่ gen ซ้ำ", () => {
+    const r = resolveRequestKey({ requestKey: "k-1", payload }, payload, "new-2");
+    expect(r.requestKey).toBe("k-1");
+  });
+
+  it("payload เปลี่ยน (ฟีมตั้งใจสร้างใหม่) → key ใหม่ (attempt ใหม่)", () => {
+    const r = resolveRequestKey({ requestKey: "k-1", payload }, { ...payload, card: "CHANGED" }, "new-3");
+    expect(r.requestKey).toBe("new-3");
+    expect(r.payload.card).toBe("CHANGED");
+  });
+});

--- a/content-creator/__tests__/s35a-routes.test.ts
+++ b/content-creator/__tests__/s35a-routes.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { eq } from "drizzle-orm";
+
+// mock Gemini (ไม่ยิง API จริงในเทสต์ — live พิสูจน์แล้ว browser truth)
+const { mockGenCaption, mockGenImage } = vi.hoisted(() => ({
+  mockGenCaption: vi.fn(),
+  mockGenImage: vi.fn(),
+}));
+vi.mock("../lib/gemini", () => ({ genCaption: mockGenCaption, genImage: mockGenImage }));
+
+// env ก่อนเรียก route (getContentDb/mediaDir อ่านตอน request)
+const TMP = mkdtempSync(join(tmpdir(), "cc-s35a-"));
+process.env.CONTENT_DB_PATH = join(TMP, "test.db");
+process.env.CONTENT_MEDIA_DIR = join(TMP, "media");
+mkdirSync(process.env.CONTENT_MEDIA_DIR, { recursive: true });
+
+import { getContentDb } from "../db/client";
+import { contentPosts } from "../db/schema";
+import { GET as templatesGET } from "@/app/content-creator/api/templates/route";
+import { POST as previewPOST } from "@/app/content-creator/api/preview/route";
+import { POST as createPOST } from "@/app/content-creator/api/create/route";
+
+const enable = () => (process.env.CONTENT_CREATOR_ENABLED = "true");
+const disable = () => delete process.env.CONTENT_CREATOR_ENABLED;
+const req = (body: unknown) =>
+  new Request("http://t", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
+const GOOD = { templateId: "finance-daily", inputData: { card: "The Sun", meaning: "การเงินสดใส" } };
+
+beforeEach(() => {
+  enable();
+  mockGenCaption.mockReset().mockResolvedValue("ปังมากแม่! #หมอมี่");
+  mockGenImage.mockReset().mockResolvedValue(new Uint8Array([1, 2, 3, 4]));
+});
+afterAll(() => rmSync(TMP, { recursive: true, force: true }));
+
+describe("[S3.5a] templates route", () => {
+  it("GET → list finance-daily (มี id+name)", async () => {
+    const res = await templatesGET();
+    expect(res.status).toBe(200);
+    const d = await res.json();
+    expect(d.templates.some((t: { id: string }) => t.id === "finance-daily")).toBe(true);
+  });
+  it("disabled → 404", async () => {
+    disable();
+    expect((await templatesGET()).status).toBe(404);
+  });
+});
+
+describe("[S3.5a] preview route — build prompt ไม่ gen (ไม่แตะ Gemini)", () => {
+  it("valid → คืน captionPrompt + imagePrompt", async () => {
+    const res = await previewPOST(req(GOOD));
+    expect(res.status).toBe(200);
+    const d = await res.json();
+    expect(d.captionPrompt.prompt).toContain("The Sun");
+    expect(d.imagePrompt).toContain("The Sun");
+    expect(mockGenCaption).not.toHaveBeenCalled(); // preview ไม่ gen
+  });
+  it("input ผิด schema → 400", async () => {
+    expect((await previewPOST(req({ templateId: "finance-daily", inputData: { card: "x" } }))).status).toBe(400);
+  });
+  it("unknown template → 400", async () => {
+    expect((await previewPOST(req({ templateId: "nope", inputData: {} }))).status).toBe(400);
+  });
+  it("disabled → 404", async () => {
+    disable();
+    expect((await previewPOST(req(GOOD))).status).toBe(404);
+  });
+});
+
+describe("[S3.5a] create route — insert PENDING + gen (sync)", () => {
+  it("valid → 200 ok + DB row GENERATED", async () => {
+    const res = await createPOST(req(GOOD));
+    expect(res.status).toBe(200);
+    const d = await res.json();
+    expect(d.ok).toBe(true);
+    expect(d.status).toBe("GENERATED");
+    const row = getContentDb().select().from(contentPosts).where(eq(contentPosts.id, d.id)).get();
+    expect(row!.status).toBe("GENERATED");
+    expect(row!.caption).toBeTruthy();
+    expect(row!.imagePath).toBeTruthy();
+  });
+
+  it("Gemini ล้ม → 502 + row FAILED (ไม่ค้าง PENDING/GENERATING)", async () => {
+    mockGenImage.mockRejectedValueOnce(new Error("gemini down"));
+    const res = await createPOST(req(GOOD));
+    expect(res.status).toBe(502);
+    const d = await res.json();
+    expect(d.ok).toBe(false);
+    expect(getContentDb().select().from(contentPosts).where(eq(contentPosts.id, d.id)).get()!.status).toBe("FAILED");
+  });
+
+  it("input ผิด schema → 400 (ไม่ insert row ขยะ)", async () => {
+    const before = getContentDb().select().from(contentPosts).all().length;
+    expect((await createPOST(req({ templateId: "finance-daily", inputData: { card: "x" } }))).status).toBe(400);
+    expect(getContentDb().select().from(contentPosts).all().length).toBe(before); // ไม่มี row เพิ่ม
+  });
+
+  it("unknown template → 400", async () => {
+    expect((await createPOST(req({ templateId: "nope", inputData: {} }))).status).toBe(400);
+  });
+
+  it("disabled → 404 (ไม่แตะ DB/Gemini)", async () => {
+    disable();
+    expect((await createPOST(req(GOOD))).status).toBe(404);
+    expect(mockGenCaption).not.toHaveBeenCalled();
+  });
+});

--- a/content-creator/__tests__/s35a-routes.test.ts
+++ b/content-creator/__tests__/s35a-routes.test.ts
@@ -149,4 +149,15 @@ describe("[S3.5a] create route — insert PENDING + gen (sync)", () => {
     expect(mockGenCaption).toHaveBeenCalledTimes(1);
     expect(getContentDb().select().from(contentPosts).where(eq(contentPosts.requestKey, key)).all()).toHaveLength(1);
   });
+
+  // [P1] same key ต่าง payload → 409 (กัน key reuse/collision คืน row ผิด)
+  it("requestKey เดิม + payload ต่าง → 409 (ไม่คืน row ที่ payload ไม่ตรง)", async () => {
+    const key = "idem-diff";
+    const first = await createPOST(req({ requestKey: key, ...GOOD }));
+    expect(first.status).toBe(200);
+    const res = await createPOST(
+      req({ requestKey: key, templateId: "finance-daily", inputData: { card: "DIFFERENT", meaning: "X" } }),
+    );
+    expect(res.status).toBe(409);
+  });
 });

--- a/content-creator/__tests__/s35a-routes.test.ts
+++ b/content-creator/__tests__/s35a-routes.test.ts
@@ -220,4 +220,22 @@ describe("[S3.5a] create route — insert PENDING + gen (sync)", () => {
     expect(rows[0].id).toBe(id);
     expect(rows[0].status).toBe("GENERATED");
   });
+
+  // [P1] lost-response: gen ล้ม (502) แล้ว response แรกหาย → retry key เดิม → 200 definitive FAILED
+  // (ไม่ใช่ 502 ซ้ำ) → client ต้อง clear ได้ (definitive:true) ไม่ค้าง stuck
+  it("duplicate row FAILED → 200 definitive:true (ไม่ stuck), client clear ได้", async () => {
+    mockGenImage.mockRejectedValueOnce(new Error("gemini down"));
+    const key = "lost-fail";
+    const first = await createPOST(req({ requestKey: key, ...GOOD }));
+    expect(first.status).toBe(502); // ครั้งแรก gen ล้ม
+    expect((await first.json()).definitive).toBe(true);
+
+    // retry key เดิม (จำลอง response แรกหาย) → duplicate FAILED → 200 definitive (ไม่ 502 ซ้ำ, ไม่ค้าง 202)
+    const retry = await createPOST(req({ requestKey: key, ...GOOD }));
+    expect(retry.status).toBe(200);
+    const d = await retry.json();
+    expect(d.definitive).toBe(true);
+    expect(d.ok).toBe(false);
+    expect(d.status).toBe("FAILED");
+  });
 });

--- a/content-creator/__tests__/s35a-routes.test.ts
+++ b/content-creator/__tests__/s35a-routes.test.ts
@@ -160,4 +160,43 @@ describe("[S3.5a] create route — insert PENDING + gen (sync)", () => {
     );
     expect(res.status).toBe(409);
   });
+
+  // [P1] lifecycle: duplicate ตอนยัง in-progress → 202 (ไม่ใช่ 200 ok), key valid จน terminal
+  it("duplicate ตอน A กำลัง gen → B ได้ 202 in-progress ; หลัง terminal → 200 GENERATED (1 row, gen ครั้งเดียว)", async () => {
+    mockGenCaption.mockClear();
+    const key = "lifecycle";
+    // A: ค้างที่ genCaption (deferred) — row จะอยู่ GENERATING
+    let releaseA!: () => void;
+    let aAtGen!: () => void;
+    const aReached = new Promise<void>((r) => (aAtGen = r));
+    mockGenCaption.mockImplementationOnce(
+      () =>
+        new Promise<string>((resolve) => {
+          aAtGen();
+          releaseA = () => resolve("ปังมากแม่");
+        }),
+    );
+    const aPromise = createPOST(req({ requestKey: key, ...GOOD })); // A: PENDING→GENERATING, ค้าง
+    await aReached;
+
+    // B: duplicate ตอน A ยัง GENERATING → ต้อง 202 (ไม่ใช่ 200 ok:true)
+    const bRes = await createPOST(req({ requestKey: key, ...GOOD }));
+    expect(bRes.status).toBe(202);
+    const bJson = await bRes.json();
+    expect(bJson.inProgress).toBe(true);
+    expect(bJson.ok).toBe(false); // ยังไม่ definitive
+
+    releaseA(); // A gen เสร็จ
+    expect((await aPromise).status).toBe(200);
+
+    // C: หลัง terminal → 200 ok GENERATED (definitive idempotent)
+    const cRes = await createPOST(req({ requestKey: key, ...GOOD }));
+    expect(cRes.status).toBe(200);
+    const cJson = await cRes.json();
+    expect(cJson.ok).toBe(true);
+    expect(cJson.status).toBe("GENERATED");
+
+    expect(getContentDb().select().from(contentPosts).where(eq(contentPosts.requestKey, key)).all()).toHaveLength(1);
+    expect(mockGenCaption).toHaveBeenCalledTimes(1); // gen ครั้งเดียวตลอด lifecycle
+  });
 });

--- a/content-creator/__tests__/s35a-routes.test.ts
+++ b/content-creator/__tests__/s35a-routes.test.ts
@@ -28,6 +28,9 @@ const disable = () => delete process.env.CONTENT_CREATOR_ENABLED;
 const req = (body: unknown) =>
   new Request("http://t", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
 const GOOD = { templateId: "finance-daily", inputData: { card: "The Sun", meaning: "การเงินสดใส" } };
+// create ต้องมี requestKey (idempotency) — fresh ต่อ call เว้นแต่ทดสอบ idempotent
+let keySeq = 0;
+const createBody = (over: Record<string, unknown> = {}) => ({ requestKey: `k-${++keySeq}`, ...GOOD, ...over });
 
 beforeEach(() => {
   enable();
@@ -72,7 +75,7 @@ describe("[S3.5a] preview route — build prompt ไม่ gen (ไม่แต�
 
 describe("[S3.5a] create route — insert PENDING + gen (sync)", () => {
   it("valid → 200 ok + DB row GENERATED", async () => {
-    const res = await createPOST(req(GOOD));
+    const res = await createPOST(req(createBody()));
     expect(res.status).toBe(200);
     const d = await res.json();
     expect(d.ok).toBe(true);
@@ -85,7 +88,7 @@ describe("[S3.5a] create route — insert PENDING + gen (sync)", () => {
 
   it("Gemini ล้ม → 502 + row FAILED (ไม่ค้าง PENDING/GENERATING)", async () => {
     mockGenImage.mockRejectedValueOnce(new Error("gemini down"));
-    const res = await createPOST(req(GOOD));
+    const res = await createPOST(req(createBody()));
     expect(res.status).toBe(502);
     const d = await res.json();
     expect(d.ok).toBe(false);
@@ -94,17 +97,56 @@ describe("[S3.5a] create route — insert PENDING + gen (sync)", () => {
 
   it("input ผิด schema → 400 (ไม่ insert row ขยะ)", async () => {
     const before = getContentDb().select().from(contentPosts).all().length;
-    expect((await createPOST(req({ templateId: "finance-daily", inputData: { card: "x" } }))).status).toBe(400);
+    expect((await createPOST(req(createBody({ inputData: { card: "x" } }))).then((r) => r.status))).toBe(400);
     expect(getContentDb().select().from(contentPosts).all().length).toBe(before); // ไม่มี row เพิ่ม
   });
 
   it("unknown template → 400", async () => {
-    expect((await createPOST(req({ templateId: "nope", inputData: {} }))).status).toBe(400);
+    expect((await createPOST(req(createBody({ templateId: "nope", inputData: {} })))).status).toBe(400);
+  });
+
+  it("ขาด requestKey → 400 (idempotency key บังคับ)", async () => {
+    expect((await createPOST(req(GOOD))).status).toBe(400); // GOOD ไม่มี requestKey
   });
 
   it("disabled → 404 (ไม่แตะ DB/Gemini)", async () => {
     disable();
-    expect((await createPOST(req(GOOD))).status).toBe(404);
+    expect((await createPOST(req(createBody()))).status).toBe(404);
     expect(mockGenCaption).not.toHaveBeenCalled();
+  });
+
+  // [P2a] ใช้ parsed.data (canonical) ไม่ใช่ raw → field แปลกปลอมถูก strip ไม่เข้า DB
+  it("strip field แปลกปลอม (canonical parsed.data ไม่ใช่ raw body)", async () => {
+    const res = await createPOST(req(createBody({ inputData: { card: "X", meaning: "Y", junk: "hax", evil: 1 } })));
+    expect(res.status).toBe(200);
+    const d = await res.json();
+    const row = getContentDb().select().from(contentPosts).where(eq(contentPosts.id, d.id)).get();
+    expect(row!.inputData).toEqual({ card: "X", meaning: "Y" }); // junk/evil ถูก strip
+  });
+
+  // [P1] idempotency — concurrent/retry ด้วย requestKey เดียว → 1 row + ยิง Gemini ครั้งเดียว (ไม่จ่ายซ้ำ)
+  it("requestKey เดียว ยิงพร้อมกัน 2 ครั้ง → 1 row, gen ครั้งเดียว", async () => {
+    mockGenCaption.mockClear();
+    const key = "idem-concurrent";
+    const [r1, r2] = await Promise.all([
+      createPOST(req({ requestKey: key, ...GOOD })),
+      createPOST(req({ requestKey: key, ...GOOD })),
+    ]);
+    const j1 = await r1.json();
+    const j2 = await r2.json();
+    expect(j1.id).toBe(j2.id); // row เดียวกัน
+    const rows = getContentDb().select().from(contentPosts).where(eq(contentPosts.requestKey, key)).all();
+    expect(rows).toHaveLength(1); // 1 row เท่านั้น
+    expect(mockGenCaption).toHaveBeenCalledTimes(1); // Gemini ยิงครั้งเดียว — ไม่จ่ายซ้ำ
+    expect([j1.idempotent, j2.idempotent]).toContain(true); // อันที่สองรู้ว่าเป็น idempotent hit
+  });
+
+  it("retry ด้วย requestKey เดิม (sequential) → ไม่ gen ซ้ำ", async () => {
+    mockGenCaption.mockClear();
+    const key = "idem-retry";
+    await createPOST(req({ requestKey: key, ...GOOD }));
+    await createPOST(req({ requestKey: key, ...GOOD })); // retry
+    expect(mockGenCaption).toHaveBeenCalledTimes(1);
+    expect(getContentDb().select().from(contentPosts).where(eq(contentPosts.requestKey, key)).all()).toHaveLength(1);
   });
 });

--- a/content-creator/__tests__/s35a-routes.test.ts
+++ b/content-creator/__tests__/s35a-routes.test.ts
@@ -199,4 +199,25 @@ describe("[S3.5a] create route — insert PENDING + gen (sync)", () => {
     expect(getContentDb().select().from(contentPosts).where(eq(contentPosts.requestKey, key)).all()).toHaveLength(1);
     expect(mockGenCaption).toHaveBeenCalledTimes(1); // gen ครั้งเดียวตลอด lifecycle
   });
+
+  // [P1] crash-after-insert-before-claim: row PENDING ค้าง (process เดิมตายก่อน claim) →
+  // retry key เดิม ต้อง "resume" gen row เดิม (ไม่ค้าง 202 ตลอด, ไม่สร้าง row ใหม่)
+  it("PENDING ค้างจาก crash → retry key เดิม resume gen → GENERATED (row เดิม ไม่สร้างใหม่)", async () => {
+    const key = "resume-stale-pending";
+    const id = crypto.randomUUID();
+    // จำลอง: insert PENDING สำเร็จ แล้ว process ตายก่อน claimForGenerate
+    getContentDb()
+      .insert(contentPosts)
+      .values({ id, requestKey: key, templateId: "finance-daily", inputData: { card: "X", meaning: "Y" }, status: "PENDING" })
+      .run();
+
+    const res = await createPOST(req({ requestKey: key, templateId: "finance-daily", inputData: { card: "X", meaning: "Y" } }));
+    expect(res.status).toBe(200);
+    expect((await res.json()).status).toBe("GENERATED"); // resume สำเร็จ ไม่ค้าง 202
+
+    const rows = getContentDb().select().from(contentPosts).where(eq(contentPosts.requestKey, key)).all();
+    expect(rows).toHaveLength(1); // resume row เดิม
+    expect(rows[0].id).toBe(id);
+    expect(rows[0].status).toBe("GENERATED");
+  });
 });

--- a/content-creator/db/migrations/0002_familiar_ulik.sql
+++ b/content-creator/db/migrations/0002_familiar_ulik.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `content_posts` ADD `request_key` text;--> statement-breakpoint
+CREATE UNIQUE INDEX `content_posts_request_key_unique` ON `content_posts` (`request_key`);

--- a/content-creator/db/migrations/meta/0002_snapshot.json
+++ b/content-creator/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,142 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b99d3e90-9f0c-45b2-9b2f-5a72e10b2886",
+  "prevId": "5e5c0789-9c11-48b4-b39f-052f41efcffe",
+  "tables": {
+    "content_posts": {
+      "name": "content_posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_key": {
+          "name": "request_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_data": {
+          "name": "input_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'PENDING'"
+        },
+        "generation_token": {
+          "name": "generation_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generating_at": {
+          "name": "generating_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_path": {
+          "name": "image_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_fbid": {
+          "name": "media_fbid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fb_post_id": {
+          "name": "fb_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publish_at": {
+          "name": "publish_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "content_posts_request_key_unique": {
+          "name": "content_posts_request_key_unique",
+          "columns": [
+            "request_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/content-creator/db/migrations/meta/_journal.json
+++ b/content-creator/db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1781340137727,
       "tag": "0001_brown_scalphunter",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1781369773806,
+      "tag": "0002_familiar_ulik",
+      "breakpoints": true
     }
   ]
 }

--- a/content-creator/db/schema.ts
+++ b/content-creator/db/schema.ts
@@ -24,6 +24,10 @@ export const contentPosts = sqliteTable("content_posts", {
   id: text("id")
     .primaryKey()
     .$defaultFn(() => crypto.randomUUID()),
+  /** idempotency key ต่อ "การ submit สร้าง 1 ครั้ง" (client ส่งมา) — unique กัน create ซ้ำ
+   *  จาก reload/timeout/double-click/retry → ไม่ยิง Gemini จ่ายซ้ำ [S3.5a ตู๋ P1].
+   *  nullable: row เก่า (S1-S3/seed) ไม่มี — sqlite unique อนุญาตหลาย NULL */
+  requestKey: text("request_key").unique(),
   /** → Template Registry (S2) — บอกว่า gen รูปแบบไหน */
   templateId: text("template_id").notNull(),
   /** fields ตาม template.inputSchema (card, meaning, …) */

--- a/content-creator/lib/create-outcome.ts
+++ b/content-creator/lib/create-outcome.ts
@@ -1,0 +1,25 @@
+/**
+ * classify create response → ตัดสิน clear key / redirect [S3.5a ตู๋ P1]
+ *
+ * client เคยเดา definitive จาก HTTP-code combo (เปราะ): clear เฉพาะ 200 GENERATED / 502 FAILED
+ * → duplicate FAILED ที่ route ตอบ "200 FAILED" หลุด → key ค้าง stuck FAILED ตลอด.
+ * แก้: server บอก `definitive` ตรง ๆ → client clear ทุก definitive (terminal จริง).
+ */
+export type CreateOutcome = "success" | "failed" | "in-progress" | "unknown";
+
+export type CreateResponseBody = {
+  definitive?: boolean;
+  ok?: boolean;
+  inProgress?: boolean;
+};
+
+export function classifyCreateResponse(httpStatus: number, body: CreateResponseBody): CreateOutcome {
+  if (httpStatus === 202 || body.inProgress) return "in-progress"; // ยังไม่ terminal — เก็บ key
+  if (body.definitive) return body.ok ? "success" : "failed"; // terminal จริง — clear key
+  return "unknown"; // 400/409/500/network/ผลไม่ชัด — เก็บ key (retry idempotent)
+}
+
+/** clear pending key เมื่อ outcome เป็น terminal definitive (สำเร็จ/ล้มจริง) เท่านั้น */
+export function shouldClearPending(outcome: CreateOutcome): boolean {
+  return outcome === "success" || outcome === "failed";
+}

--- a/content-creator/lib/preview-guard.ts
+++ b/content-creator/lib/preview-guard.ts
@@ -1,0 +1,25 @@
+/**
+ * PreviewGuard — กัน preview response stale/out-of-order แบบ deterministic [S3.5a ตู๋ P2]
+ *
+ * ปัญหา: ยิง preview A → เปลี่ยน input เป็น B → A response กลับมาทีหลัง → แสดง prompt A ตอน input B.
+ * แก้ด้วย sequence: ทุก begin() ออก token เพิ่มขึ้น ; invalidate() (เรียกตอน input เปลี่ยน) bump seq
+ * → ทำให้ in-flight ก่อนหน้า "ตกขบวน". accepts(token) จริงเฉพาะ token ล่าสุดเท่านั้น.
+ */
+export class PreviewGuard {
+  private seq = 0;
+
+  /** เริ่ม preview request ใหม่ → คืน token ของรอบนี้ */
+  begin(): number {
+    return ++this.seq;
+  }
+
+  /** input เปลี่ยน → in-flight request ทั้งหมดถือว่า stale (สำคัญ: ไม่งั้น A กลับมาก่อนกด preview ใหม่จะผ่าน guard) */
+  invalidate(): void {
+    this.seq++;
+  }
+
+  /** response ของ token นี้ ยัง relevant ไหม (ไม่มีอะไรใหม่กว่ามาทับ) */
+  accepts(token: number): boolean {
+    return token === this.seq;
+  }
+}

--- a/content-creator/lib/request-draft.ts
+++ b/content-creator/lib/request-draft.ts
@@ -1,0 +1,62 @@
+/**
+ * request-draft — idempotency key ที่ persist ข้าม reload [S3.5a ตู๋ P1]
+ *
+ * ปัญหา: requestKey ที่ gen ต่อ mount หายเมื่อ reload → response หาย/timeout แล้ว reload =
+ * key ใหม่ = สร้าง row + จ่าย Gemini ซ้ำ. แก้ด้วย persist {key, payload} (localStorage) ข้าม reload:
+ *   - payload เดิม (retry/reload) → ใช้ key เดิม → server idempotent ไม่ gen ซ้ำ
+ *   - payload เปลี่ยน (ฟีมตั้งใจสร้างใหม่) → key ใหม่ (attempt ใหม่)
+ *   - สำเร็จแล้ว → clear (submit ครั้งหน้า = attempt ใหม่)
+ *
+ * logic ตัดสิน key แยกเป็น pure function (resolveRequestKey) เพื่อ test deterministic.
+ */
+export type DraftPayload = { templateId: string; card: string; meaning: string };
+export type PendingRequest = { requestKey: string; payload: DraftPayload };
+
+const STORAGE_KEY = "cc-pending-create";
+
+function samePayload(a: DraftPayload, b: DraftPayload): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * ตัดสิน requestKey สำหรับ submit:
+ *  - ถ้า pending มีอยู่ + payload ตรง → reuse key เดิม (retry/reload idempotent)
+ *  - ไม่งั้น → ใช้ newKey (attempt ใหม่) + persist payload ใหม่
+ * pure — ไม่แตะ storage (caller เอา .pending ไป persist)
+ */
+export function resolveRequestKey(
+  pending: PendingRequest | null,
+  payload: DraftPayload,
+  newKey: string,
+): PendingRequest {
+  if (pending && samePayload(pending.payload, payload)) {
+    return pending; // retry เดิม — key เดิม
+  }
+  return { requestKey: newKey, payload };
+}
+
+// ---- localStorage wrappers (thin, guarded — client only) ----
+export function readPending(): PendingRequest | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as PendingRequest) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writePending(p: PendingRequest): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(p));
+  } catch {
+    /* storage เต็ม/ปิด — best-effort */
+  }
+}
+
+export function clearPending(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    /* ignore */
+  }
+}


### PR DESCRIPTION
## S3.5a — Seeding UI (ทางเข้าที่ pipeline ขาด)

ก่อนหน้านี้ S1-S3 สร้าง "ครึ่งหลัง" (gen→approve) แต่ **ไม่มีทางเข้า** — ไม่มีโค้ดสร้าง PENDING / trigger `generate()` (verify แล้ว: ไม่มี `insert(contentPosts)` นอก test). browser truth ต้องพึ่ง dev script. S3.5a เติมทางเข้าเป็น UI จริง

### สร้างอะไร
- **หน้า `/content-creator/new`** (client): เลือก template → กรอก input → **พรีวิว prompt** (ไม่ gen) → **สร้าง + Generate (sync ~10s)** → เด้งกลับคิว approve เห็นโพสต์ GENERATED
- **ปุ่ม `[+ สร้างใหม่]`** ในหน้า list (S3)
- **API** ใต้ `/content-creator/api/*` (middleware guard ครอบ + เช็ค `isContentCreatorEnabled()` ซ้ำ defense-in-depth):
  - `GET templates` — list (dropdown)
  - `POST preview` — build caption/image prompt **โดยไม่เรียก Gemini** (ฟรี — ดูก่อนกด)
  - `POST create` — validate template+input **ก่อน insert** (400 ไม่ทิ้ง row ขยะ) → insert PENDING → `generate()` **sync** → GENERATED ; gen ล้ม → **502 + row FAILED**

### Decision (จากคุยกับฟีม)
- **sync generate** (กดรอ ~10s) ก่อน — simple+robust สำหรับ admin tool คนเดียว ; async ทีหลังถ้าช้าไป
- **template เดียว** (finance-daily) → form fields hardcode `card`+`meaning` ; ขยายเป็น data-driven เมื่อมี template หลายแบบ
- settings/Brand Profile (style prompt + reference images นาโนบานาน่า) = **S3.5b/c** stage ถัดไป (ยังไม่อยู่ใน PR นี้)

### Verify
- `tsc` 0 · `vitest` **80 passed** (+11 S3.5a: templates/preview/create — enabled-gate, validate-400, gen-success→GENERATED, gen-fail→502+FAILED, no-junk-row)
- `CONTENT_CREATOR_ENABLED=true next build` → **compiled** (`/content-creator/new` + api/create/preview/templates ขึ้นครบ)
- **browser truth ผ่านจริง**: gen Gemini จริง 3 ภาพ ~1.5MB PNG + approve flow ทำงาน end-to-end บน localhost

### Finding (เก็บไว้ ไม่อยู่ใน PR นี้)
imagen เตือน `"size" not supported → use aspectRatio` ตอน gen — gen สำเร็จแต่ engine (S2) ส่ง param ที่ model ไม่รับ. ควร clean ใน engine แยก (ไม่ block)

🤖 ตอบโดย goo จาก [ฟีม] → goo-oracle