### PR TITLE
feat(content-creator): S6a — image strategy (ai|composition) renderer architecture

### DIFF
--- a/app/content-creator/api/preview/route.ts
+++ b/app/content-creator/api/preview/route.ts
@@ -38,9 +38,11 @@ export async function POST(request: Request) {
   }
 
   // ใช้ parsed.data (canonical — strip/defaults/transforms) ให้ preview ตรงกับที่ create จะ gen [ตู๋ P2]
+  // strategy-aware: ai → imagePrompt ; composition → ไม่มี prompt (render เอง) [ตู๋ S6a]
   return NextResponse.json({
     ok: true,
     captionPrompt: template.buildCaptionPrompt(parsed.data),
-    imagePrompt: template.buildImagePrompt(parsed.data),
+    imageStrategy: template.imageStrategy,
+    imagePrompt: template.imageStrategy === "ai" ? template.buildImagePrompt?.(parsed.data) : undefined,
   });
 }

--- a/app/content-creator/api/preview/route.ts
+++ b/app/content-creator/api/preview/route.ts
@@ -43,6 +43,6 @@ export async function POST(request: Request) {
     ok: true,
     captionPrompt: template.buildCaptionPrompt(parsed.data),
     imageStrategy: template.imageStrategy,
-    imagePrompt: template.imageStrategy === "ai" ? template.buildImagePrompt?.(parsed.data) : undefined,
+    imagePrompt: template.imageStrategy === "ai" ? template.buildImagePrompt(parsed.data) : undefined,
   });
 }

--- a/content-creator/__tests__/engine.test.ts
+++ b/content-creator/__tests__/engine.test.ts
@@ -16,6 +16,22 @@ vi.mock("../lib/gemini", () => ({
   genImageWithRef: mockGenImageWithRef,
 }));
 
+// inject composition template "comp-test" เข้า registry (finance ยังเป็นของจริง) [S6a]
+const { mockRenderImage } = vi.hoisted(() => ({ mockRenderImage: vi.fn() }));
+vi.mock("../templates", async (orig) => {
+  const actual = await orig<typeof import("../templates")>();
+  const { z } = await import("zod");
+  const comp = {
+    id: "comp-test",
+    name: "comp",
+    inputSchema: z.object({ x: z.string() }),
+    buildCaptionPrompt: () => ({ system: "s", prompt: "p" }),
+    imageStrategy: "composition" as const,
+    renderImage: mockRenderImage,
+  };
+  return { ...actual, getTemplate: (id: string) => (id === "comp-test" ? comp : actual.getTemplate(id)) };
+});
+
 import { createContentDb } from "../db/client";
 import { contentPosts } from "../db/schema";
 import { updateBrandProfile } from "../db/brand";
@@ -38,6 +54,7 @@ beforeEach(() => {
   mockGenCaption.mockReset().mockResolvedValue(`ปังมากแม่! #หมอมี่ ทักเลย ${CTA_URL}`);
   mockGenImage.mockReset().mockResolvedValue(new Uint8Array([1, 2, 3, 4]));
   mockGenImageWithRef.mockReset().mockResolvedValue(new Uint8Array([5, 6, 7, 8]));
+  mockRenderImage.mockReset().mockResolvedValue(new Uint8Array([10, 11, 12]));
 });
 afterEach(() => {
   for (const d of tmpDirs.splice(0)) rmSync(d, { recursive: true, force: true });
@@ -163,6 +180,35 @@ describe("generate engine [S2]", () => {
     const mediaRoot = resolve(join(dir, "media"));
     expect(resolve(res.imagePath!).startsWith(mediaRoot + sep)).toBe(true); // อยู่ใต้ media root
     expect(existsSync(res.imagePath!)).toBe(true);
+  });
+});
+
+describe("engine image strategy [S6a] — ai vs composition dispatch", () => {
+  it("composition → renderImage ; ไม่เรียก Gemini image + ไม่อ่าน brand ref (แม้ brand มี ref)", async () => {
+    const { db } = setup({ ref: "content-creator/brand/mimi-reference.png" }); // brand มี ref แต่ composition ต้องไม่แตะ
+    db.insert(contentPosts).values({ id: "c1", templateId: "comp-test", inputData: { x: "hi" }, status: "PENDING" }).run();
+    const res = await generate(db, "c1");
+    expect(res.status).toBe("GENERATED");
+    expect(mockRenderImage).toHaveBeenCalledTimes(1);
+    expect(mockGenImage).not.toHaveBeenCalled();
+    expect(mockGenImageWithRef).not.toHaveBeenCalled(); // composition ไม่แตะ Gemini image แม้ brand มี ref
+  });
+
+  it("composition render ล้ม → FAILED ก่อน paid caption (fail-fast, ไม่จ่าย genCaption)", async () => {
+    const { db } = setup();
+    mockRenderImage.mockRejectedValueOnce(new Error("font/bg หาย"));
+    db.insert(contentPosts).values({ id: "c2", templateId: "comp-test", inputData: { x: "hi" }, status: "PENDING" }).run();
+    const res = await generate(db, "c2");
+    expect(res.status).toBe("FAILED");
+    expect(mockGenCaption).not.toHaveBeenCalled(); // render ก่อน caption → ไม่จ่าย
+  });
+
+  it("finance ยังเดิน ai path (regression) — genImage ไม่ใช่ renderImage", async () => {
+    const { db } = setup({ ref: null });
+    insertPending(db, "f1", { card: "X", meaning: "Y" });
+    await generate(db, "f1");
+    expect(mockGenImage).toHaveBeenCalledTimes(1);
+    expect(mockRenderImage).not.toHaveBeenCalled();
   });
 });
 

--- a/content-creator/__tests__/preview-strategy.test.ts
+++ b/content-creator/__tests__/preview-strategy.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// inject composition template เข้า registry (finance ยังของจริง) — preview ต้อง strategy-aware [ตู๋ P2]
+vi.mock("@/content-creator/templates", async (orig) => {
+  const actual = await orig<typeof import("@/content-creator/templates")>();
+  const { z } = await import("zod");
+  const comp = {
+    id: "comp-prev",
+    name: "comp",
+    inputSchema: z.object({ x: z.string() }),
+    buildCaptionPrompt: () => ({ system: "", prompt: "" }),
+    imageStrategy: "composition" as const,
+    renderImage: async () => new Uint8Array(),
+  };
+  return { ...actual, getTemplate: (id: string) => (id === "comp-prev" ? comp : actual.getTemplate(id)) };
+});
+
+import { POST as previewPOST } from "@/app/content-creator/api/preview/route";
+
+const req = (body: unknown) =>
+  new Request("http://t", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
+
+beforeEach(() => (process.env.CONTENT_CREATOR_ENABLED = "true"));
+
+describe("[ตู๋ P2] preview strategy-aware", () => {
+  it("ai (finance) → imageStrategy=ai + มี imagePrompt", async () => {
+    const res = await previewPOST(req({ templateId: "finance-daily", inputData: { card: "The Sun", meaning: "ดี" } }));
+    expect(res.status).toBe(200);
+    const d = await res.json();
+    expect(d.imageStrategy).toBe("ai");
+    expect(d.imagePrompt).toBeTruthy();
+  });
+
+  it("composition → imageStrategy=composition + ไม่มี imagePrompt (ไม่สมมติ prompt)", async () => {
+    const res = await previewPOST(req({ templateId: "comp-prev", inputData: { x: "hi" } }));
+    expect(res.status).toBe(200);
+    const d = await res.json();
+    expect(d.imageStrategy).toBe("composition");
+    expect(d.imagePrompt).toBeUndefined();
+    expect(d.captionPrompt).toBeTruthy();
+  });
+});

--- a/content-creator/engine.ts
+++ b/content-creator/engine.ts
@@ -102,37 +102,42 @@ export async function generate(db: ContentDb, id: string): Promise<GenerateResul
     if (!row) throw new Error(`content post not found: ${id}`);
 
     const template = getTemplate(row.templateId);
-    template.inputSchema.parse(row.inputData); // validate (throw → FAILED)
+    const parsed = template.inputSchema.parse(row.inputData); // validate + canonical (throw → FAILED)
 
     // brand profile (หมอมี่) steer ทุก gen ให้ theme เดียวกัน [S3.5b/c]
     const brand = getBrandProfile(db);
 
-    // CTA mandatory [S5/ตู๋]: ทุกโพสต์ต้องมี CTA link → ต้องตั้ง ctaUrl ก่อน gen.
-    // เช็ค "ก่อน paid Gemini call" — ไม่ตั้ง = FAILED ทันที (ไม่จ่ายฟรี)
+    // CTA mandatory [S5/ตู๋]: ทุกโพสต์ต้องมี CTA link (ทั้ง ai + composition) → เช็คก่อน paid caption
     if (!brand.ctaUrl.trim()) {
       throw new Error("CTA บังคับ: ต้องตั้ง CTA link (ctaUrl) ใน Settings ก่อน gen (ทุกโพสต์ต้องมี CTA)");
     }
 
-    // preflight: ถ้าใช้ ref → อ่าน+validate ref "ก่อน" Gemini call ใด ๆ
-    // (ref ไม่พบ/ไม่ปลอดภัย → FAILED ทันที ไม่จ่าย genCaption ฟรี) [ตู๋ P1]
-    const refImage = brand.refImagePath ? loadBrandRef(brand.refImagePath) : null;
-
-    // caption [S5]: ฟันธงสั้น (≤maxChars) + CTA ชวนใช้ระบบ + ไม่ซ้ำของเก่า
     const recentCaptions = getRecentCaptions(db, id);
-    const caption = await generateCaption(template.buildCaptionPrompt(row.inputData), brand, recentCaptions);
+    let caption: string;
+    let bytes: Uint8Array;
 
-    const basePrompt = template.buildImagePrompt(row.inputData);
-    const themeWithStyle = brand.stylePrompt ? `${basePrompt}\n\nสไตล์ภาพ: ${brand.stylePrompt}` : basePrompt;
-    // มี ref → nano banana: refDirective นำ (ยึดตัวละคร) + theme เป็นฉาก/props รอง + ห้าม text
-    // ไม่มี ref → imagen text-to-image (theme เป็น prompt หลักเลย)
-    const bytes = refImage
-      ? await genImageWithRef({
-          prompt: `${refDirective(themeWithStyle)}\n\n${NO_TEXT_DIRECTIVE}`,
-          refImage,
-          model: brand.imageModel ?? undefined,
-        })
-      : await genImage({ prompt: themeWithStyle });
-    attemptPath = persistImage(id, token, bytes);
+    if (template.imageStrategy === "composition") {
+      // composition [S6a]: template render ภาพเอง — **ไม่แตะ brand ref / Gemini image**.
+      // render "ก่อน" paid caption (local + fail-fast: font/bg หาย → ไม่จ่าย caption ฟรี) [ตู๋ ordering]
+      if (!template.renderImage) throw new Error(`template ${template.id} เป็น composition แต่ไม่มี renderImage`);
+      bytes = await template.renderImage(parsed, { brand });
+      caption = await generateCaption(template.buildCaptionPrompt(parsed), brand, recentCaptions);
+    } else {
+      // ai [finance]: preflight ref ก่อน paid → caption → Gemini image (เดิม)
+      if (!template.buildImagePrompt) throw new Error(`template ${template.id} เป็น ai แต่ไม่มี buildImagePrompt`);
+      const refImage = brand.refImagePath ? loadBrandRef(brand.refImagePath) : null;
+      caption = await generateCaption(template.buildCaptionPrompt(parsed), brand, recentCaptions);
+      const basePrompt = template.buildImagePrompt(parsed);
+      const themeWithStyle = brand.stylePrompt ? `${basePrompt}\n\nสไตล์ภาพ: ${brand.stylePrompt}` : basePrompt;
+      bytes = refImage
+        ? await genImageWithRef({
+            prompt: `${refDirective(themeWithStyle)}\n\n${NO_TEXT_DIRECTIVE}`,
+            refImage,
+            model: brand.imageModel ?? undefined,
+          })
+        : await genImage({ prompt: themeWithStyle });
+    }
+    attemptPath = persistImage(id, token, bytes); // fence เดิม (token-scoped) ครอบทั้ง 2 path
 
     // commit DB เฉพาะถ้า token ยังตรง. ไม่ตรง = โดน reclaim → ลบ artifact ของ attempt เรา (ไม่แตะ winner)
     if (!markGenerated(db, id, token, caption, attemptPath)) {

--- a/content-creator/engine.ts
+++ b/content-creator/engine.ts
@@ -117,14 +117,12 @@ export async function generate(db: ContentDb, id: string): Promise<GenerateResul
     let bytes: Uint8Array;
 
     if (template.imageStrategy === "composition") {
-      // composition [S6a]: template render ภาพเอง — **ไม่แตะ brand ref / Gemini image**.
+      // composition [S6a]: template render ภาพเอง (narrow → renderImage บังคับมี) — **ไม่แตะ brand ref / Gemini image**.
       // render "ก่อน" paid caption (local + fail-fast: font/bg หาย → ไม่จ่าย caption ฟรี) [ตู๋ ordering]
-      if (!template.renderImage) throw new Error(`template ${template.id} เป็น composition แต่ไม่มี renderImage`);
       bytes = await template.renderImage(parsed, { brand });
       caption = await generateCaption(template.buildCaptionPrompt(parsed), brand, recentCaptions);
     } else {
-      // ai [finance]: preflight ref ก่อน paid → caption → Gemini image (เดิม)
-      if (!template.buildImagePrompt) throw new Error(`template ${template.id} เป็น ai แต่ไม่มี buildImagePrompt`);
+      // ai [finance]: narrow → buildImagePrompt บังคับมี ; preflight ref ก่อน paid → caption → Gemini image (เดิม)
       const refImage = brand.refImagePath ? loadBrandRef(brand.refImagePath) : null;
       caption = await generateCaption(template.buildCaptionPrompt(parsed), brand, recentCaptions);
       const basePrompt = template.buildImagePrompt(parsed);

--- a/content-creator/templates/finance-daily.ts
+++ b/content-creator/templates/finance-daily.ts
@@ -15,6 +15,7 @@ export const financeDaily: ContentTemplate = {
   id: "finance-daily",
   name: "ดวงการเงินรายวัน (หมอมี่)",
   inputSchema: financeDailySchema,
+  imageStrategy: "ai", // gen ภาพด้วย Gemini (nano banana + brand ref) — path เดิม
   buildCaptionPrompt(data) {
     const d = financeDailySchema.parse(data);
     return {

--- a/content-creator/templates/types.ts
+++ b/content-creator/templates/types.ts
@@ -22,7 +22,7 @@ export interface RenderContext {
  */
 export type ImageStrategy = "ai" | "composition";
 
-export interface ContentTemplate {
+interface BaseTemplate {
   /** templateId — ผูกกับ ContentPost.templateId */
   id: string;
   /** ชื่อให้คนอ่าน (UI) */
@@ -31,10 +31,23 @@ export interface ContentTemplate {
   inputSchema: z.ZodTypeAny;
   /** สร้าง prompt สำหรับ caption (gemini genCaption) จาก input */
   buildCaptionPrompt(data: unknown): CaptionPrompt;
-  /** วิธีสร้างภาพ — engine เลือก path ตามนี้ */
-  imageStrategy: ImageStrategy;
-  /** [ai] สร้าง prompt สำหรับภาพ (Gemini gen) */
-  buildImagePrompt?(data: unknown): string;
-  /** [composition] render ภาพเอง → Uint8Array (parsed canonical + ctx ; ไม่เรียก Gemini/brand ref) */
-  renderImage?(data: unknown, ctx: RenderContext): Promise<Uint8Array>;
 }
+
+/** template ที่ gen ภาพด้วย Gemini — buildImagePrompt บังคับ */
+export interface AiTemplate extends BaseTemplate {
+  imageStrategy: "ai";
+  buildImagePrompt(data: unknown): string;
+}
+
+/** template ที่ render ภาพเอง (composition) — renderImage บังคับ ; ไม่เรียก Gemini/brand ref */
+export interface CompositionTemplate extends BaseTemplate {
+  imageStrategy: "composition";
+  renderImage(data: unknown, ctx: RenderContext): Promise<Uint8Array>;
+}
+
+/**
+ * discriminated union — แต่ละ strategy บังคับ method ของตัวเอง [ตู๋ P1]:
+ *   ai → ต้องมี buildImagePrompt ; composition → ต้องมี renderImage
+ * (เลิก optional ทั้งคู่ → ไม่มี impossible combo หลุดถึง runtime + engine narrow ได้ ไม่ต้อง guard/?.)
+ */
+export type ContentTemplate = AiTemplate | CompositionTemplate;

--- a/content-creator/templates/types.ts
+++ b/content-creator/templates/types.ts
@@ -3,11 +3,24 @@
  * เพิ่ม "แบบ" ใหม่ = เพิ่มไฟล์ template + ลงทะเบียนใน index.ts (ไม่แตะ engine) [open/closed]
  */
 import type { z } from "zod";
+import type { BrandProfile } from "../db/schema";
 
 export interface CaptionPrompt {
   system: string;
   prompt: string;
 }
+
+/** context (minimal explicit) ที่ engine ส่งให้ renderImage — ขยายเมื่อ template ต้องใช้จริง [S6a] */
+export interface RenderContext {
+  brand: BrandProfile;
+}
+
+/**
+ * imageStrategy:
+ *  - "ai": gen ภาพด้วย Gemini (buildImagePrompt) — ใช้ brand ref/nano banana [finance]
+ *  - "composition": template render ภาพเอง (renderImage) — **ไม่แตะ Gemini image / brand ref** [daily-7]
+ */
+export type ImageStrategy = "ai" | "composition";
 
 export interface ContentTemplate {
   /** templateId — ผูกกับ ContentPost.templateId */
@@ -18,6 +31,10 @@ export interface ContentTemplate {
   inputSchema: z.ZodTypeAny;
   /** สร้าง prompt สำหรับ caption (gemini genCaption) จาก input */
   buildCaptionPrompt(data: unknown): CaptionPrompt;
-  /** สร้าง prompt สำหรับภาพ (gemini genImage) จาก input */
-  buildImagePrompt(data: unknown): string;
+  /** วิธีสร้างภาพ — engine เลือก path ตามนี้ */
+  imageStrategy: ImageStrategy;
+  /** [ai] สร้าง prompt สำหรับภาพ (Gemini gen) */
+  buildImagePrompt?(data: unknown): string;
+  /** [composition] render ภาพเอง → Uint8Array (parsed canonical + ctx ; ไม่เรียก Gemini/brand ref) */
+  renderImage?(data: unknown, ctx: RenderContext): Promise<Uint8Array>;
 }


### PR DESCRIPTION
## S6a — Renderer architecture (เตรียมทาง daily-7)

ก่อน build daily-7 (composition ผ่าน next/og) — วาง architecture ให้ engine รองรับ **2 image strategy** ตาม design ที่ align กับตู๋ (conditional LGTM + guardrails)

### สร้างอะไร
- **template interface**: `imageStrategy: "ai" | "composition"` + `renderImage?(parsed, ctx)` (composition) + `buildImagePrompt?` (ai) + `RenderContext` (minimal: brand)
- **engine dispatch**:
  - `composition` → `template.renderImage(parsed, {brand})` **ก่อน paid caption** (local render = fail-fast: font/bg หาย → ไม่จ่าย caption) · **ไม่แตะ brand ref / Gemini image** (ตู๋ acceptance)
  - `ai` → ref preflight → caption → `genImage`/`genImageWithRef` (**path เดิม ไม่เปลี่ยน**)
  - render bytes ทั้ง 2 path ผ่าน `persistImage` token-scoped + `markGenerated` fence เดิม
  - CTA mandatory (ctaUrl) ทั้ง 2 path
- **finance**: `imageStrategy: "ai"` (path เดิม)
- **preview route**: strategy-aware (composition ไม่คืน imagePrompt) [ตู๋]

### ตอบ S6a acceptance (ตู๋)
- ✅ renderImage async รับ parsed canonical + minimal ctx ({brand})
- ✅ composition **ไม่ load brand ref / ไม่ call image Gemini** (test ยืนยัน: brand มี ref แต่ composition → genImageWithRef ไม่ถูกเรียก)
- ✅ preflight ordering: composition render-first (fail-fast ก่อน paid caption) ; ai ref-preflight เดิม ; CTA ก่อน paid ทั้งคู่
- ✅ finance regression: ยังเดิน ai path (genImage called, renderImage not)

### Verify
- `tsc` 0 · `vitest` **145 passed** (+composition dispatch/no-Gemini/no-ref, render-fail→FAILED-before-caption, finance ai regression)
- `next build` compiled · ไม่มี migration

### NEXT (guardrails ตู๋ — S6b/c)
- **S6b**: daily-7 template + composition render (next/og + NotoSansThai + bg เปล่า) + golden dimensions/layout + browser truth (hash ไม่ pin platform)
- **S6c**: draft prep — gen7 **server-persist keyed by requestKey** (lost-response idempotent) + same-key-diff-payload→409 ; **FinalInput schema** (days exactly 7, canonical, unique, day-order) ; create รับ FinalInput

🤖 ตอบโดย goo จาก [ฟีม] → goo-oracle