### PR TITLE
feat(content-creator): S4a — publish to Facebook (manual) + safe-path util

### DIFF
--- a/app/content-creator/api/media/[name]/route.ts
+++ b/app/content-creator/api/media/[name]/route.ts
@@ -7,36 +7,21 @@
  * ไม่ leak fs path ออกไป ; ปิดเมื่อ feature ไม่ enabled (middleware + เช็คซ้ำที่นี่)
  */
 import { NextResponse } from "next/server";
-import { existsSync, lstatSync, readFileSync, realpathSync } from "node:fs";
-import { basename, join, resolve, sep } from "node:path";
+import { readFileSync } from "node:fs";
+import { basename } from "node:path";
 import { isContentCreatorEnabled } from "@/content-creator/lib/enabled";
+import { safeResolveUnderRoot } from "@/content-creator/lib/safe-path";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 const mediaDir = () => process.env.CONTENT_MEDIA_DIR || "content-creator/media";
 
-/**
- * คืน absolute path ที่ปลอดภัยจริง หรือ null. กัน traversal 2 ชั้น [ตู๋ P1/P2]:
- *   1. lexical: basename ตัด ../, บังคับ .png
- *   2. symlink: reject ไฟล์ที่เป็น symlink + realpath ต้องยังอยู่ใต้ media root จริง
- *      (lexical resolve อย่างเดียวไม่พอ — symlink ใน media dir ชี้ออกนอกได้)
- */
+/** path-safe ผ่าน util เดียว [S4a refactor] + บังคับ .png + ตัด path component จาก URL param */
 function safeMediaPath(name: string): string | null {
   const safe = basename(name);
   if (!safe.endsWith(".png")) return null;
-  try {
-    const root = realpathSync(resolve(mediaDir())); // realpath root (กัน symlink ใน path เช่น /tmp→/private/tmp)
-    const candidate = join(root, safe);
-    if (!existsSync(candidate)) return null;
-    if (lstatSync(candidate).isSymbolicLink()) return null; // ไม่ follow symlink ออกนอก root
-    const real = realpathSync(candidate);
-    if (real !== candidate) return null; // มี symlink component กลางทาง
-    if (real !== root && !real.startsWith(root + sep)) return null; // belt: ยังอยู่ใต้ root
-    return real;
-  } catch {
-    return null; // media dir ไม่มี / stat ล้ม → ถือว่าไม่พบ
-  }
+  return safeResolveUnderRoot(mediaDir(), safe);
 }
 
 export async function GET(_request: Request, ctx: { params: Promise<{ name: string }> }) {

--- a/app/content-creator/api/publish/route.ts
+++ b/app/content-creator/api/publish/route.ts
@@ -58,44 +58,60 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: false, error: "claim ไม่ได้ (อาจถูกยิงอยู่/ไม่ใช่ APPROVED)" }, { status: 409 });
   }
 
-  try {
-    // upload media (idempotent: มี mediaFbid แล้ว reuse — ไม่ upload ซ้ำ)
-    let mediaFbid = row.mediaFbid;
-    if (!mediaFbid) {
-      // อ่าน image ผ่าน util เดียวกัน (path-safe) — root=media dir, basename(imagePath) [S4a]
+  // ===== UPLOAD phase — ยังไม่โพสต์ → ล้มได้ release→APPROVED ปลอดภัย (retry) =====
+  let mediaFbid = row.mediaFbid;
+  if (!mediaFbid) {
+    try {
+      // อ่าน image ผ่าน util เดียวกัน (path-safe) — root=media dir, basename(imagePath)
       const mediaDir = process.env.CONTENT_MEDIA_DIR || "content-creator/media";
       const real = safeResolveUnderRoot(mediaDir, basename(row.imagePath));
       if (!real) throw new Error(`image path ไม่ปลอดภัย/ไม่พบ: ${row.imagePath}`);
       const bytes = new Uint8Array(readFileSync(real));
       mediaFbid = await uploadUnpublishedPhoto({ pageId, token, bytes }); // published=false (ยังไม่โผล่)
-      db.update(contentPosts)
+      // [ตู๋ P2] conditional update ต้อง changes===1 — ยืนยัน ownership (เรายัง hold PUBLISHING)
+      const upd = db
+        .update(contentPosts)
         .set({ mediaFbid, updatedAt: new Date() })
         .where(and(eq(contentPosts.id, body.id), eq(contentPosts.status, "PUBLISHING")))
         .run();
+      if (upd.changes !== 1) throw new Error("ownership lost: mediaFbid update ไม่สำเร็จ (status ไม่ใช่ PUBLISHING)");
+    } catch (upErr) {
+      releaseClaim(db, body.id, "APPROVED"); // ยังไม่โพสต์ → retry ปลอดภัย
+      return NextResponse.json({ ok: false, error: upErr instanceof Error ? upErr.message : String(upErr) }, { status: 502 });
     }
-
-    // publish ขึ้น feed (โผล่เพจจริง) — lib maxRetries:0 กันโพสต์ซ้ำ
-    let postId: string;
-    try {
-      postId = await publishToFeed({ pageId, token, mediaFbid, message: row.caption });
-    } catch (pubErr) {
-      // AMBIGUOUS — publish ล้ม/กำกวม อาจโพสต์สำเร็จแล้ว: คง PUBLISHING ไม่ release (กันโพสต์ซ้ำ) [ตู๋ gate]
-      return NextResponse.json(
-        {
-          ok: false,
-          ambiguous: true,
-          status: "PUBLISHING",
-          error: `publish กำกวม — เช็คเพจว่าขึ้นไหม. ค้าง PUBLISHING ไว้ (ไม่ release กันโพสต์ซ้ำ) ต้อง reconcile มือ: ${pubErr instanceof Error ? pubErr.message : String(pubErr)}`,
-        },
-        { status: 502 },
-      );
-    }
-
-    markPosted(db, body.id, postId); // PUBLISHING→POSTED + fbPostId
-    return NextResponse.json({ ok: true, status: "POSTED", fbPostId: postId });
-  } catch (err) {
-    // ล้มก่อน publish (อ่าน image/upload) = ยังไม่โพสต์ → release→APPROVED ปลอดภัย (retry ได้)
-    releaseClaim(db, body.id, "APPROVED");
-    return NextResponse.json({ ok: false, error: err instanceof Error ? err.message : String(err) }, { status: 502 });
   }
+
+  // ===== POINT OF NO RETURN — หลังเริ่ม POST /feed "ห้าม release" (อาจโพสต์ขึ้นเพจแล้ว) [ตู๋ P1] =====
+  let postId: string;
+  try {
+    postId = await publishToFeed({ pageId, token, mediaFbid, message: row.caption }); // lib maxRetries:0 กันซ้ำ
+  } catch (pubErr) {
+    // AMBIGUOUS — อาจโพสต์สำเร็จแล้ว response หาย → คง PUBLISHING ไม่ release (กันโพสต์ซ้ำ)
+    return NextResponse.json(
+      {
+        ok: false,
+        ambiguous: true,
+        status: "PUBLISHING",
+        error: `publish กำกวม — เช็คเพจว่าขึ้นไหม. ค้าง PUBLISHING (ไม่ release กันโพสต์ซ้ำ) reconcile มือ: ${pubErr instanceof Error ? pubErr.message : String(pubErr)}`,
+      },
+      { status: 502 },
+    );
+  }
+
+  // publishToFeed สำเร็จ = โพสต์ขึ้นเพจแล้ว → persist ; ถ้า DB ล้ม "ห้าม release/retry" (จะโพสต์ซ้ำ) [ตู๋ P1]
+  try {
+    markPosted(db, body.id, postId); // PUBLISHING→POSTED + fbPostId
+  } catch (persistErr) {
+    return NextResponse.json(
+      {
+        ok: false,
+        ambiguous: true,
+        status: "PUBLISHING",
+        fbPostId: postId,
+        error: `โพสต์ขึ้นเพจแล้ว (fbPostId=${postId}) แต่บันทึก DB ล้ม — reconcile: set POSTED มือ. ห้าม retry publish (จะซ้ำ): ${persistErr instanceof Error ? persistErr.message : String(persistErr)}`,
+      },
+      { status: 502 },
+    );
+  }
+  return NextResponse.json({ ok: true, status: "POSTED", fbPostId: postId });
 }

--- a/app/content-creator/api/publish/route.ts
+++ b/app/content-creator/api/publish/route.ts
@@ -1,0 +1,101 @@
+/**
+ * POST /content-creator/api/publish — เผยแพร่โพสต์ขึ้น Facebook เพจจริง (manual) [S4a]
+ * body: { id } → claimForPublish (APPROVED→PUBLISHING) → upload media → publishToFeed → markPosted
+ *
+ * Carry-forward gates (ตู๋):
+ *  - publishToFeed ล้ม = AMBIGUOUS (อาจโพสต์แล้ว response หาย) → **ไม่ releaseClaim** คง PUBLISHING
+ *    ให้ reconcile มือ (กันโพสต์ซ้ำ) — ห้าม auto-release→APPROVED
+ *  - ล้มก่อน publish (อ่าน image/upload) = ยังไม่โพสต์ → release→APPROVED ปลอดภัย (retry ได้)
+ *  - mediaFbid reuse: upload สำเร็จแล้วเก็บไว้ → retry ไม่ upload ซ้ำ
+ */
+import { NextResponse } from "next/server";
+import { readFileSync } from "node:fs";
+import { basename } from "node:path";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+import { getContentDb } from "@/content-creator/db/client";
+import { contentPosts } from "@/content-creator/db/schema";
+import { claimForPublish, markPosted, releaseClaim } from "@/content-creator/db/transition";
+import { uploadUnpublishedPhoto, publishToFeed } from "@/content-creator/lib/facebook";
+import { safeResolveUnderRoot } from "@/content-creator/lib/safe-path";
+import { isContentCreatorEnabled } from "@/content-creator/lib/enabled";
+import { fbPageId, fbPageToken } from "@/content-creator/lib/config";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const BodySchema = z.object({ id: z.string().min(1) });
+
+export async function POST(request: Request) {
+  if (!isContentCreatorEnabled()) return new NextResponse(null, { status: 404 });
+
+  let body: z.infer<typeof BodySchema>;
+  try {
+    body = BodySchema.parse(await request.json());
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid body (ต้องมี id)" }, { status: 400 });
+  }
+
+  const pageId = fbPageId();
+  const token = fbPageToken();
+  if (!pageId || !token) {
+    return NextResponse.json({ ok: false, error: "FB env ไม่ครบ (CONTENT_FB_PAGE_ID/ACCESS_TOKEN)" }, { status: 500 });
+  }
+
+  const db = getContentDb();
+  // preflight ก่อน claim — เช็ค row พร้อมจริง (กัน claim แล้วติด)
+  const row = db.select().from(contentPosts).where(eq(contentPosts.id, body.id)).get();
+  if (!row) return NextResponse.json({ ok: false, error: "ไม่พบโพสต์" }, { status: 404 });
+  if (row.status !== "APPROVED") {
+    return NextResponse.json({ ok: false, error: `ต้องเป็น APPROVED ก่อน publish (ปัจจุบัน ${row.status})` }, { status: 409 });
+  }
+  if (!row.caption || !row.imagePath) {
+    return NextResponse.json({ ok: false, error: "โพสต์ไม่มี caption/image" }, { status: 409 });
+  }
+
+  // claim atomic (APPROVED→PUBLISHING) — worker เดียวยิง FB กัน concurrent post ซ้ำ
+  if (!claimForPublish(db, body.id)) {
+    return NextResponse.json({ ok: false, error: "claim ไม่ได้ (อาจถูกยิงอยู่/ไม่ใช่ APPROVED)" }, { status: 409 });
+  }
+
+  try {
+    // upload media (idempotent: มี mediaFbid แล้ว reuse — ไม่ upload ซ้ำ)
+    let mediaFbid = row.mediaFbid;
+    if (!mediaFbid) {
+      // อ่าน image ผ่าน util เดียวกัน (path-safe) — root=media dir, basename(imagePath) [S4a]
+      const mediaDir = process.env.CONTENT_MEDIA_DIR || "content-creator/media";
+      const real = safeResolveUnderRoot(mediaDir, basename(row.imagePath));
+      if (!real) throw new Error(`image path ไม่ปลอดภัย/ไม่พบ: ${row.imagePath}`);
+      const bytes = new Uint8Array(readFileSync(real));
+      mediaFbid = await uploadUnpublishedPhoto({ pageId, token, bytes }); // published=false (ยังไม่โผล่)
+      db.update(contentPosts)
+        .set({ mediaFbid, updatedAt: new Date() })
+        .where(and(eq(contentPosts.id, body.id), eq(contentPosts.status, "PUBLISHING")))
+        .run();
+    }
+
+    // publish ขึ้น feed (โผล่เพจจริง) — lib maxRetries:0 กันโพสต์ซ้ำ
+    let postId: string;
+    try {
+      postId = await publishToFeed({ pageId, token, mediaFbid, message: row.caption });
+    } catch (pubErr) {
+      // AMBIGUOUS — publish ล้ม/กำกวม อาจโพสต์สำเร็จแล้ว: คง PUBLISHING ไม่ release (กันโพสต์ซ้ำ) [ตู๋ gate]
+      return NextResponse.json(
+        {
+          ok: false,
+          ambiguous: true,
+          status: "PUBLISHING",
+          error: `publish กำกวม — เช็คเพจว่าขึ้นไหม. ค้าง PUBLISHING ไว้ (ไม่ release กันโพสต์ซ้ำ) ต้อง reconcile มือ: ${pubErr instanceof Error ? pubErr.message : String(pubErr)}`,
+        },
+        { status: 502 },
+      );
+    }
+
+    markPosted(db, body.id, postId); // PUBLISHING→POSTED + fbPostId
+    return NextResponse.json({ ok: true, status: "POSTED", fbPostId: postId });
+  } catch (err) {
+    // ล้มก่อน publish (อ่าน image/upload) = ยังไม่โพสต์ → release→APPROVED ปลอดภัย (retry ได้)
+    releaseClaim(db, body.id, "APPROVED");
+    return NextResponse.json({ ok: false, error: err instanceof Error ? err.message : String(err) }, { status: 502 });
+  }
+}

--- a/app/content-creator/page.tsx
+++ b/app/content-creator/page.tsx
@@ -76,8 +76,34 @@ export default function ContentCreatorPage() {
     [load],
   );
 
+  const publishPost = useCallback(
+    async (id: string) => {
+      if (!confirm("เผยแพร่ขึ้นเพจ Facebook จริง? (โพสต์จะขึ้นหน้าเพจ)")) return;
+      setBusyId(id);
+      setError(null);
+      try {
+        const res = await fetch("/content-creator/api/publish", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id }),
+        });
+        const d = await res.json().catch(() => ({}));
+        if (!res.ok || !d.ok) {
+          throw new Error(d.error ?? `publish ไม่สำเร็จ (${res.status})`);
+        }
+        await load();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "publish ล้ม");
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [load],
+  );
+
   const pending = posts.filter((p) => p.status === "GENERATED");
-  const others = posts.filter((p) => p.status !== "GENERATED");
+  const approved = posts.filter((p) => p.status === "APPROVED");
+  const others = posts.filter((p) => p.status !== "GENERATED" && p.status !== "APPROVED");
 
   return (
     <main className="mx-auto max-w-3xl px-4 py-8">
@@ -155,6 +181,38 @@ export default function ContentCreatorPage() {
           </article>
         ))}
       </section>
+
+      {approved.length > 0 && (
+        <section className="mt-8">
+          <h2 className="mb-2 text-sm font-semibold text-gray-500">รอเผยแพร่ (APPROVED {approved.length})</h2>
+          <div className="space-y-4">
+            {approved.map((p) => (
+              <article key={p.id} className="overflow-hidden rounded-xl border shadow-sm">
+                {p.imageUrl && (
+                  // eslint-disable-next-line @next/next/no-img-element -- admin tool, local fs media
+                  <img src={p.imageUrl} alt="approved" className="aspect-square w-full bg-gray-100 object-cover" />
+                )}
+                <div className="space-y-3 p-4">
+                  <div className="flex items-center gap-2">
+                    <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_STYLE[p.status] ?? ""}`}>
+                      {p.status}
+                    </span>
+                    <span className="text-xs text-gray-400">{p.templateId}</span>
+                  </div>
+                  <p className="whitespace-pre-wrap text-sm">{p.caption}</p>
+                  <button
+                    onClick={() => publishPost(p.id)}
+                    disabled={busyId === p.id}
+                    className="w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+                  >
+                    {busyId === p.id ? "กำลังเผยแพร่…" : "🚀 เผยแพร่ขึ้นเพจ (Publish)"}
+                  </button>
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+      )}
 
       {others.length > 0 && (
         <section className="mt-8">

--- a/content-creator/README.md
+++ b/content-creator/README.md
@@ -39,6 +39,19 @@ feature นี้ **รันบนเครื่อง local เท่าน�
 - brand asset: `content-creator/brand/mimi-reference.png` (committed) · ~$0.039/ภาพ (nano banana)
 - **NOTE**: PR นี้ ref = หมอมี่ fixed ; upload ref เอง = follow-up
 
+## 🚀 Publish to Facebook (S4a — manual)
+
+ปุ่ม **เผยแพร่ (Publish)** ในหน้า approve สำหรับโพสต์ `APPROVED` → ยิงขึ้นเพจจริง
+- `POST /content-creator/api/publish {id}` → `claimForPublish` (APPROVED→PUBLISHING atomic) →
+  `uploadUnpublishedPhoto` (published=false) → `publishToFeed` → `markPosted` (POSTED + fbPostId)
+- **path-safe image read** ผ่าน `lib/safe-path.ts` (`safeResolveUnderRoot`) — util เดียวที่ media route + brand ref + publish ใช้ร่วม (DRY, กัน symlink/traversal)
+- **Carry-forward gates (ตู๋)**:
+  - `publishToFeed` ล้ม = **ambiguous** (อาจโพสต์แล้ว) → คง `PUBLISHING` **ไม่ release** (กันโพสต์ซ้ำ) → reconcile มือ
+  - ล้มก่อน publish (อ่าน image/upload) → release→`APPROVED` (retry ได้, ยังไม่โพสต์)
+  - `mediaFbid` reuse → retry ไม่ upload ซ้ำ
+- env: `CONTENT_FB_PAGE_ID`, `CONTENT_FB_PAGE_ACCESS_TOKEN`
+- **NOTE**: manual trigger ใน S4a ; scheduler (pm2 + cron + schedule config จ/อ/พ) = **S4b** (ทีหลัง) ; stuck-PUBLISHING auto-reconcile = S4b
+
 ## ▶️ วิธีรัน (runnable target)
 
 ```bash

--- a/content-creator/__tests__/publish-route.test.ts
+++ b/content-creator/__tests__/publish-route.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { eq } from "drizzle-orm";
+
+// mock FB lib (ไม่ยิงเพจจริงในเทสต์ — live พิสูจน์ POC#2)
+const { mockUpload, mockPublish } = vi.hoisted(() => ({ mockUpload: vi.fn(), mockPublish: vi.fn() }));
+vi.mock("../lib/facebook", () => ({ uploadUnpublishedPhoto: mockUpload, publishToFeed: mockPublish }));
+
+const TMP = mkdtempSync(join(tmpdir(), "cc-pub-"));
+process.env.CONTENT_DB_PATH = join(TMP, "test.db");
+process.env.CONTENT_MEDIA_DIR = join(TMP, "media");
+process.env.CONTENT_FB_PAGE_ID = "page123";
+process.env.CONTENT_FB_PAGE_ACCESS_TOKEN = "tok123";
+mkdirSync(process.env.CONTENT_MEDIA_DIR, { recursive: true });
+writeFileSync(join(process.env.CONTENT_MEDIA_DIR, "img.png"), Buffer.from([1, 2, 3])); // image จริง
+
+import { getContentDb } from "../db/client";
+import { contentPosts } from "../db/schema";
+import { POST as publishPOST } from "@/app/content-creator/api/publish/route";
+
+const enable = () => (process.env.CONTENT_CREATOR_ENABLED = "true");
+const disable = () => delete process.env.CONTENT_CREATOR_ENABLED;
+const req = (body: unknown) =>
+  new Request("http://t", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
+
+let seq = 0;
+function seedApproved(over: Record<string, unknown> = {}) {
+  const id = `pub-${++seq}`;
+  getContentDb()
+    .insert(contentPosts)
+    .values({ id, templateId: "finance-daily", inputData: {}, status: "APPROVED", caption: "ปังมาก", imagePath: "content-creator/media/img.png", ...over })
+    .run();
+  return id;
+}
+const statusOf = (id: string) => getContentDb().select().from(contentPosts).where(eq(contentPosts.id, id)).get()!.status;
+
+beforeEach(() => {
+  enable();
+  mockUpload.mockReset().mockResolvedValue("media_fb_1");
+  mockPublish.mockReset().mockResolvedValue("post_fb_1");
+});
+afterAll(() => rmSync(TMP, { recursive: true, force: true }));
+
+describe("[S4a] publish route", () => {
+  it("disabled → 404 (ไม่แตะ FB)", async () => {
+    disable();
+    const id = seedApproved();
+    expect((await publishPOST(req({ id }))).status).toBe(404);
+    expect(mockPublish).not.toHaveBeenCalled();
+  });
+
+  it("APPROVED → 200 POSTED (upload→publish→markPosted + fbPostId)", async () => {
+    const id = seedApproved();
+    const res = await publishPOST(req({ id }));
+    expect(res.status).toBe(200);
+    const d = await res.json();
+    expect(d.status).toBe("POSTED");
+    expect(d.fbPostId).toBe("post_fb_1");
+    expect(statusOf(id)).toBe("POSTED");
+    expect(mockUpload).toHaveBeenCalledTimes(1);
+    expect(mockPublish).toHaveBeenCalledTimes(1);
+  });
+
+  it("ไม่ใช่ APPROVED (เช่น GENERATED) → 409 (ไม่ยิง FB)", async () => {
+    const id = seedApproved({ status: "GENERATED" });
+    expect((await publishPOST(req({ id }))).status).toBe(409);
+    expect(mockUpload).not.toHaveBeenCalled();
+  });
+
+  it("ghost id → 404", async () => {
+    expect((await publishPOST(req({ id: "nope" }))).status).toBe(404);
+  });
+
+  // [gate ตู๋] publishToFeed ล้ม = AMBIGUOUS → คง PUBLISHING (ไม่ release กันโพสต์ซ้ำ)
+  it("publish ล้ม → 502 ambiguous + ค้าง PUBLISHING (ไม่ release→APPROVED)", async () => {
+    mockPublish.mockRejectedValueOnce(new Error("FB 5xx response หาย"));
+    const id = seedApproved();
+    const res = await publishPOST(req({ id }));
+    expect(res.status).toBe(502);
+    const d = await res.json();
+    expect(d.ambiguous).toBe(true);
+    expect(statusOf(id)).toBe("PUBLISHING"); // ค้าง — ไม่ release (กันโพสต์ซ้ำ)
+  });
+
+  // upload ล้ม = ยังไม่โพสต์ → release→APPROVED ปลอดภัย (retry ได้)
+  it("upload ล้ม (ก่อน publish) → 502 + กลับ APPROVED (retry ได้, ไม่ยิง publish)", async () => {
+    mockUpload.mockRejectedValueOnce(new Error("upload fail"));
+    const id = seedApproved();
+    const res = await publishPOST(req({ id }));
+    expect(res.status).toBe(502);
+    expect(statusOf(id)).toBe("APPROVED"); // release ปลอดภัย
+    expect(mockPublish).not.toHaveBeenCalled();
+  });
+
+  // mediaFbid reuse — มีแล้วไม่ upload ซ้ำ
+  it("มี mediaFbid แล้ว → ข้าม upload, publish เลย (กัน upload ซ้ำ)", async () => {
+    const id = seedApproved({ mediaFbid: "already_uploaded" });
+    const res = await publishPOST(req({ id }));
+    expect(res.status).toBe(200);
+    expect(mockUpload).not.toHaveBeenCalled();
+    expect(mockPublish).toHaveBeenCalledTimes(1);
+    expect(mockPublish.mock.calls[0][0].mediaFbid).toBe("already_uploaded");
+  });
+
+  it("FB env ไม่ครบ → 500", async () => {
+    const saved = process.env.CONTENT_FB_PAGE_ID;
+    delete process.env.CONTENT_FB_PAGE_ID;
+    const id = seedApproved();
+    expect((await publishPOST(req({ id }))).status).toBe(500);
+    process.env.CONTENT_FB_PAGE_ID = saved;
+  });
+});

--- a/content-creator/__tests__/publish-route.test.ts
+++ b/content-creator/__tests__/publish-route.test.ts
@@ -7,6 +7,12 @@ import { eq } from "drizzle-orm";
 // mock FB lib (ไม่ยิงเพจจริงในเทสต์ — live พิสูจน์ POC#2)
 const { mockUpload, mockPublish } = vi.hoisted(() => ({ mockUpload: vi.fn(), mockPublish: vi.fn() }));
 vi.mock("../lib/facebook", () => ({ uploadUnpublishedPhoto: mockUpload, publishToFeed: mockPublish }));
+// partial-mock transition — default = ของจริง, override markPosted ได้ใน test P1 (จำลอง DB persist ล้ม)
+vi.mock("../db/transition", async (orig) => {
+  const actual = await orig<typeof import("../db/transition")>();
+  return { ...actual, markPosted: vi.fn(actual.markPosted) };
+});
+import * as transition from "../db/transition";
 
 const TMP = mkdtempSync(join(tmpdir(), "cc-pub-"));
 process.env.CONTENT_DB_PATH = join(TMP, "test.db");
@@ -61,6 +67,22 @@ describe("[S4a] publish route", () => {
     expect(statusOf(id)).toBe("POSTED");
     expect(mockUpload).toHaveBeenCalledTimes(1);
     expect(mockPublish).toHaveBeenCalledTimes(1);
+    // [P2] mediaFbid persist สำเร็จ (conditional update changes===1 ยืนยัน ownership)
+    expect(getContentDb().select().from(contentPosts).where(eq(contentPosts.id, id)).get()!.mediaFbid).toBe("media_fb_1");
+  });
+
+  // [ตู๋ P1] publishToFeed สำเร็จ (โพสต์ขึ้นแล้ว) แต่ markPosted (DB) ล้ม → ห้าม release (ไม่งั้น retry โพสต์ซ้ำ)
+  it("publish สำเร็จ แต่ persist DB ล้ม → 502 ambiguous + คง PUBLISHING (ไม่ release→APPROVED)", async () => {
+    const id = seedApproved();
+    (transition.markPosted as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+      throw new Error("DB persist fail หลัง publish");
+    });
+    const res = await publishPOST(req({ id }));
+    expect(res.status).toBe(502);
+    const d = await res.json();
+    expect(d.ambiguous).toBe(true);
+    expect(d.fbPostId).toBe("post_fb_1"); // โพสต์ขึ้นเพจแล้ว
+    expect(statusOf(id)).toBe("PUBLISHING"); // คง PUBLISHING — ไม่ release (กัน retry โพสต์ซ้ำ)
   });
 
   it("ไม่ใช่ APPROVED (เช่น GENERATED) → 409 (ไม่ยิง FB)", async () => {

--- a/content-creator/__tests__/safe-path.test.ts
+++ b/content-creator/__tests__/safe-path.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, afterAll } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { safeResolveUnderRoot } from "../lib/safe-path";
+
+const TMP = mkdtempSync(join(tmpdir(), "cc-safepath-"));
+const root = join(TMP, "root");
+mkdirSync(root, { recursive: true });
+writeFileSync(join(root, "ok.png"), Buffer.from([1]));
+writeFileSync(join(TMP, "outside.png"), Buffer.from([2])); // นอก root
+symlinkSync(join(TMP, "outside.png"), join(root, "link.png")); // symlink ใน root ชี้ออกนอก
+
+afterAll(() => rmSync(TMP, { recursive: true, force: true }));
+
+describe("safeResolveUnderRoot [S4a] — DRY path-safety util", () => {
+  it("ไฟล์ใน root → คืน real path", () => {
+    expect(safeResolveUnderRoot(root, "ok.png")).toBeTruthy();
+  });
+  it("../ escape → null", () => {
+    expect(safeResolveUnderRoot(root, "../outside.png")).toBeNull();
+  });
+  it("symlink ชี้ออกนอก root → null (ไม่ follow)", () => {
+    expect(safeResolveUnderRoot(root, "link.png")).toBeNull();
+  });
+  it("ไฟล์ไม่มีจริง → null", () => {
+    expect(safeResolveUnderRoot(root, "nope.png")).toBeNull();
+  });
+});

--- a/content-creator/engine.ts
+++ b/content-creator/engine.ts
@@ -6,7 +6,7 @@
  *  - gen ล้ม → releaseGenerate(FAILED) (recovery)
  *  - ภาพเก็บเป็น file (CONTENT_MEDIA_DIR) + imagePath ใน DB (รูปไม่ยัดใน sqlite)
  */
-import { existsSync, lstatSync, mkdirSync, readFileSync, realpathSync, writeFileSync, rmSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync, rmSync } from "node:fs";
 import { join, resolve, sep } from "node:path";
 import { eq } from "drizzle-orm";
 import type { ContentDb } from "./db/client";
@@ -14,6 +14,7 @@ import { contentPosts } from "./db/schema";
 import { getBrandProfile } from "./db/brand";
 import { claimForGenerate, markGenerated, releaseGenerate } from "./db/transition";
 import { genCaption, genImage, genImageWithRef } from "./lib/gemini";
+import { safeResolveUnderRoot } from "./lib/safe-path";
 import { getTemplate } from "./templates";
 
 const mediaDir = () => process.env.CONTENT_MEDIA_DIR || "content-creator/media";
@@ -33,19 +34,12 @@ const refDirective = (theme: string) =>
 
 /**
  * อ่าน brand reference image แบบ path-safe (admin-set ใน DB — เชื่อไม่ได้) [ตู๋ P1].
- * lexical resolve อย่างเดียวไม่พอ — symlink ใน path ชี้ออกนอก repo ได้ → local bytes หลุดไป Gemini.
- * ใช้ realpath + reject symlink (แนวเดียวกับ media route S3).
+ * ใช้ safeResolveUnderRoot (util เดียวกับ media route + publish) — กัน traversal + symlink escape.
  */
 function loadBrandRef(refImagePath: string): Uint8Array {
   if (!refImagePath.endsWith(".png")) throw new Error(`brand ref ต้องเป็น .png: ${refImagePath}`);
-  const root = realpathSync(resolve(process.cwd())); // realpath root (กัน symlink ใน path เช่น /tmp→/private/tmp)
-  const candidate = resolve(root, refImagePath);
-  if (!existsSync(candidate)) throw new Error(`brand ref ไม่พบ: ${refImagePath}`);
-  if (lstatSync(candidate).isSymbolicLink()) throw new Error(`brand ref เป็น symlink (ไม่อนุญาต): ${refImagePath}`);
-  const real = realpathSync(candidate);
-  if (real !== candidate || !real.startsWith(root + sep)) {
-    throw new Error(`brand ref path ไม่ปลอดภัย (หลุดนอก repo): ${refImagePath}`);
-  }
+  const real = safeResolveUnderRoot(process.cwd(), refImagePath);
+  if (!real) throw new Error(`brand ref ไม่พบ/ไม่ปลอดภัย: ${refImagePath}`);
   return new Uint8Array(readFileSync(real));
 }
 

--- a/content-creator/lib/config.ts
+++ b/content-creator/lib/config.ts
@@ -20,3 +20,7 @@ export const REF_IMAGE_MODEL = process.env.CONTENT_REF_IMAGE_MODEL || "gemini-2.
 
 /** caption temperature เริ่มต้น (คุม tone — override ได้ต่อ call) */
 export const DEFAULT_CAPTION_TEMPERATURE = 0.8;
+
+/** Facebook page id + token (อ่านตอน request — publish route ใช้) [S4a]. คืน "" ถ้าไม่ตั้ง → caller เช็ค */
+export const fbPageId = () => process.env.CONTENT_FB_PAGE_ID || "";
+export const fbPageToken = () => process.env.CONTENT_FB_PAGE_ACCESS_TOKEN || "";

--- a/content-creator/lib/safe-path.ts
+++ b/content-creator/lib/safe-path.ts
@@ -1,0 +1,28 @@
+/**
+ * safe-path — path traversal + symlink escape guard ที่เดียว (DRY) [S4a]
+ *
+ * รวม logic ที่ verify แล้วจาก media route (S3 P2) + loadBrandRef (S3.5c ตู๋ P1) ไว้ที่เดียว
+ * เพื่อกัน "เขียน lexical check ซ้ำแล้วลืม symlten" (เคยพลาดรอบ 2). file access ใหม่ใน content-creator
+ * (เช่น publish อ่าน image) เรียกอันนี้ — ไม่เขียน path-safety เองอีก.
+ */
+import { existsSync, lstatSync, realpathSync } from "node:fs";
+import { resolve, sep } from "node:path";
+
+/**
+ * คืน real absolute path ที่อยู่ "ใต้ rootDir จริง" เท่านั้น (กัน ../ traversal + symlink ชี้ออกนอก).
+ * @returns real path ถ้าปลอดภัย+มีจริง ; null ถ้าไม่ปลอดภัย/ไม่พบ (caller ตัดสินเอง 404 หรือ throw)
+ */
+export function safeResolveUnderRoot(rootDir: string, relPath: string): string | null {
+  try {
+    const root = realpathSync(resolve(rootDir)); // realpath root (กัน symlink ใน path เช่น /tmp→/private/tmp)
+    const candidate = resolve(root, relPath);
+    if (!existsSync(candidate)) return null;
+    if (lstatSync(candidate).isSymbolicLink()) return null; // ไม่ follow symlink (final)
+    const real = realpathSync(candidate);
+    if (real !== candidate) return null; // มี symlink component กลางทาง
+    if (real !== root && !real.startsWith(root + sep)) return null; // หลุดนอก root
+    return real;
+  } catch {
+    return null; // stat ล้ม / root ไม่มี → ถือว่าไม่พบ
+  }
+}


### PR DESCRIPTION
## S4a — Publish to Facebook (manual) + safe-path util

publish-on-approve แบบ **manual trigger** (ปุ่ม Publish) — ให้ฟีม "ลองจัดสักโพส" จริง ก่อนเอา scheduler มาครอบ (S4b). ตามที่ตกลง: **S4a manual ก่อน → S4b scheduler ทีหลัง** (อย่า automate side-effect ถาวรก่อน verify path จริง — บทเรียนฟีนิกซ์)

### สร้างอะไร
- **`lib/safe-path.ts` (`safeResolveUnderRoot`)** — path-safety util เดียว (realpath + reject symlink + assert under-root). **refactor `media route` + `engine loadBrandRef` → ใช้ util ร่วม** (DRY)
  - แก้ root cause: lexical path-bug เคยซ้ำ 2 รอบ (media S3, brand ref S3.5c) เพราะเขียนแยก → ตอนนี้ที่เดียว กันพลาดรอบ 3
- **`POST /content-creator/api/publish {id}`**: `claimForPublish` (APPROVED→PUBLISHING atomic) → `uploadUnpublishedPhoto` (published=false) → `publishToFeed` → `markPosted` (POSTED + fbPostId) ; image read ผ่าน util
- **UI**: ปุ่ม "🚀 เผยแพร่ขึ้นเพจ" สำหรับโพสต์ `APPROVED` (+ confirm dialog เพราะโผล่เพจจริง)

### Carry-forward gates (ตู๋ — verified ใน test)
- **`publishToFeed` ล้ม = ambiguous** (อาจโพสต์แล้ว response หาย) → **คง `PUBLISHING` ไม่ release** (กันโพสต์ซ้ำ) → reconcile มือ. *ไม่* auto-release→APPROVED
- ล้มก่อน publish (อ่าน image/upload) = ยังไม่โพสต์ → release→`APPROVED` (retry ปลอดภัย)
- `mediaFbid` reuse → retry ไม่ upload ซ้ำ

### จุดที่อยากให้ตู๋ตรวจ
1. **ambiguous gate** — publish ล้ม → ค้าง PUBLISHING (test ยืนยัน status ไม่ release) ; ถูกต้องไหม
2. **safe-path util refactor** — 2 call site เดิม (media/brand) เปลี่ยนเป็น util — behavior เท่าเดิม (regression tests เดิมยังเขียว)
3. **stuck-PUBLISHING** หลัง ambiguous → ตอนนี้ reconcile มือ (auto-reconcile = S4b) — ยอมรับได้ไหมสำหรับ S4a

### Verify
- `tsc` 0 · `vitest` **122 passed** (+safe-path util 4, +publish 8: disabled/POSTED/non-approved/ambiguous-keep-PUBLISHING/upload-fail-release/mediaFbid-reuse/env)
- `next build` compiled
- ⚠️ ยังไม่ได้ยิงเพจจริง (จะ browser truth กับฟีม — `published=false`/ลองจริงตามที่ฟีมเลือก)

### NOTE
scheduler (pm2 + cron + schedule config จ/อ/พ + 3 เวลา) + stuck-PUBLISHING auto-reconcile = **S4b**

🤖 ตอบโดย goo จาก [ฟีม] → goo-oracle