### PR TITLE
S6c.1: daily-7 draft/edit/regen/finalize backend

### DIFF
--- a/app/content-creator/api/daily/draft/[id]/finalize/route.ts
+++ b/app/content-creator/api/daily/draft/[id]/finalize/route.ts
@@ -1,0 +1,38 @@
+/**
+ * POST /content-creator/api/daily/draft/:id/finalize — snapshot → สร้าง contentPost (PENDING) [S6c]
+ * body: { finalizeKey, expectedRevision, backgroundId }
+ * validate FinalInput strict (7 วัน canonical) + backgroundId อยู่ใน manifest ; atomic กัน double-finalize
+ * → คืน contentPostId (ฟีมไปต่อที่ gen ภาพ/approve queue)
+ */
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getContentDb } from "@/content-creator/db/client";
+import { isContentCreatorEnabled } from "@/content-creator/lib/enabled";
+import { finalizeDaily7Draft, draftErrorStatus } from "@/content-creator/daily7-service";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const Body = z.object({
+  finalizeKey: z.string().min(1),
+  expectedRevision: z.number().int().min(0),
+  backgroundId: z.string().min(1),
+});
+
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  if (!isContentCreatorEnabled()) return new NextResponse(null, { status: 404 });
+  const { id } = await params;
+  let body: z.infer<typeof Body>;
+  try {
+    body = Body.parse(await request.json());
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid body (ต้องมี finalizeKey + expectedRevision + backgroundId)" }, { status: 400 });
+  }
+  try {
+    const res = finalizeDaily7Draft(getContentDb(), id, body.finalizeKey, body.expectedRevision, body.backgroundId);
+    return NextResponse.json({ ok: true, contentPostId: res.contentPostId, idempotent: res.replay }, { status: 200 });
+  } catch (e) {
+    const { status, error } = draftErrorStatus(e);
+    return NextResponse.json({ ok: false, error }, { status });
+  }
+}

--- a/app/content-creator/api/daily/draft/[id]/regenerate/route.ts
+++ b/app/content-creator/api/daily/draft/[id]/regenerate/route.ts
@@ -1,0 +1,33 @@
+/**
+ * POST /content-creator/api/daily/draft/:id/regenerate — gen 7 คำทำนายใหม่ทั้งชุด [S6c]
+ * body: { attemptKey, expectedRevision } — attemptKey ใหม่ = จงใจ regen ; ซ้ำ = replay (ไม่ gen ซ้ำ)
+ * กัน stale regen ทับ user edits ด้วย token+revision (ดู db/drafts)
+ */
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getContentDb } from "@/content-creator/db/client";
+import { isContentCreatorEnabled } from "@/content-creator/lib/enabled";
+import { regenDaily7Draft, draftErrorStatus } from "@/content-creator/daily7-service";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const Body = z.object({ attemptKey: z.string().min(1), expectedRevision: z.number().int().min(0) });
+
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  if (!isContentCreatorEnabled()) return new NextResponse(null, { status: 404 });
+  const { id } = await params;
+  let body: z.infer<typeof Body>;
+  try {
+    body = Body.parse(await request.json());
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid body (ต้องมี attemptKey + expectedRevision)" }, { status: 400 });
+  }
+  try {
+    const draft = await regenDaily7Draft(getContentDb(), id, body.attemptKey, body.expectedRevision);
+    return NextResponse.json({ ok: draft.status !== "FAILED", draft }, { status: 200 });
+  } catch (e) {
+    const { status, error } = draftErrorStatus(e);
+    return NextResponse.json({ ok: false, error }, { status });
+  }
+}

--- a/app/content-creator/api/daily/draft/[id]/route.ts
+++ b/app/content-creator/api/daily/draft/[id]/route.ts
@@ -8,13 +8,18 @@ import { z } from "zod";
 import { getContentDb } from "@/content-creator/db/client";
 import { isContentCreatorEnabled } from "@/content-creator/lib/enabled";
 import { editDaily7Draft, draftErrorStatus } from "@/content-creator/daily7-service";
+import { WEEKDAYS } from "@/content-creator/templates/daily7";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+// draft = workspace (ยอมไม่ครบ 7/ว่างชั่วคราว) แต่ bounded: weekday enum + ไม่ซ้ำ + ยาวจำกัด [ตู๋ P2]
 const Body = z.object({
   expectedRevision: z.number().int().min(0),
-  days: z.array(z.object({ day: z.string().min(1), fortune: z.string() })).max(7),
+  days: z
+    .array(z.object({ day: z.enum(WEEKDAYS), fortune: z.string().max(200) }))
+    .max(7)
+    .refine((arr) => new Set(arr.map((d) => d.day)).size === arr.length, "day ห้ามซ้ำ"),
 });
 
 export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {

--- a/app/content-creator/api/daily/draft/[id]/route.ts
+++ b/app/content-creator/api/daily/draft/[id]/route.ts
@@ -1,0 +1,36 @@
+/**
+ * PATCH /content-creator/api/daily/draft/:id — แก้คำทำนาย (optimistic concurrency) [S6c]
+ * body: { expectedRevision, days: [{day, fortune}] } — draft=workspace (ยอมว่าง/ไม่ครบชั่วคราว)
+ * revision ไม่ตรง/ไม่ใช่ READY → 409 (กัน stale overwrite)
+ */
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getContentDb } from "@/content-creator/db/client";
+import { isContentCreatorEnabled } from "@/content-creator/lib/enabled";
+import { editDaily7Draft, draftErrorStatus } from "@/content-creator/daily7-service";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const Body = z.object({
+  expectedRevision: z.number().int().min(0),
+  days: z.array(z.object({ day: z.string().min(1), fortune: z.string() })).max(7),
+});
+
+export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  if (!isContentCreatorEnabled()) return new NextResponse(null, { status: 404 });
+  const { id } = await params;
+  let body: z.infer<typeof Body>;
+  try {
+    body = Body.parse(await request.json());
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid body (ต้องมี expectedRevision + days)" }, { status: 400 });
+  }
+  try {
+    const draft = editDaily7Draft(getContentDb(), id, body.expectedRevision, body.days);
+    return NextResponse.json({ ok: true, draft }, { status: 200 });
+  } catch (e) {
+    const { status, error } = draftErrorStatus(e);
+    return NextResponse.json({ ok: false, error }, { status });
+  }
+}

--- a/app/content-creator/api/daily/draft/route.ts
+++ b/app/content-creator/api/daily/draft/route.ts
@@ -1,20 +1,23 @@
 /**
  * POST /content-creator/api/daily/draft — สร้าง daily-7 draft + gen 7 คำทำนาย (sync) [S6c]
- * body: { requestKey, targetDate? }  (ไม่ส่ง targetDate → วันนี้กรุงเทพ, freeze ครั้งแรก)
- * idempotent: requestKey เดิ่ม → คืน draft เดิม (ไม่ gen ซ้ำ) ; payload ต่าง → 409
+ * body: { requestKey, targetDate }  — targetDate **client-frozen** (บังคับส่ง):
+ *   ห้าม server derive today (retry เดิมข้ามเที่ยงคืน → payload ต่าง → 409 ไม่ idempotent) [ตู๋ P1.1]
+ * idempotent: requestKey เดิ่ม + payload ตรง → คืน draft เดิม (ไม่ gen ซ้ำ) ; payload ต่าง → 409
  */
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { getContentDb } from "@/content-creator/db/client";
 import { isContentCreatorEnabled } from "@/content-creator/lib/enabled";
-import { createDaily7Draft, bangkokTodayISO, draftErrorStatus } from "@/content-creator/daily7-service";
+import { createDaily7Draft, draftErrorStatus } from "@/content-creator/daily7-service";
+import { isValidIsoDate } from "@/content-creator/templates/daily7";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 const Body = z.object({
   requestKey: z.string().min(1),
-  targetDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  // calendar-valid + client-frozen — ไม่ใช่แค่ \d{4}-\d{2}-\d{2} (กัน 2026-99-99 จ่าย Gemini) [ตู๋ P1.3]
+  targetDate: z.string().refine(isValidIsoDate, "targetDate ต้องเป็นวันปฏิทินจริง YYYY-MM-DD"),
 });
 
 export async function POST(request: Request) {
@@ -23,11 +26,10 @@ export async function POST(request: Request) {
   try {
     body = Body.parse(await request.json());
   } catch {
-    return NextResponse.json({ ok: false, error: "invalid body (ต้องมี requestKey)" }, { status: 400 });
+    return NextResponse.json({ ok: false, error: "invalid body (ต้องมี requestKey + targetDate วันจริง)" }, { status: 400 });
   }
-  const targetDate = body.targetDate ?? bangkokTodayISO();
   try {
-    const draft = await createDaily7Draft(getContentDb(), body.requestKey, targetDate);
+    const draft = await createDaily7Draft(getContentDb(), body.requestKey, body.targetDate);
     return NextResponse.json({ ok: draft.status !== "FAILED", draft }, { status: 200 });
   } catch (e) {
     const { status, error } = draftErrorStatus(e);

--- a/app/content-creator/api/daily/draft/route.ts
+++ b/app/content-creator/api/daily/draft/route.ts
@@ -1,0 +1,36 @@
+/**
+ * POST /content-creator/api/daily/draft — สร้าง daily-7 draft + gen 7 คำทำนาย (sync) [S6c]
+ * body: { requestKey, targetDate? }  (ไม่ส่ง targetDate → วันนี้กรุงเทพ, freeze ครั้งแรก)
+ * idempotent: requestKey เดิ่ม → คืน draft เดิม (ไม่ gen ซ้ำ) ; payload ต่าง → 409
+ */
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getContentDb } from "@/content-creator/db/client";
+import { isContentCreatorEnabled } from "@/content-creator/lib/enabled";
+import { createDaily7Draft, bangkokTodayISO, draftErrorStatus } from "@/content-creator/daily7-service";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const Body = z.object({
+  requestKey: z.string().min(1),
+  targetDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+});
+
+export async function POST(request: Request) {
+  if (!isContentCreatorEnabled()) return new NextResponse(null, { status: 404 });
+  let body: z.infer<typeof Body>;
+  try {
+    body = Body.parse(await request.json());
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid body (ต้องมี requestKey)" }, { status: 400 });
+  }
+  const targetDate = body.targetDate ?? bangkokTodayISO();
+  try {
+    const draft = await createDaily7Draft(getContentDb(), body.requestKey, targetDate);
+    return NextResponse.json({ ok: draft.status !== "FAILED", draft }, { status: 200 });
+  } catch (e) {
+    const { status, error } = draftErrorStatus(e);
+    return NextResponse.json({ ok: false, error }, { status });
+  }
+}

--- a/app/content-creator/api/daily7-preview/route.tsx
+++ b/app/content-creator/api/daily7-preview/route.tsx
@@ -14,7 +14,7 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 const SAMPLE: Daily7Input = {
-  dateLabel: "วันนี้",
+  targetDate: "2026-06-15",
   days: [
     { day: "จันทร์", fortune: "การงานไหลลื่น เจ้านายเอ็นดู มีโอกาสได้งานใหม่" },
     { day: "อังคาร", fortune: "ระวังปากเสียงกับคนใกล้ตัว ใจเย็นไว้" },
@@ -43,7 +43,8 @@ export async function GET(request: Request) {
     }
   }
 
-  const bytes = await daily7.renderImage(input, { brand: DEFAULT_BRAND, seed });
+  // daily7 composition ไม่ใช้ brand แต่ RenderContext.brand type ต้องครบ — เติม updatedAt
+  const bytes = await daily7.renderImage(input, { brand: { ...DEFAULT_BRAND, updatedAt: new Date() }, seed });
   return new NextResponse(new Uint8Array(bytes), {
     headers: { "content-type": "image/png", "cache-control": "no-store" },
   });

--- a/app/content-creator/api/daily7-preview/route.tsx
+++ b/app/content-creator/api/daily7-preview/route.tsx
@@ -1,0 +1,50 @@
+/**
+ * GET /content-creator/api/daily7-preview — render daily-7 สดให้ดู (dev playground) [S6b browser-truth]
+ *
+ * ไม่แตะ DB / ไม่เรียก Gemini / ไม่ต้องตั้ง CTA — เรียก renderImage ตรง ๆ (path ที่ ship จริง)
+ * query: ?d=<base64(utf8 json ของ Daily7Input)>  ?seed=<string>  (ไม่ส่ง → sample)
+ * dev-only: prod → 404 (กันโผล่ public)
+ */
+import { NextResponse } from "next/server";
+import { daily7, daily7Schema, type Daily7Input } from "@/content-creator/templates/daily7";
+import { DEFAULT_BRAND } from "@/content-creator/db/brand";
+import { isContentCreatorEnabled } from "@/content-creator/lib/enabled";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const SAMPLE: Daily7Input = {
+  dateLabel: "วันนี้",
+  days: [
+    { day: "จันทร์", fortune: "การงานไหลลื่น เจ้านายเอ็นดู มีโอกาสได้งานใหม่" },
+    { day: "อังคาร", fortune: "ระวังปากเสียงกับคนใกล้ตัว ใจเย็นไว้" },
+    { day: "พุธ", fortune: "การเงินคล่องตัว มีรายได้เสริมเข้ามา" },
+    { day: "พฤหัสบดี", fortune: "ความรักสดใส คนโสดมีเกณฑ์เจอคนถูกใจ" },
+    { day: "ศุกร์", fortune: "สุขภาพดี พลังงานเต็มเปี่ยม เหมาะเริ่มสิ่งใหม่" },
+    { day: "เสาร์", fortune: "มีโชคลาภเล็กๆ จากผู้ใหญ่ ลองเสี่ยงดู" },
+    { day: "อาทิตย์", fortune: "ได้พักผ่อนเต็มที่ ครอบครัวอบอุ่น ใจสงบ" },
+  ],
+};
+
+export async function GET(request: Request) {
+  if (process.env.NODE_ENV === "production" || !isContentCreatorEnabled()) {
+    return new NextResponse(null, { status: 404 });
+  }
+  const { searchParams } = new URL(request.url);
+  const d = searchParams.get("d");
+  const seed = searchParams.get("seed") || "playground";
+
+  let input: Daily7Input = SAMPLE;
+  if (d) {
+    try {
+      input = daily7Schema.parse(JSON.parse(Buffer.from(decodeURIComponent(d), "base64").toString("utf8")));
+    } catch (err) {
+      return NextResponse.json({ ok: false, error: err instanceof Error ? err.message : String(err) }, { status: 400 });
+    }
+  }
+
+  const bytes = await daily7.renderImage(input, { brand: DEFAULT_BRAND, seed });
+  return new NextResponse(new Uint8Array(bytes), {
+    headers: { "content-type": "image/png", "cache-control": "no-store" },
+  });
+}

--- a/app/content-creator/daily7-playground/page.tsx
+++ b/app/content-creator/daily7-playground/page.tsx
@@ -22,18 +22,18 @@ function toBase64(s: string): string {
 }
 
 export default function Daily7Playground() {
-  const [dateLabel, setDateLabel] = useState("วันนี้");
+  const [targetDate, setTargetDate] = useState("2026-06-15");
   const [fortunes, setFortunes] = useState<Record<string, string>>({ ...DEFAULTS });
   const [seed, setSeed] = useState("playground");
 
   const src = useMemo(() => {
     const input = {
-      dateLabel: dateLabel.trim() || undefined,
+      targetDate,
       days: WEEKDAYS.map((day) => ({ day, fortune: fortunes[day]?.trim() || "—" })),
     };
     const d = encodeURIComponent(toBase64(JSON.stringify(input)));
     return `/content-creator/api/daily7-preview?d=${d}&seed=${encodeURIComponent(seed)}`;
-  }, [dateLabel, fortunes, seed]);
+  }, [targetDate, fortunes, seed]);
 
   return (
     <div style={{ display: "flex", gap: 24, padding: 24, fontFamily: "sans-serif", alignItems: "flex-start" }}>
@@ -41,8 +41,8 @@ export default function Daily7Playground() {
         <h2 style={{ margin: 0 }}>daily-7 playground 🔮</h2>
         <p style={{ margin: 0, color: "#666", fontSize: 13 }}>กรอกแล้วภาพอัปเดตสด · ไม่แตะ DB/Gemini · dev only</p>
 
-        <label style={{ fontSize: 13, color: "#444" }}>ป้ายวันที่ (header)</label>
-        <input value={dateLabel} onChange={(e) => setDateLabel(e.target.value)} style={{ padding: 8, borderRadius: 8, border: "1px solid #ccc" }} />
+        <label style={{ fontSize: 13, color: "#444" }}>targetDate (ISO — renderer แปลงเป็นวันที่ไทยเอง)</label>
+        <input type="date" value={targetDate} onChange={(e) => setTargetDate(e.target.value)} style={{ padding: 8, borderRadius: 8, border: "1px solid #ccc" }} />
 
         {WEEKDAYS.map((day) => (
           <div key={day} style={{ display: "flex", flexDirection: "column", gap: 2 }}>

--- a/app/content-creator/daily7-playground/page.tsx
+++ b/app/content-creator/daily7-playground/page.tsx
@@ -1,0 +1,70 @@
+"use client";
+/**
+ * daily-7 playground [S6b browser-truth] — กรอกคำทำนาย 7 วัน → เห็นภาพอัปเดตสด
+ * dev tool: เรียก /api/daily7-preview (renderImage ตรง, ไม่แตะ DB/Gemini). ลองเล่น layout/ข้อความ
+ */
+import { useMemo, useState } from "react";
+
+const WEEKDAYS = ["จันทร์", "อังคาร", "พุธ", "พฤหัสบดี", "ศุกร์", "เสาร์", "อาทิตย์"] as const;
+
+const DEFAULTS: Record<string, string> = {
+  จันทร์: "การงานไหลลื่น เจ้านายเอ็นดู มีโอกาสได้งานใหม่",
+  อังคาร: "ระวังปากเสียงกับคนใกล้ตัว ใจเย็นไว้",
+  พุธ: "การเงินคล่องตัว มีรายได้เสริมเข้ามา",
+  พฤหัสบดี: "ความรักสดใส คนโสดมีเกณฑ์เจอคนถูกใจ",
+  ศุกร์: "สุขภาพดี พลังงานเต็มเปี่ยม เหมาะเริ่มสิ่งใหม่",
+  เสาร์: "มีโชคลาภเล็กๆ จากผู้ใหญ่ ลองเสี่ยงดู",
+  อาทิตย์: "ได้พักผ่อนเต็มที่ ครอบครัวอบอุ่น ใจสงบ",
+};
+
+function toBase64(s: string): string {
+  return btoa(String.fromCharCode(...new TextEncoder().encode(s)));
+}
+
+export default function Daily7Playground() {
+  const [dateLabel, setDateLabel] = useState("วันนี้");
+  const [fortunes, setFortunes] = useState<Record<string, string>>({ ...DEFAULTS });
+  const [seed, setSeed] = useState("playground");
+
+  const src = useMemo(() => {
+    const input = {
+      dateLabel: dateLabel.trim() || undefined,
+      days: WEEKDAYS.map((day) => ({ day, fortune: fortunes[day]?.trim() || "—" })),
+    };
+    const d = encodeURIComponent(toBase64(JSON.stringify(input)));
+    return `/content-creator/api/daily7-preview?d=${d}&seed=${encodeURIComponent(seed)}`;
+  }, [dateLabel, fortunes, seed]);
+
+  return (
+    <div style={{ display: "flex", gap: 24, padding: 24, fontFamily: "sans-serif", alignItems: "flex-start" }}>
+      <div style={{ display: "flex", flexDirection: "column", gap: 10, width: 460 }}>
+        <h2 style={{ margin: 0 }}>daily-7 playground 🔮</h2>
+        <p style={{ margin: 0, color: "#666", fontSize: 13 }}>กรอกแล้วภาพอัปเดตสด · ไม่แตะ DB/Gemini · dev only</p>
+
+        <label style={{ fontSize: 13, color: "#444" }}>ป้ายวันที่ (header)</label>
+        <input value={dateLabel} onChange={(e) => setDateLabel(e.target.value)} style={{ padding: 8, borderRadius: 8, border: "1px solid #ccc" }} />
+
+        {WEEKDAYS.map((day) => (
+          <div key={day} style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            <label style={{ fontSize: 13, fontWeight: 600 }}>{day}</label>
+            <textarea
+              value={fortunes[day] ?? ""}
+              onChange={(e) => setFortunes((f) => ({ ...f, [day]: e.target.value }))}
+              rows={2}
+              style={{ padding: 8, borderRadius: 8, border: "1px solid #ccc", resize: "vertical", fontFamily: "inherit" }}
+            />
+          </div>
+        ))}
+
+        <label style={{ fontSize: 13, color: "#444" }}>seed (เปลี่ยน bg เมื่อมี pool หลายใบ — ตอนนี้ N=1 ภาพเดิม)</label>
+        <input value={seed} onChange={(e) => setSeed(e.target.value)} style={{ padding: 8, borderRadius: 8, border: "1px solid #ccc" }} />
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 8, position: "sticky", top: 24 }}>
+        {/* key=src → reload ภาพเมื่อ input เปลี่ยน */}
+        <img key={src} src={src} alt="daily-7 preview" width={520} height={520} style={{ borderRadius: 16, border: "1px solid #eee", boxShadow: "0 4px 20px rgba(0,0,0,0.08)" }} />
+        <span style={{ fontSize: 12, color: "#999" }}>1080×1080 · render จริงจาก renderImage (path เดียวกับ production)</span>
+      </div>
+    </div>
+  );
+}

--- a/content-creator/__tests__/daily-draft-route.test.ts
+++ b/content-creator/__tests__/daily-draft-route.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const WEEKDAYS = ["จันทร์", "อังคาร", "พุธ", "พฤหัสบดี", "ศุกร์", "เสาร์", "อาทิตย์"] as const;
+
+const mockGenObject = vi.hoisted(() => vi.fn());
+const dbHolder = vi.hoisted(() => ({ db: null as unknown }));
+
+vi.mock("@/content-creator/lib/gemini", () => ({ genObject: mockGenObject }));
+vi.mock("@/content-creator/db/client", async (orig) => {
+  const actual = await orig<typeof import("@/content-creator/db/client")>();
+  return { ...actual, getContentDb: () => dbHolder.db };
+});
+
+import { createContentDb } from "@/content-creator/db/client";
+import { POST as createDraft } from "@/app/content-creator/api/daily/draft/route";
+
+const req = (body: unknown) =>
+  new Request("http://t/content-creator/api/daily/draft", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
+
+beforeEach(() => {
+  process.env.CONTENT_CREATOR_ENABLED = "true";
+  dbHolder.db = createContentDb(":memory:");
+  mockGenObject.mockReset();
+  mockGenObject.mockResolvedValue({ days: WEEKDAYS.map((day) => ({ day, fortune: `${day} ดี` })) });
+});
+
+describe("POST /api/daily/draft regression [ตู๋ P1.1/P1.3]", () => {
+  it("ไม่ส่ง targetDate → 400 (require client-frozen, ไม่ derive today)", async () => {
+    const res = await createDraft(req({ requestKey: "rk" }));
+    expect(res.status).toBe(400);
+    expect(mockGenObject).not.toHaveBeenCalled();
+  });
+
+  it("targetDate ไม่ใช่วันปฏิทินจริง (2026-99-99) → 400 (ก่อนจ่าย Gemini)", async () => {
+    const res = await createDraft(req({ requestKey: "rk", targetDate: "2026-99-99" }));
+    expect(res.status).toBe(400);
+    expect(mockGenObject).not.toHaveBeenCalled();
+  });
+
+  it("valid → 200 READY ; retry key เดิ่ม payload ตรง → idempotent (ไม่ gen ซ้ำ)", async () => {
+    const a = await createDraft(req({ requestKey: "rk", targetDate: "2026-06-15" }));
+    const aj = await a.json();
+    expect(a.status).toBe(200);
+    expect(aj.draft.status).toBe("READY");
+
+    const b = await createDraft(req({ requestKey: "rk", targetDate: "2026-06-15" }));
+    const bj = await b.json();
+    expect(bj.draft.id).toBe(aj.draft.id);
+    expect(mockGenObject).toHaveBeenCalledTimes(1); // retry ไม่ gen ซ้ำ
+  });
+
+  it("key เดิ่ม + targetDate ต่าง → 409 (key reuse, ไม่ idempotent ผิด ๆ)", async () => {
+    await createDraft(req({ requestKey: "rk", targetDate: "2026-06-15" }));
+    const res = await createDraft(req({ requestKey: "rk", targetDate: "2026-12-31" }));
+    expect(res.status).toBe(409);
+  });
+});

--- a/content-creator/__tests__/daily7-service.test.ts
+++ b/content-creator/__tests__/daily7-service.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const WEEKDAYS = ["จันทร์", "อังคาร", "พุธ", "พฤหัสบดี", "ศุกร์", "เสาร์", "อาทิตย์"] as const;
+
+// mock เฉพาะ genObject (gen 7 คำทำนาย) — ไม่เรียก Gemini จริงใน test
+const mockGenObject = vi.hoisted(() => vi.fn());
+vi.mock("../lib/gemini", () => ({ genObject: mockGenObject }));
+
+import { createContentDb, type ContentDb } from "../db/client";
+import { contentPosts } from "../db/schema";
+import { eq } from "drizzle-orm";
+import { createDaily7Draft, regenDaily7Draft, editDaily7Draft, finalizeDaily7Draft } from "../daily7-service";
+import { getDraft } from "../db/drafts";
+
+const full = () => ({ days: WEEKDAYS.map((day) => ({ day, fortune: `${day} วันนี้ดีมาก` })) });
+const VALID_BG = "mimi-crystal-pastel"; // อยู่ใน manifest จริง
+
+let db: ContentDb;
+beforeEach(() => {
+  db = createContentDb(":memory:");
+  mockGenObject.mockReset();
+  mockGenObject.mockResolvedValue(full());
+});
+
+describe("createDaily7Draft [S6c gen + idempotency]", () => {
+  it("fresh → gen 7 วัน → READY", async () => {
+    const d = await createDaily7Draft(db, "rk", "2026-06-15");
+    expect(d.status).toBe("READY");
+    expect((d.draftData as { days: unknown[] }).days).toHaveLength(7);
+    expect(mockGenObject).toHaveBeenCalledTimes(1);
+  });
+  it("retry requestKey เดิม → ไม่ gen ซ้ำ (idempotent)", async () => {
+    await createDaily7Draft(db, "rk", "2026-06-15");
+    await createDaily7Draft(db, "rk", "2026-06-15");
+    expect(mockGenObject).toHaveBeenCalledTimes(1);
+  });
+  it("gen คืนไม่ครบ 7 → regen 1 ครั้ง → ยังไม่ครบ → FAILED", async () => {
+    mockGenObject.mockResolvedValue({ days: WEEKDAYS.slice(0, 6).map((day) => ({ day, fortune: "x" })) });
+    const d = await createDaily7Draft(db, "rk", "2026-06-15");
+    expect(d.status).toBe("FAILED");
+    expect(mockGenObject).toHaveBeenCalledTimes(2); // gen + regen-once
+  });
+});
+
+describe("regenDaily7Draft", () => {
+  it("attemptKey ใหม่ → gen ใหม่ ; days อัปเดต", async () => {
+    const d = await createDaily7Draft(db, "rk", "2026-06-15");
+    mockGenObject.mockResolvedValue({ days: WEEKDAYS.map((day) => ({ day, fortune: `${day} เปลี่ยนแล้ว` })) });
+    const after = await regenDaily7Draft(db, d.id, "attempt-1", d.revision);
+    expect(after.status).toBe("READY");
+    expect((after.draftData as { days: { fortune: string }[] }).days[0].fortune).toContain("เปลี่ยนแล้ว");
+  });
+});
+
+describe("finalizeDaily7Draft validation [ตู๋ P1.A/B]", () => {
+  it("valid 7 วัน + backgroundId ใน manifest → สร้าง contentPost PENDING", async () => {
+    const d = await createDaily7Draft(db, "rk", "2026-06-15");
+    const res = finalizeDaily7Draft(db, d.id, "fk", d.revision, VALID_BG);
+    const post = db.select().from(contentPosts).where(eq(contentPosts.id, res.contentPostId)).get();
+    expect(post?.status).toBe("PENDING");
+    expect((post?.inputData as { backgroundId: string }).backgroundId).toBe(VALID_BG);
+    expect((post?.inputData as { targetDate: string }).targetDate).toBe("2026-06-15");
+  });
+  it("backgroundId ไม่อยู่ใน manifest → throw (กัน render พังตอน gen)", async () => {
+    const d = await createDaily7Draft(db, "rk", "2026-06-15");
+    expect(() => finalizeDaily7Draft(db, d.id, "fk", d.revision, "ไม่มีจริง")).toThrow(/manifest/);
+  });
+  it("draftData ไม่ครบ 7 (แก้ให้เหลือ 6) → finalize ไม่ผ่าน (ZodError)", async () => {
+    const d = await createDaily7Draft(db, "rk", "2026-06-15");
+    const edited = editDaily7Draft(db, d.id, d.revision, WEEKDAYS.slice(0, 6).map((day) => ({ day, fortune: "x" })));
+    expect(() => finalizeDaily7Draft(db, d.id, "fk", edited.revision, VALID_BG)).toThrow();
+    expect(getDraft(db, d.id)!.status).toBe("READY"); // ไม่ถูก finalize
+  });
+});

--- a/content-creator/__tests__/daily7.test.ts
+++ b/content-creator/__tests__/daily7.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { writeFileSync } from "node:fs";
-import { daily7, daily7Schema, deriveThaiDateLabel, canonicalizeDays, type Daily7Input } from "../templates/daily7";
+import { daily7, daily7Schema, deriveThaiDateLabel, canonicalizeDays, isValidIsoDate, type Daily7Input } from "../templates/daily7";
 import { DEFAULT_BRAND } from "../db/brand";
 
 const SAMPLE: Daily7Input = {
@@ -32,6 +32,27 @@ describe("daily7Schema [S6b FinalInput]", () => {
   });
   it("targetDate ผิดรูปแบบ → fail", () => {
     expect(daily7Schema.safeParse({ targetDate: "15/06/2026", days: SAMPLE.days }).success).toBe(false);
+  });
+  it("targetDate รูปแบบถูกแต่ไม่ใช่วันจริง (2026-99-99 / 2026-02-30) → fail [ตู๋ P1.3]", () => {
+    expect(daily7Schema.safeParse({ targetDate: "2026-99-99", days: SAMPLE.days }).success).toBe(false);
+    expect(daily7Schema.safeParse({ targetDate: "2026-02-30", days: SAMPLE.days }).success).toBe(false);
+  });
+});
+
+describe("isValidIsoDate [ตู๋ P1.3]", () => {
+  it("วันจริง → true", () => {
+    expect(isValidIsoDate("2026-06-15")).toBe(true);
+    expect(isValidIsoDate("2024-02-29")).toBe(true); // อธิกสุรทิน
+  });
+  it("ไม่ใช่วันจริง → false", () => {
+    expect(isValidIsoDate("2026-99-99")).toBe(false);
+    expect(isValidIsoDate("2026-02-30")).toBe(false);
+    expect(isValidIsoDate("2026-13-01")).toBe(false);
+    expect(isValidIsoDate("2025-02-29")).toBe(false); // ไม่ใช่อธิกสุรทิน
+    expect(isValidIsoDate("15/06/2026")).toBe(false);
+  });
+  it("deriveThaiDateLabel โยน error ถ้าไม่ใช่วันจริง", () => {
+    expect(() => deriveThaiDateLabel("2026-99-99")).toThrow();
   });
 });
 

--- a/content-creator/__tests__/daily7.test.ts
+++ b/content-creator/__tests__/daily7.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { writeFileSync } from "node:fs";
-import { daily7, daily7Schema, type Daily7Input } from "../templates/daily7";
+import { daily7, daily7Schema, deriveThaiDateLabel, canonicalizeDays, type Daily7Input } from "../templates/daily7";
 import { DEFAULT_BRAND } from "../db/brand";
 
 const SAMPLE: Daily7Input = {
-  dateLabel: "15 มิ.ย. 68",
+  targetDate: "2026-06-15",
   days: [
     { day: "จันทร์", fortune: "การงานไหลลื่น เจ้านายเอ็นดู มีโอกาสได้งานใหม่เข้ามา" },
     { day: "อังคาร", fortune: "ระวังปากเสียงกับคนใกล้ตัว ใจเย็นไว้แล้วจะผ่านไปด้วยดี" },
@@ -21,14 +21,39 @@ describe("daily7Schema [S6b FinalInput]", () => {
     expect(daily7Schema.safeParse(SAMPLE).success).toBe(true);
   });
   it("ไม่ครบ 7 วัน → fail", () => {
-    expect(daily7Schema.safeParse({ days: SAMPLE.days.slice(0, 6) }).success).toBe(false);
+    expect(daily7Schema.safeParse({ targetDate: "2026-06-15", days: SAMPLE.days.slice(0, 6) }).success).toBe(false);
   });
   it("วันซ้ำ (ครบ 7 ช่องแต่ซ้ำ) → fail", () => {
     const dup = [...SAMPLE.days.slice(0, 6), { day: "จันทร์" as const, fortune: "ซ้ำ" }];
-    expect(daily7Schema.safeParse({ days: dup }).success).toBe(false);
+    expect(daily7Schema.safeParse({ targetDate: "2026-06-15", days: dup }).success).toBe(false);
   });
   it("เกิน 7 → fail", () => {
-    expect(daily7Schema.safeParse({ days: [...SAMPLE.days, { day: "จันทร์", fortune: "x" }] }).success).toBe(false);
+    expect(daily7Schema.safeParse({ targetDate: "2026-06-15", days: [...SAMPLE.days, { day: "จันทร์", fortune: "x" }] }).success).toBe(false);
+  });
+  it("targetDate ผิดรูปแบบ → fail", () => {
+    expect(daily7Schema.safeParse({ targetDate: "15/06/2026", days: SAMPLE.days }).success).toBe(false);
+  });
+});
+
+describe("deriveThaiDateLabel [S6c]", () => {
+  it("ISO → Thai date (พ.ศ. 2 หลัก)", () => {
+    expect(deriveThaiDateLabel("2026-06-15")).toBe("15 มิ.ย. 69"); // 2026+543=2569
+    expect(deriveThaiDateLabel("2025-01-05")).toBe("5 ม.ค. 68");
+  });
+});
+
+describe("canonicalizeDays [S6c gen validate]", () => {
+  const full = SAMPLE.days.map((d) => ({ day: d.day as string, fortune: d.fortune }));
+  it("ครบ 7 → เรียง canonical", () => {
+    const out = canonicalizeDays([...full].reverse());
+    expect(out.map((d) => d.day)).toEqual(["จันทร์", "อังคาร", "พุธ", "พฤหัสบดี", "ศุกร์", "เสาร์", "อาทิตย์"]);
+  });
+  it("ขาดวัน/ซ้ำ → throw", () => {
+    expect(() => canonicalizeDays(full.slice(0, 6))).toThrow(/ขาดวัน|ครบ 7/);
+  });
+  it("คำทำนายว่าง → throw", () => {
+    const withEmpty = [{ day: "จันทร์", fortune: "  " }, ...full.slice(1)];
+    expect(() => canonicalizeDays(withEmpty)).toThrow(/ว่าง/);
   });
 });
 
@@ -43,6 +68,17 @@ describe("daily7.renderImage [S6b composition — verify real output]", () => {
     writeFileSync("/tmp/daily7-preview.png", bytes);
   }, 30000);
 
+  it("backgroundId (finalized by-id path) → PNG 1080x1080", async () => {
+    const bytes = await daily7.renderImage({ ...SAMPLE, backgroundId: "mimi-crystal-pastel" }, { brand: DEFAULT_BRAND, seed: "ignored-when-by-id" });
+    expect(bytes.slice(0, 4)).toEqual(new Uint8Array([0x89, 0x50, 0x4e, 0x47]));
+    const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    expect(dv.getUint32(16)).toBe(1080);
+  }, 30000);
+
+  it("backgroundId ไม่อยู่ใน manifest → throw (ไม่เงียบ)", async () => {
+    await expect(daily7.renderImage({ ...SAMPLE, backgroundId: "ghost" }, { brand: DEFAULT_BRAND, seed: "s" })).rejects.toThrow(/manifest/);
+  }, 30000);
+
   it("seed เดิม → bytes เท่าเดิม (deterministic, golden นิ่ง)", async () => {
     const a = await daily7.renderImage(SAMPLE, { brand: DEFAULT_BRAND, seed: "fixed-seed" });
     const b = await daily7.renderImage(SAMPLE, { brand: DEFAULT_BRAND, seed: "fixed-seed" });
@@ -51,6 +87,7 @@ describe("daily7.renderImage [S6b composition — verify real output]", () => {
 
   it("worst-case Thai ไม่มี space ทุก 7 slot → ยัง 1080x1080 (geometry กันล้น) [ตู๋ P1 regression]", async () => {
     const worst: Daily7Input = {
+      targetDate: "2026-06-15",
       days: (["จันทร์", "อังคาร", "พุธ", "พฤหัสบดี", "ศุกร์", "เสาร์", "อาทิตย์"] as const).map((day) => ({
         day,
         fortune: "ก".repeat(200), // no break opportunity — เคยล้น panel ทับตัวละคร

--- a/content-creator/__tests__/drafts.test.ts
+++ b/content-creator/__tests__/drafts.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { eq } from "drizzle-orm";
+import { createContentDb, type ContentDb } from "../db/client";
+import { contentDrafts, contentPosts } from "../db/schema";
+import {
+  createDraft,
+  completeDraftGen,
+  failDraftGen,
+  editDraft,
+  claimRegen,
+  finalizeDraft,
+  getDraft,
+  DraftConflictError,
+  DraftStaleError,
+} from "../db/drafts";
+
+const SEED = { targetDate: "2026-06-15" };
+const FINAL = { targetDate: "2026-06-15", backgroundId: "x", days: [] as unknown[] };
+
+let db: ContentDb;
+beforeEach(() => {
+  db = createContentDb(":memory:");
+});
+
+/** helper: สร้าง draft แล้ว complete เป็น READY (จำลอง gen สำเร็จ) → คืน draft READY */
+function readyDraft(requestKey = "rk-1") {
+  const { draft, token } = createDraft(db, { requestKey, templateId: "daily-7", seedPayload: SEED });
+  completeDraftGen(db, draft.id, token!, { ...SEED, days: [{ day: "จันทร์", fortune: "x" }] });
+  return getDraft(db, draft.id)!;
+}
+
+describe("createDraft idempotency [S6c ตู๋ P1.A]", () => {
+  it("fresh insert → fresh+token, status GENERATING", () => {
+    const r = createDraft(db, { requestKey: "rk", templateId: "daily-7", seedPayload: SEED });
+    expect(r.fresh).toBe(true);
+    expect(r.token).toBeTruthy();
+    expect(r.draft.status).toBe("GENERATING");
+  });
+  it("requestKey เดิม + payload ตรง → idempotent (fresh=false, draft เดิม, ไม่ gen ซ้ำ)", () => {
+    const a = createDraft(db, { requestKey: "rk", templateId: "daily-7", seedPayload: SEED });
+    const b = createDraft(db, { requestKey: "rk", templateId: "daily-7", seedPayload: SEED });
+    expect(b.fresh).toBe(false);
+    expect(b.token).toBeNull();
+    expect(b.draft.id).toBe(a.draft.id);
+  });
+  it("requestKey เดิม + payload ต่าง → 409 DraftConflictError", () => {
+    createDraft(db, { requestKey: "rk", templateId: "daily-7", seedPayload: SEED });
+    expect(() => createDraft(db, { requestKey: "rk", templateId: "daily-7", seedPayload: { targetDate: "2026-12-31" } })).toThrow(DraftConflictError);
+  });
+});
+
+describe("completeDraftGen/failDraftGen token guard", () => {
+  it("token ตรง → READY + revision bump + draftData", () => {
+    const { draft, token } = createDraft(db, { requestKey: "rk", templateId: "daily-7", seedPayload: SEED });
+    expect(completeDraftGen(db, draft.id, token!, { days: 7 })).toBe(true);
+    const d = getDraft(db, draft.id)!;
+    expect(d.status).toBe("READY");
+    expect(d.revision).toBe(1);
+  });
+  it("token ผิด → false (ไม่ทับ — superseded)", () => {
+    const { draft } = createDraft(db, { requestKey: "rk", templateId: "daily-7", seedPayload: SEED });
+    expect(completeDraftGen(db, draft.id, "wrong-token", { days: 7 })).toBe(false);
+    expect(getDraft(db, draft.id)!.status).toBe("GENERATING");
+  });
+  it("fail token ตรง → FAILED + error", () => {
+    const { draft, token } = createDraft(db, { requestKey: "rk", templateId: "daily-7", seedPayload: SEED });
+    expect(failDraftGen(db, draft.id, token!, "boom")).toBe(true);
+    expect(getDraft(db, draft.id)!.status).toBe("FAILED");
+  });
+});
+
+describe("editDraft optimistic concurrency", () => {
+  it("revision ตรง (READY) → bump + อัปเดต draftData", () => {
+    const d = readyDraft();
+    const after = editDraft(db, d.id, d.revision, { ...SEED, days: [{ day: "อังคาร", fortune: "y" }] });
+    expect(after.revision).toBe(d.revision + 1);
+  });
+  it("revision ไม่ตรง → DraftStaleError (กัน lost-update)", () => {
+    const d = readyDraft();
+    expect(() => editDraft(db, d.id, d.revision + 5, { x: 1 })).toThrow(DraftStaleError);
+  });
+  it("ไม่ใช่ READY (GENERATING) → DraftStaleError", () => {
+    const { draft } = createDraft(db, { requestKey: "rk", templateId: "daily-7", seedPayload: SEED });
+    expect(() => editDraft(db, draft.id, draft.revision, { x: 1 })).toThrow(DraftStaleError);
+  });
+});
+
+describe("claimRegen [ตู๋ P1.D]", () => {
+  it("READY + revision ตรง → claim (token, GENERATING, attemptKey, revision bump)", () => {
+    const d = readyDraft();
+    const r = claimRegen(db, d.id, "attempt-1", d.revision);
+    expect(r.replay).toBe(false);
+    expect(r.token).toBeTruthy();
+    expect(r.draft.status).toBe("GENERATING");
+    expect(r.draft.revision).toBe(d.revision + 1);
+  });
+  it("attemptKey เดิม → replay (token null, ไม่ claim ซ้ำ)", () => {
+    const d = readyDraft();
+    claimRegen(db, d.id, "attempt-1", d.revision);
+    const replay = claimRegen(db, d.id, "attempt-1", d.revision + 1);
+    expect(replay.replay).toBe(true);
+    expect(replay.token).toBeNull();
+  });
+  it("revision ไม่ตรง → DraftStaleError", () => {
+    const d = readyDraft();
+    expect(() => claimRegen(db, d.id, "attempt-1", d.revision + 9)).toThrow(DraftStaleError);
+  });
+  it("stale regen เก่า complete ไม่ทับ attempt ใหม่ (token ใหม่ชนะ)", () => {
+    const d = readyDraft();
+    const first = claimRegen(db, d.id, "attempt-1", d.revision); // token T1, GENERATING
+    // จำลอง lease หมดอายุ (gen T1 ค้าง) → set generatingAt ย้อนหลัง
+    db.update(contentDrafts).set({ generatingAt: new Date(Date.now() - 10 * 60 * 1000) }).where(eq(contentDrafts.id, d.id)).run();
+    const second = claimRegen(db, d.id, "attempt-2", 0); // ยึดผ่าน stale lease → token T2
+    expect(second.token).toBeTruthy();
+    // T1 (เก่า) complete ทีหลัง → ต้องไม่ทับ
+    expect(completeDraftGen(db, d.id, first.token!, { stale: true })).toBe(false);
+    expect(completeDraftGen(db, d.id, second.token!, { fresh: true })).toBe(true);
+    expect(getDraft(db, d.id)!.draftData).toEqual({ fresh: true });
+  });
+});
+
+describe("finalizeDraft atomic + double-finalize guard [ตู๋ P1.A]", () => {
+  it("READY + revision ตรง → สร้าง contentPost PENDING + draft FINALIZED", () => {
+    const d = readyDraft();
+    const r = finalizeDraft(db, d.id, "fk-1", d.revision, FINAL, "daily-7");
+    expect(r.replay).toBe(false);
+    const post = db.select().from(contentPosts).where(eq(contentPosts.id, r.contentPostId)).get();
+    expect(post?.status).toBe("PENDING");
+    expect(post?.requestKey).toBe(`draft:${d.id}`);
+    expect(getDraft(db, d.id)!.status).toBe("FINALIZED");
+  });
+  it("replay finalizeKey เดิม → contentPostId เดิม (ไม่สร้าง post ซ้ำ)", () => {
+    const d = readyDraft();
+    const a = finalizeDraft(db, d.id, "fk-1", d.revision, FINAL, "daily-7");
+    const b = finalizeDraft(db, d.id, "fk-1", d.revision + 1, FINAL, "daily-7");
+    expect(b.replay).toBe(true);
+    expect(b.contentPostId).toBe(a.contentPostId);
+    expect(db.select().from(contentPosts).all().length).toBe(1);
+  });
+  it("double-finalize ด้วย finalizeKey ใหม่ → DraftConflictError", () => {
+    const d = readyDraft();
+    finalizeDraft(db, d.id, "fk-1", d.revision, FINAL, "daily-7");
+    expect(() => finalizeDraft(db, d.id, "fk-2", 99, FINAL, "daily-7")).toThrow(DraftConflictError);
+  });
+  it("revision ไม่ตรง → DraftStaleError (ไม่สร้าง post)", () => {
+    const d = readyDraft();
+    expect(() => finalizeDraft(db, d.id, "fk-1", d.revision + 7, FINAL, "daily-7")).toThrow(DraftStaleError);
+    expect(db.select().from(contentPosts).all().length).toBe(0);
+  });
+  it("ไม่ใช่ READY → DraftStaleError", () => {
+    const { draft } = createDraft(db, { requestKey: "rk", templateId: "daily-7", seedPayload: SEED });
+    expect(() => finalizeDraft(db, draft.id, "fk-1", draft.revision, FINAL, "daily-7")).toThrow(DraftStaleError);
+  });
+});

--- a/content-creator/__tests__/drafts.test.ts
+++ b/content-creator/__tests__/drafts.test.ts
@@ -107,15 +107,30 @@ describe("claimRegen [ตู๋ P1.D]", () => {
   });
   it("stale regen เก่า complete ไม่ทับ attempt ใหม่ (token ใหม่ชนะ)", () => {
     const d = readyDraft();
-    const first = claimRegen(db, d.id, "attempt-1", d.revision); // token T1, GENERATING
+    const first = claimRegen(db, d.id, "attempt-1", d.revision); // token T1, GENERATING, rev bump
     // จำลอง lease หมดอายุ (gen T1 ค้าง) → set generatingAt ย้อนหลัง
     db.update(contentDrafts).set({ generatingAt: new Date(Date.now() - 10 * 60 * 1000) }).where(eq(contentDrafts.id, d.id)).run();
-    const second = claimRegen(db, d.id, "attempt-2", 0); // ยึดผ่าน stale lease → token T2
+    const cur = getDraft(db, d.id)!;
+    const second = claimRegen(db, d.id, "attempt-2", cur.revision); // ยึดผ่าน stale lease (revision ต้องตรง) → T2
     expect(second.token).toBeTruthy();
     // T1 (เก่า) complete ทีหลัง → ต้องไม่ทับ
     expect(completeDraftGen(db, d.id, first.token!, { stale: true })).toBe(false);
     expect(completeDraftGen(db, d.id, second.token!, { fresh: true })).toBe(true);
     expect(getDraft(db, d.id)!.draftData).toEqual({ fresh: true });
+  });
+  it("stale lease แต่ revision ไม่ตรง → throw (กัน reclaim ด้วย revision ค้าง) [ตู๋ P1.2]", () => {
+    const d = readyDraft();
+    claimRegen(db, d.id, "attempt-1", d.revision); // GENERATING, rev bump
+    db.update(contentDrafts).set({ generatingAt: new Date(Date.now() - 10 * 60 * 1000) }).where(eq(contentDrafts.id, d.id)).run();
+    expect(() => claimRegen(db, d.id, "attempt-2", 0)).toThrow(DraftStaleError); // revision เก่า แม้ lease หมดอายุ
+  });
+  it("FINALIZED + attemptKey เดิม → throw (เช็ค FINALIZED ก่อน replay) [ตู๋ P2]", () => {
+    const d = readyDraft();
+    const c = claimRegen(db, d.id, "attempt-X", d.revision);
+    completeDraftGen(db, d.id, c.token!, { ...SEED, days: [{ day: "จันทร์", fortune: "x" }] });
+    const ready = getDraft(db, d.id)!; // READY, attemptKey=attempt-X
+    finalizeDraft(db, d.id, "fk", ready.revision, FINAL, "daily-7"); // → FINALIZED
+    expect(() => claimRegen(db, d.id, "attempt-X", 99)).toThrow(DraftStaleError); // ไม่ replay draft ที่ finalize แล้ว
   });
 });
 

--- a/content-creator/daily7-service.ts
+++ b/content-creator/daily7-service.ts
@@ -30,11 +30,6 @@ export function draftErrorStatus(e: unknown): { status: number; error: string } 
   return { status: 500, error: e instanceof Error ? e.message : String(e) };
 }
 
-/** วันนี้ตามเขตเวลากรุงเทพ (YYYY-MM-DD) — freeze ตอนสร้าง draft ครั้งแรก (ไม่ derive ใหม่ทุก retry) */
-export function bangkokTodayISO(): string {
-  return new Intl.DateTimeFormat("en-CA", { timeZone: "Asia/Bangkok", year: "numeric", month: "2-digit", day: "2-digit" }).format(new Date());
-}
-
 /** gen ผลกลับเข้า draft (complete/fail ตาม token) — ใช้ร่วม create+regen */
 async function runGen(db: ContentDb, id: string, token: string, targetDate: string): Promise<void> {
   try {

--- a/content-creator/daily7-service.ts
+++ b/content-creator/daily7-service.ts
@@ -1,0 +1,86 @@
+/**
+ * daily-7 draft service [S6c] — ผูก draft lifecycle (db/drafts) เข้ากับ daily-7 gen/validate.
+ * route handler บาง: เรียก service เหล่านี้ (gen sync ใน request — admin tool, ฟีมรอไม่กี่วิ)
+ */
+import { ZodError } from "zod";
+import type { ContentDb } from "./db/client";
+import {
+  createDraft,
+  completeDraftGen,
+  failDraftGen,
+  editDraft,
+  claimRegen,
+  finalizeDraft,
+  getDraft,
+  DraftStaleError,
+  DraftConflictError,
+  type ContentDraft,
+  type FinalizeResult,
+} from "./db/drafts";
+import { genDaily7Days, daily7Schema, canonicalizeDays } from "./templates/daily7";
+import { assertValidBackgroundId } from "./lib/bg-pool";
+
+export const DAILY7_TEMPLATE_ID = "daily-7";
+
+/** map error ของ draft lifecycle → HTTP status (route ใช้ร่วม) */
+export function draftErrorStatus(e: unknown): { status: number; error: string } {
+  if (e instanceof DraftConflictError) return { status: 409, error: e.message };
+  if (e instanceof DraftStaleError) return { status: 409, error: e.message };
+  if (e instanceof ZodError) return { status: 400, error: "draftData ไม่ผ่าน schema (ครบ 7 วัน/ไม่ซ้ำ?)" };
+  return { status: 500, error: e instanceof Error ? e.message : String(e) };
+}
+
+/** วันนี้ตามเขตเวลากรุงเทพ (YYYY-MM-DD) — freeze ตอนสร้าง draft ครั้งแรก (ไม่ derive ใหม่ทุก retry) */
+export function bangkokTodayISO(): string {
+  return new Intl.DateTimeFormat("en-CA", { timeZone: "Asia/Bangkok", year: "numeric", month: "2-digit", day: "2-digit" }).format(new Date());
+}
+
+/** gen ผลกลับเข้า draft (complete/fail ตาม token) — ใช้ร่วม create+regen */
+async function runGen(db: ContentDb, id: string, token: string, targetDate: string): Promise<void> {
+  try {
+    const days = await genDaily7Days(targetDate);
+    completeDraftGen(db, id, token, { targetDate, days });
+  } catch (e) {
+    failDraftGen(db, id, token, e instanceof Error ? e.message : String(e));
+  }
+}
+
+/** สร้าง draft + gen 7 วัน (sync). retry idempotent (requestKey เดิม → ไม่ gen ซ้ำ) */
+export async function createDaily7Draft(db: ContentDb, requestKey: string, targetDate: string): Promise<ContentDraft> {
+  const { draft, token, fresh } = createDraft(db, { requestKey, templateId: DAILY7_TEMPLATE_ID, seedPayload: { targetDate } });
+  if (fresh && token) await runGen(db, draft.id, token, targetDate);
+  return getDraft(db, draft.id)!;
+}
+
+/** regen ทั้งชุด (จงใจ) — attemptKey ใหม่ + expectedRevision. replay (key เดิม) → ไม่ gen ซ้ำ */
+export async function regenDaily7Draft(db: ContentDb, id: string, attemptKey: string, expectedRevision: number): Promise<ContentDraft> {
+  const { draft, token, replay } = claimRegen(db, id, attemptKey, expectedRevision);
+  if (replay || !token) return draft;
+  const targetDate = String((draft.seedPayload as { targetDate?: string }).targetDate ?? "");
+  await runGen(db, id, token, targetDate);
+  return getDraft(db, id)!;
+}
+
+/** edit คำทำนาย — draft = workspace (ยอมว่าง/ไม่ครบชั่วคราว ก็เก็บได้) ; strict ตอน finalize.
+ *  เก็บ days ที่ส่งมาตามรูป (validate แค่ shape หลวม ๆ ที่ caller ทำ) คู่กับ targetDate เดิม */
+export function editDaily7Draft(db: ContentDb, id: string, expectedRevision: number, days: { day: string; fortune: string }[]): ContentDraft {
+  const draft = getDraft(db, id);
+  if (!draft) throw new DraftStaleError(`ไม่พบ draft: ${id}`);
+  const targetDate = String((draft.seedPayload as { targetDate?: string }).targetDate ?? "");
+  return editDraft(db, id, expectedRevision, { targetDate, days });
+}
+
+/**
+ * finalize → สร้าง contentPost. validate FinalInput strict (7 วัน canonical) + backgroundId อยู่ใน manifest.
+ * @throws DraftStaleError ถ้าไม่พบ ; ZodError ถ้า draftData ไม่ผ่าน strict ; Error ถ้า backgroundId ไม่ valid
+ */
+export function finalizeDaily7Draft(db: ContentDb, id: string, finalizeKey: string, expectedRevision: number, backgroundId: string): FinalizeResult {
+  const draft = getDraft(db, id);
+  if (!draft) throw new DraftStaleError(`ไม่พบ draft: ${id}`);
+  assertValidBackgroundId(backgroundId); // id ต้องอยู่ใน manifest (ไม่งั้น render พัง ตอน gen)
+  // strict: draftData (targetDate+days) + backgroundId → FinalInput canonical (ครบ 7/ไม่ซ้ำ)
+  const finalInput = daily7Schema.parse({ ...(draft.draftData ?? {}), backgroundId });
+  // re-canonicalize days ให้เรียง + trim ก่อน persist (กัน order/whitespace หลุดจาก edit)
+  const canonical = canonicalizeDays(finalInput.days);
+  return finalizeDraft(db, id, finalizeKey, expectedRevision, { ...finalInput, days: canonical }, DAILY7_TEMPLATE_ID);
+}

--- a/content-creator/db/drafts.ts
+++ b/content-creator/db/drafts.ts
@@ -1,0 +1,194 @@
+/**
+ * content-creator draft lifecycle [S6c] — generic ต่อ template (daily-7 ใช้ก่อน)
+ *
+ * concurrency model (ตู๋ P1.A/D):
+ *  - requestKey (unique) = idempotency ของ "สร้าง draft 1 ครั้ง" : retry เน็ตหลุด → คืน draft เดิม
+ *    (same key + payload ต่าง → 409)
+ *  - revision = optimistic lock : edit/regen/finalize ต้อง WHERE revision=expected → bump ทุกครั้ง
+ *  - generationToken = ownership ของ gen/regen attempt : เขียนผลกลับเฉพาะ token+state ยังตรง
+ *    (กัน stale regen ทับ user edits / attempt ใหม่)
+ *  - attemptKey = idempotency ของ regen (จงใจ gen ใหม่) : replay → ไม่ gen ซ้ำ
+ *  - finalizeKey + contentPostId NULL guard + contentPosts.requestKey unique = กัน double-finalize
+ */
+import { and, eq, sql } from "drizzle-orm";
+import type { ContentDb } from "./client";
+import { contentDrafts, contentPosts, type ContentDraft } from "./schema";
+
+export type { ContentDraft } from "./schema";
+
+/** GENERATING lease หมดอายุ → regen ยึดต่อได้ (กัน stuck จาก lost-response ที่ gen ตายกลางคัน) */
+const STALE_LEASE_MS = 2 * 60 * 1000;
+
+/** requestKey ซ้ำแต่ payload ต่าง / regen-finalize ชน state → 409 */
+export class DraftConflictError extends Error {}
+/** revision ไม่ตรง หรือ state ไม่อนุญาต (stale / finalized) */
+export class DraftStaleError extends Error {}
+
+/** stable stringify (sort keys) — เทียบ seedPayload equality ไม่ให้ลำดับ key หลอก */
+function stableStringify(v: unknown): string {
+  if (v === null || typeof v !== "object") return JSON.stringify(v) ?? "null";
+  if (Array.isArray(v)) return `[${v.map(stableStringify).join(",")}]`;
+  const o = v as Record<string, unknown>;
+  return `{${Object.keys(o).sort().map((k) => `${JSON.stringify(k)}:${stableStringify(o[k])}`).join(",")}}`;
+}
+
+export function getDraft(db: ContentDb, id: string): ContentDraft | undefined {
+  return db.select().from(contentDrafts).where(eq(contentDrafts.id, id)).get();
+}
+
+export interface CreateDraftArgs {
+  requestKey: string;
+  templateId: string;
+  /** canonical seed (frozen identity เช่น { targetDate }) */
+  seedPayload: Record<string, unknown>;
+}
+export interface CreateDraftResult {
+  draft: ContentDraft;
+  /** token สำหรับ gen ครั้งแรก (มีเฉพาะ fresh=true) — fresh=false คือ retry idempotent */
+  token: string | null;
+  fresh: boolean;
+}
+
+/**
+ * สร้าง draft (หรือคืนของเดิมแบบ idempotent ถ้า requestKey ซ้ำ + payload ตรง).
+ * fresh=true → caller ต้อง gen แล้ว complete/fail ด้วย token. fresh=false → gen ไปแล้ว/กำลังทำ (อย่า gen ซ้ำ).
+ * @throws DraftConflictError ถ้า requestKey ซ้ำแต่ payload/template ต่าง
+ */
+export function createDraft(db: ContentDb, args: CreateDraftArgs): CreateDraftResult {
+  const idempotentReturn = (): CreateDraftResult | null => {
+    const ex = db.select().from(contentDrafts).where(eq(contentDrafts.requestKey, args.requestKey)).get();
+    if (!ex) return null;
+    if (ex.templateId !== args.templateId || stableStringify(ex.seedPayload) !== stableStringify(args.seedPayload)) {
+      throw new DraftConflictError(`requestKey ซ้ำแต่ payload/template ต่าง: ${args.requestKey}`);
+    }
+    return { draft: ex, token: null, fresh: false };
+  };
+
+  const pre = idempotentReturn();
+  if (pre) return pre;
+
+  const token = crypto.randomUUID();
+  const id = crypto.randomUUID();
+  try {
+    db.insert(contentDrafts)
+      .values({ id, requestKey: args.requestKey, templateId: args.templateId, seedPayload: args.seedPayload, status: "GENERATING", revision: 0, generationToken: token, generatingAt: new Date() })
+      .run();
+  } catch {
+    // race: request อื่น insert requestKey เดียวกันก่อน (unique) → คืน idempotent
+    const post = idempotentReturn();
+    if (post) return post;
+    throw new Error(`createDraft insert ล้มเหลว: ${args.requestKey}`);
+  }
+  return { draft: getDraft(db, id)!, token, fresh: true };
+}
+
+/** gen สำเร็จ: GENERATING+token → READY (เก็บ draftData) เฉพาะ token ตรง. false = superseded */
+export function completeDraftGen(db: ContentDb, id: string, token: string, draftData: Record<string, unknown>): boolean {
+  const res = db
+    .update(contentDrafts)
+    .set({ status: "READY", draftData, generationToken: null, generatingAt: null, error: null, revision: sql`${contentDrafts.revision} + 1`, updatedAt: new Date() })
+    .where(and(eq(contentDrafts.id, id), eq(contentDrafts.status, "GENERATING"), eq(contentDrafts.generationToken, token)))
+    .run();
+  return res.changes === 1;
+}
+
+/** gen ล้ม: GENERATING+token → FAILED เฉพาะ token ตรง. false = superseded */
+export function failDraftGen(db: ContentDb, id: string, token: string, error: string): boolean {
+  const res = db
+    .update(contentDrafts)
+    .set({ status: "FAILED", error, generationToken: null, generatingAt: null, revision: sql`${contentDrafts.revision} + 1`, updatedAt: new Date() })
+    .where(and(eq(contentDrafts.id, id), eq(contentDrafts.status, "GENERATING"), eq(contentDrafts.generationToken, token)))
+    .run();
+  return res.changes === 1;
+}
+
+/**
+ * edit draftData (ฟีมแก้คำทำนาย) — optimistic: READY + revision=expected → bump.
+ * @throws DraftStaleError ถ้า revision ไม่ตรง/ไม่ใช่ READY (stale/finalized/กำลัง gen)
+ */
+export function editDraft(db: ContentDb, id: string, expectedRevision: number, draftData: Record<string, unknown>): ContentDraft {
+  const res = db
+    .update(contentDrafts)
+    .set({ draftData, revision: sql`${contentDrafts.revision} + 1`, updatedAt: new Date() })
+    .where(and(eq(contentDrafts.id, id), eq(contentDrafts.status, "READY"), eq(contentDrafts.revision, expectedRevision)))
+    .run();
+  if (res.changes !== 1) throw new DraftStaleError(`edit ไม่สำเร็จ: revision ไม่ตรง/ไม่ใช่ READY (id=${id})`);
+  return getDraft(db, id)!;
+}
+
+export interface RegenClaim {
+  draft: ContentDraft;
+  /** token สำหรับ gen รอบนี้ (null = replay ของ attemptKey เดิม → อย่า gen ซ้ำ) */
+  token: string | null;
+  replay: boolean;
+}
+
+/**
+ * claim เพื่อ regen ทั้งชุด (จงใจ gen ใหม่) — ต้อง attemptKey ใหม่ + expectedRevision [ตู๋ P1.D].
+ * same attemptKey → replay (คืนสถานะปัจจุบัน ไม่ gen ซ้ำ). claim ได้จาก READY/FAILED ที่ revision ตรง
+ * หรือ GENERATING ที่ lease หมดอายุ (stuck). คืน token → caller gen แล้ว complete/fail.
+ * @throws DraftStaleError ถ้า claim ไม่ได้ (revision ไม่ตรง/กำลัง gen อยู่/finalized)
+ */
+export function claimRegen(db: ContentDb, id: string, attemptKey: string, expectedRevision: number): RegenClaim {
+  return db.transaction((tx) => {
+    const cur = tx.select().from(contentDrafts).where(eq(contentDrafts.id, id)).get();
+    if (!cur) throw new DraftStaleError(`ไม่พบ draft: ${id}`);
+    if (cur.attemptKey === attemptKey) return { draft: cur, token: null, replay: true };
+    if (cur.status === "FINALIZED") throw new DraftStaleError("draft finalized แล้ว (read-only)");
+
+    const staleLease = cur.status === "GENERATING" && !!cur.generatingAt && Date.now() - cur.generatingAt.getTime() > STALE_LEASE_MS;
+    const freshClaim = (cur.status === "READY" || cur.status === "FAILED") && cur.revision === expectedRevision;
+    if (!freshClaim && !staleLease) {
+      throw new DraftStaleError(`regen claim ไม่ได้: status=${cur.status} revision=${cur.revision} (expected ${expectedRevision})`);
+    }
+    const token = crypto.randomUUID();
+    const res = tx
+      .update(contentDrafts)
+      .set({ status: "GENERATING", generationToken: token, generatingAt: new Date(), attemptKey, revision: sql`${contentDrafts.revision} + 1`, updatedAt: new Date() })
+      .where(and(eq(contentDrafts.id, id), eq(contentDrafts.revision, cur.revision))) // guard: ไม่มีใครแทรกระหว่าง read→write
+      .run();
+    if (res.changes !== 1) throw new DraftStaleError(`regen claim race: id=${id}`);
+    return { draft: tx.select().from(contentDrafts).where(eq(contentDrafts.id, id)).get()!, token, replay: false };
+  });
+}
+
+export interface FinalizeResult {
+  contentPostId: string;
+  replay: boolean;
+}
+
+/**
+ * finalize: snapshot FinalInput → สร้าง contentPost (PENDING) แบบ atomic + mark draft FINALIZED [ตู๋ P1.A].
+ * กัน double-finalize 3 ชั้น: finalizeKey replay + contentPostId NULL guard + contentPosts.requestKey unique.
+ * @throws DraftStaleError ถ้า revision ไม่ตรง/ไม่ใช่ READY/finalized ไปแล้วด้วย key อื่น
+ */
+export function finalizeDraft(
+  db: ContentDb,
+  id: string,
+  finalizeKey: string,
+  expectedRevision: number,
+  finalInput: Record<string, unknown>,
+  templateId: string,
+): FinalizeResult {
+  return db.transaction((tx) => {
+    const cur = tx.select().from(contentDrafts).where(eq(contentDrafts.id, id)).get();
+    if (!cur) throw new DraftStaleError(`ไม่พบ draft: ${id}`);
+    // replay ของ finalize เดิม → คืน post เดิม (idempotent)
+    if (cur.finalizeKey === finalizeKey && cur.contentPostId) return { contentPostId: cur.contentPostId, replay: true };
+    if (cur.contentPostId) throw new DraftConflictError("draft ถูก finalize ไปแล้ว (double-finalize)");
+    if (cur.status !== "READY" || cur.revision !== expectedRevision) {
+      throw new DraftStaleError(`finalize ไม่ได้: status=${cur.status} revision=${cur.revision} (expected ${expectedRevision})`);
+    }
+    const postId = crypto.randomUUID();
+    tx.insert(contentPosts)
+      .values({ id: postId, requestKey: `draft:${id}`, templateId, inputData: finalInput, status: "PENDING" })
+      .run(); // requestKey unique = backstop กัน 2 post จาก draft เดียว
+    const res = tx
+      .update(contentDrafts)
+      .set({ status: "FINALIZED", contentPostId: postId, finalizeKey, revision: sql`${contentDrafts.revision} + 1`, updatedAt: new Date() })
+      .where(and(eq(contentDrafts.id, id), eq(contentDrafts.revision, cur.revision), sql`${contentDrafts.contentPostId} IS NULL`))
+      .run();
+    if (res.changes !== 1) throw new DraftStaleError(`finalize race: id=${id}`);
+    return { contentPostId: postId, replay: false };
+  });
+}

--- a/content-creator/db/drafts.ts
+++ b/content-creator/db/drafts.ts
@@ -133,13 +133,18 @@ export function claimRegen(db: ContentDb, id: string, attemptKey: string, expect
   return db.transaction((tx) => {
     const cur = tx.select().from(contentDrafts).where(eq(contentDrafts.id, id)).get();
     if (!cur) throw new DraftStaleError(`ไม่พบ draft: ${id}`);
-    if (cur.attemptKey === attemptKey) return { draft: cur, token: null, replay: true };
+    // FINALIZED = read-only — เช็คก่อน replay [ตู๋ P2] (กัน attemptKey เดิม replay คืน draft ที่ finalize ไปแล้ว)
     if (cur.status === "FINALIZED") throw new DraftStaleError("draft finalized แล้ว (read-only)");
+    if (cur.attemptKey === attemptKey) return { draft: cur, token: null, replay: true };
 
+    // revision ต้องตรงเสมอ — ทั้ง fresh และ stale-lease [ตู๋ P1.2] (กัน reclaim paid regen ด้วย revision ค้าง)
+    if (cur.revision !== expectedRevision) {
+      throw new DraftStaleError(`regen claim ไม่ได้: revision=${cur.revision} (expected ${expectedRevision})`);
+    }
     const staleLease = cur.status === "GENERATING" && !!cur.generatingAt && Date.now() - cur.generatingAt.getTime() > STALE_LEASE_MS;
-    const freshClaim = (cur.status === "READY" || cur.status === "FAILED") && cur.revision === expectedRevision;
-    if (!freshClaim && !staleLease) {
-      throw new DraftStaleError(`regen claim ไม่ได้: status=${cur.status} revision=${cur.revision} (expected ${expectedRevision})`);
+    const statusAllows = cur.status === "READY" || cur.status === "FAILED" || staleLease;
+    if (!statusAllows) {
+      throw new DraftStaleError(`regen claim ไม่ได้: status=${cur.status} (กำลัง gen อยู่ ยังไม่หมดอายุ)`);
     }
     const token = crypto.randomUUID();
     const res = tx

--- a/content-creator/db/migrations/0005_amusing_risque.sql
+++ b/content-creator/db/migrations/0005_amusing_risque.sql
@@ -1,0 +1,19 @@
+CREATE TABLE `content_drafts` (
+	`id` text PRIMARY KEY NOT NULL,
+	`request_key` text NOT NULL,
+	`template_id` text NOT NULL,
+	`seed_payload` text NOT NULL,
+	`draft_data` text,
+	`status` text DEFAULT 'GENERATING' NOT NULL,
+	`revision` integer DEFAULT 0 NOT NULL,
+	`generation_token` text,
+	`generating_at` integer,
+	`attempt_key` text,
+	`finalize_key` text,
+	`content_post_id` text,
+	`error` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `content_drafts_request_key_unique` ON `content_drafts` (`request_key`);

--- a/content-creator/db/migrations/meta/0005_snapshot.json
+++ b/content-creator/db/migrations/meta/0005_snapshot.json
@@ -1,0 +1,345 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "fac0062e-f1c7-4088-8ab2-0e6f085c3952",
+  "prevId": "67cee17c-997b-4242-96c0-900bb0a624d7",
+  "tables": {
+    "brand_profile": {
+      "name": "brand_profile",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "style_prompt": {
+          "name": "style_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "caption_persona": {
+          "name": "caption_persona",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "ref_image_path": {
+          "name": "ref_image_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_model": {
+          "name": "image_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caption_max_chars": {
+          "name": "caption_max_chars",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 300
+        },
+        "cta_text": {
+          "name": "cta_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "cta_url": {
+          "name": "cta_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "content_drafts": {
+      "name": "content_drafts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_key": {
+          "name": "request_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seed_payload": {
+          "name": "seed_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "draft_data": {
+          "name": "draft_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'GENERATING'"
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "generation_token": {
+          "name": "generation_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generating_at": {
+          "name": "generating_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_key": {
+          "name": "attempt_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finalize_key": {
+          "name": "finalize_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_post_id": {
+          "name": "content_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "content_drafts_request_key_unique": {
+          "name": "content_drafts_request_key_unique",
+          "columns": [
+            "request_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "content_posts": {
+      "name": "content_posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_key": {
+          "name": "request_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_data": {
+          "name": "input_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'PENDING'"
+        },
+        "generation_token": {
+          "name": "generation_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generating_at": {
+          "name": "generating_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_path": {
+          "name": "image_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_fbid": {
+          "name": "media_fbid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fb_post_id": {
+          "name": "fb_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publish_at": {
+          "name": "publish_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "content_posts_request_key_unique": {
+          "name": "content_posts_request_key_unique",
+          "columns": [
+            "request_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/content-creator/db/migrations/meta/_journal.json
+++ b/content-creator/db/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1781447477767,
       "tag": "0004_good_talos",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1781505350803,
+      "tag": "0005_amusing_risque",
+      "breakpoints": true
     }
   ]
 }

--- a/content-creator/db/schema.ts
+++ b/content-creator/db/schema.ts
@@ -78,3 +78,47 @@ export const brandProfile = sqliteTable("brand_profile", {
 
 export type BrandProfile = typeof brandProfile.$inferSelect;
 export type NewBrandProfile = typeof brandProfile.$inferInsert;
+
+/**
+ * ContentDraft [S6c] — "พื้นที่ร่าง/แก้ไข" ก่อนกลายเป็น contentPost จริง (ตู๋ P1.A).
+ * แยก table เด็ดขาดจาก contentPosts: draft = mutable editorial workspace, contentPosts =
+ * publication artifact + state machine. finalize = snapshot draft → สร้าง contentPost (atomic).
+ *
+ * lifecycle: GENERATING → READY → FINALIZED ; READY/FAILED → (regen) GENERATING ; FINALIZED = read-only
+ * concurrency: optimistic ผ่าน `revision` (เขียนต้อง WHERE revision=expected) + generationToken
+ *   (gen/regen เขียนกลับเฉพาะ token+revision ยังตรง — กัน stale regen ทับ user edits)
+ */
+export const DRAFT_STATUSES = ["GENERATING", "READY", "FAILED", "FINALIZED"] as const;
+export type DraftStatus = (typeof DRAFT_STATUSES)[number];
+
+export const contentDrafts = sqliteTable("content_drafts", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  /** idempotency key ต่อ "การสร้าง draft 1 ครั้ง" (retry เน็ตหลุด = key เดิม → ได้ draft เดิม) */
+  requestKey: text("request_key").notNull().unique(),
+  templateId: text("template_id").notNull(),
+  /** canonical seed ที่ "นิยาม identity ของ draft" (frozen): เช่น { targetDate } — freeze เวลาสร้าง
+   *  ไม่ derive ใหม่ทุก retry (กัน lost-response ข้ามเที่ยงคืน same-key คนละความหมาย) [ตู๋ P1.C] */
+  seedPayload: text("seed_payload", { mode: "json" }).notNull().$type<Record<string, unknown>>(),
+  /** เนื้อหาที่ gen/แก้ได้ (7 วัน ฯลฯ) — mutable */
+  draftData: text("draft_data", { mode: "json" }).$type<Record<string, unknown>>(),
+  status: text("status").$type<DraftStatus>().notNull().default("GENERATING"),
+  /** optimistic concurrency — bump ทุกครั้งที่เขียนสำเร็จ */
+  revision: integer("revision").notNull().default(0),
+  /** ownership token ของ gen/regen attempt ปัจจุบัน — เขียนผลกลับเฉพาะ token ตรง (กัน stale overwrite) */
+  generationToken: text("generation_token"),
+  generatingAt: integer("generating_at", { mode: "timestamp" }),
+  /** key ของ regen attempt ปัจจุบัน (จงใจ gen ใหม่) — แยกจาก requestKey (retry) [ตู๋ P1.D] */
+  attemptKey: text("attempt_key"),
+  /** key ของการ finalize (replay → คืน contentPostId เดิม) — แยกจาก draft/regen key */
+  finalizeKey: text("finalize_key"),
+  /** หลัง finalize → post จริงที่สร้าง (กัน double-finalize: NULL = ยังไม่ finalize) */
+  contentPostId: text("content_post_id"),
+  error: text("error"),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull().$defaultFn(() => new Date()),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).notNull().$defaultFn(() => new Date()),
+});
+
+export type ContentDraft = typeof contentDrafts.$inferSelect;
+export type NewContentDraft = typeof contentDrafts.$inferInsert;

--- a/content-creator/lib/bg-pool.ts
+++ b/content-creator/lib/bg-pool.ts
@@ -94,8 +94,29 @@ export function loadEntryBytes(entry: BgManifestEntry): Uint8Array {
   return bytes;
 }
 
-/** เลือก + โหลด bg สำหรับ seed (post id) ในก้าวเดียว — ใช้โดย renderImage */
+/** เลือก + โหลด bg สำหรับ seed (post id) ในก้าวเดียว — ใช้โดย renderImage (fallback path) */
 export function loadBackgroundForSeed(seed: string): { entry: BgManifestEntry; bytes: Uint8Array } {
   const entry = selectEntry(seed, loadManifest());
+  return { entry, bytes: loadEntryBytes(entry) };
+}
+
+/**
+ * เลือก entry ตาม id ตรง ๆ [S6c] — finalize persist backgroundId แล้ว render by-id (ไม่ fallback hash)
+ * → ผลคงที่ถาวรไม่ขึ้นกับ pool size → **ขยาย pool ได้** หลัง persist. id ไม่อยู่ใน manifest → throw.
+ */
+export function selectById(id: string, manifest: BgManifestEntry[]): BgManifestEntry {
+  const e = manifest.find((x) => x.id === id);
+  if (!e) throw new Error(`bg id ไม่อยู่ใน manifest: ${id}`);
+  return e;
+}
+
+/** validate ว่า id อยู่ใน manifest (ใช้ตอน finalize ก่อน persist) — id ไม่ valid → throw */
+export function assertValidBackgroundId(id: string): void {
+  selectById(id, loadManifest());
+}
+
+/** เลือก + โหลด bg ตาม id (finalized render path) */
+export function loadBackgroundById(id: string): { entry: BgManifestEntry; bytes: Uint8Array } {
+  const entry = selectById(id, loadManifest());
   return { entry, bytes: loadEntryBytes(entry) };
 }

--- a/content-creator/lib/gemini.ts
+++ b/content-creator/lib/gemini.ts
@@ -9,7 +9,8 @@
  * พิสูจน์ feasibility แล้วใน POC #1 (gemini-2.5-flash + imagen-4.0-generate-001)
  */
 import { google } from "@ai-sdk/google";
-import { generateText, experimental_generateImage as generateImage } from "ai";
+import { generateText, generateObject, experimental_generateImage as generateImage } from "ai";
+import type { z } from "zod";
 import { TEXT_MODEL, IMAGE_MODEL, REF_IMAGE_MODEL, DEFAULT_CAPTION_TEMPERATURE } from "./config";
 
 export interface CaptionInput {
@@ -30,6 +31,26 @@ export async function genCaption(input: CaptionInput): Promise<string> {
     temperature: input.temperature ?? DEFAULT_CAPTION_TEMPERATURE,
   });
   return text;
+}
+
+/**
+ * gen แบบ structured output (JSON ตรง schema) — ใช้กับ daily-7 gen 7 วันทั้งชุดในครั้งเดียว [S6c].
+ * model คืน object ที่ผ่าน schema (ai SDK retry/repair ให้ระดับนึง) ; caller validate ซ้ำอีกชั้น.
+ */
+export async function genObject<T>(input: {
+  schema: z.ZodType<T>;
+  system: string;
+  prompt: string;
+  temperature?: number;
+}): Promise<T> {
+  const { object } = await generateObject({
+    model: google(TEXT_MODEL),
+    schema: input.schema,
+    system: input.system,
+    prompt: input.prompt,
+    temperature: input.temperature ?? DEFAULT_CAPTION_TEMPERATURE,
+  });
+  return object;
 }
 
 export interface ImageInput {

--- a/content-creator/templates/daily7.tsx
+++ b/content-creator/templates/daily7.tsx
@@ -16,8 +16,20 @@ import { loadBackgroundForSeed, loadBackgroundById } from "../lib/bg-pool";
 import { genObject } from "../lib/gemini";
 
 /** ลำดับ canonical (render เรียงนี้เสมอ ไม่ขึ้นกับลำดับ input) */
-const WEEKDAYS = ["จันทร์", "อังคาร", "พุธ", "พฤหัสบดี", "ศุกร์", "เสาร์", "อาทิตย์"] as const;
+export const WEEKDAYS = ["จันทร์", "อังคาร", "พุธ", "พฤหัสบดี", "ศุกร์", "เสาร์", "อาทิตย์"] as const;
 type Weekday = (typeof WEEKDAYS)[number];
+
+/**
+ * ISO date ที่เป็น "วันปฏิทินจริง" (ไม่ใช่แค่ \d{4}-\d{2}-\d{2}) — กัน 2026-99-99 / 2026-02-30
+ * หลุดเข้า paid gen + label undefined [ตู๋ P1.3]. UTC round-trip → deterministic ไม่พึ่ง tz.
+ */
+export function isValidIsoDate(s: string): boolean {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s);
+  if (!m) return false;
+  const [y, mo, d] = [Number(m[1]), Number(m[2]), Number(m[3])];
+  const dt = new Date(Date.UTC(y, mo - 1, d));
+  return dt.getUTCFullYear() === y && dt.getUTCMonth() === mo - 1 && dt.getUTCDate() === d;
+}
 
 /** สีประจำวันเกิดไทย — คนไทยรู้สีวันเกิดตัวเอง ใช้เป็น cue หา slot ได้เร็ว */
 const DAY_COLOR: Record<Weekday, string> = {
@@ -45,7 +57,7 @@ const dayFortuneSchema = z.object({ day: z.enum(WEEKDAYS), fortune: z.string().m
  */
 export const daily7Schema = z
   .object({
-    targetDate: z.string().regex(ISO_DATE, "targetDate ต้องเป็น YYYY-MM-DD"),
+    targetDate: z.string().regex(ISO_DATE, "targetDate ต้องเป็น YYYY-MM-DD").refine(isValidIsoDate, "targetDate ไม่ใช่วันปฏิทินจริง"),
     backgroundId: z.string().min(1).optional(),
     days: z.array(dayFortuneSchema).length(7),
   })
@@ -62,8 +74,7 @@ export type DayFortune = { day: Weekday; fortune: string };
 /** เดือนไทยย่อ — derive Thai dateLabel จาก ISO date แบบ deterministic (ไม่พึ่ง timezone/locale ระบบ) */
 const THAI_MONTHS = ["ม.ค.", "ก.พ.", "มี.ค.", "เม.ย.", "พ.ค.", "มิ.ย.", "ก.ค.", "ส.ค.", "ก.ย.", "ต.ค.", "พ.ย.", "ธ.ค."];
 export function deriveThaiDateLabel(isoDate: string): string {
-  const m = isoDate.match(ISO_DATE);
-  if (!m) throw new Error(`targetDate ไม่ถูกต้อง: ${isoDate}`);
+  if (!isValidIsoDate(isoDate)) throw new Error(`targetDate ไม่ใช่วันปฏิทินจริง: ${isoDate}`);
   const [y, mo, d] = isoDate.split("-").map(Number);
   const be2 = String((y + 543) % 100).padStart(2, "0"); // ปี พ.ศ. 2 หลักท้าย
   return `${d} ${THAI_MONTHS[mo - 1]} ${be2}`;

--- a/content-creator/templates/daily7.tsx
+++ b/content-creator/templates/daily7.tsx
@@ -12,7 +12,8 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { z } from "zod";
 import type { CompositionTemplate, RenderContext } from "./types";
-import { loadBackgroundForSeed } from "../lib/bg-pool";
+import { loadBackgroundForSeed, loadBackgroundById } from "../lib/bg-pool";
+import { genObject } from "../lib/gemini";
 
 /** ลำดับ canonical (render เรียงนี้เสมอ ไม่ขึ้นกับลำดับ input) */
 const WEEKDAYS = ["จันทร์", "อังคาร", "พุธ", "พฤหัสบดี", "ศุกร์", "เสาร์", "อาทิตย์"] as const;
@@ -29,14 +30,24 @@ const DAY_COLOR: Record<Weekday, string> = {
   อาทิตย์: "#E2453F", // แดง
 };
 
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+const MAX_PREDICTION = 200; // content cap ต่อวัน (visual ถูก clip ด้วย geometry อีกชั้น)
+
+const dayFortuneSchema = z.object({ day: z.enum(WEEKDAYS), fortune: z.string().min(1).max(MAX_PREDICTION) });
+
+/**
+ * FinalInput (canonical) — สิ่งที่ persist ใน contentPost.inputData + ใช้ render [S6c ตู๋].
+ *  - targetDate (ISO, freeze เวลากรุงเทพตอนสร้าง) — renderer derive Thai dateLabel เอง deterministic
+ *    (ไม่เก็บ dateLabel แก้มือ — กัน label ไม่ตรง date)
+ *  - backgroundId (optional) — finalize set ให้เสมอ → render by-id (ปลดล็อกขยาย pool) ;
+ *    ไม่มี → fallback seed hash (back-compat S6b path)
+ *  - days ครบ 7 ไม่ซ้ำ (จันทร์–อาทิตย์)
+ */
 export const daily7Schema = z
   .object({
-    /** ป้ายวันที่บนหัวการ์ด (optional) เช่น "15 มิ.ย. 68" */
-    dateLabel: z.string().min(1).max(40).optional(),
-    /** 7 วัน ครบไม่ซ้ำ (จันทร์–อาทิตย์) — canonical FinalInput */
-    days: z
-      .array(z.object({ day: z.enum(WEEKDAYS), fortune: z.string().min(1).max(200) }))
-      .length(7),
+    targetDate: z.string().regex(ISO_DATE, "targetDate ต้องเป็น YYYY-MM-DD"),
+    backgroundId: z.string().min(1).optional(),
+    days: z.array(dayFortuneSchema).length(7),
   })
   .superRefine((val, ctx) => {
     const set = new Set(val.days.map((d) => d.day));
@@ -46,6 +57,62 @@ export const daily7Schema = z
   });
 
 export type Daily7Input = z.infer<typeof daily7Schema>;
+export type DayFortune = { day: Weekday; fortune: string };
+
+/** เดือนไทยย่อ — derive Thai dateLabel จาก ISO date แบบ deterministic (ไม่พึ่ง timezone/locale ระบบ) */
+const THAI_MONTHS = ["ม.ค.", "ก.พ.", "มี.ค.", "เม.ย.", "พ.ค.", "มิ.ย.", "ก.ค.", "ส.ค.", "ก.ย.", "ต.ค.", "พ.ย.", "ธ.ค."];
+export function deriveThaiDateLabel(isoDate: string): string {
+  const m = isoDate.match(ISO_DATE);
+  if (!m) throw new Error(`targetDate ไม่ถูกต้อง: ${isoDate}`);
+  const [y, mo, d] = isoDate.split("-").map(Number);
+  const be2 = String((y + 543) % 100).padStart(2, "0"); // ปี พ.ศ. 2 หลักท้าย
+  return `${d} ${THAI_MONTHS[mo - 1]} ${be2}`;
+}
+
+/**
+ * canonicalize ผล gen → 7 วันเรียง canonical, trim, ไม่ว่าง, ครบ/ไม่ซ้ำ. ผิด → throw [ตู๋ P1.B].
+ * (ไม่ patch ทีละ slot — caller regen ทั้งชุดถ้าไม่ผ่าน)
+ */
+export function canonicalizeDays(raw: { day: string; fortune: string }[]): DayFortune[] {
+  const map = new Map<string, string>();
+  for (const r of raw) {
+    const f = (r.fortune ?? "").trim().replace(/\s+/g, " ");
+    if (!f) throw new Error(`คำทำนายว่าง: ${r.day}`);
+    map.set(r.day, f.slice(0, MAX_PREDICTION));
+  }
+  return WEEKDAYS.map((day) => {
+    const fortune = map.get(day);
+    if (!fortune) throw new Error(`ขาดวัน/ซ้ำ: ${day} (ต้องครบ 7 วันไม่ซ้ำ)`);
+    return { day, fortune };
+  });
+}
+
+/** schema ที่ model ต้องคืน (structured output) — gen 7 วันทั้งชุดครั้งเดียว */
+const draftGenSchema = z.object({ days: z.array(z.object({ day: z.enum(WEEKDAYS), fortune: z.string() })).length(7) });
+
+const DRAFT_SYSTEM =
+  'คุณคือ "หมอมี่" หมอดูสายฟีลกู้ดน่ารักเป็นกันเอง. เขียน "ดวงรายวัน" ภาพรวมของแต่ละวันเกิด ' +
+  "(จันทร์ อังคาร พุธ พฤหัสบดี ศุกร์ เสาร์ อาทิตย์) ว่าวันนี้โดยรวมเป็นยังไง — สั้นกระชับ 1 ประโยค " +
+  "ต่อวัน ฟันธงชัด ฟีลบวก ครบทั้ง 7 วัน ไม่ซ้ำ. แต่ละวันยาวไม่เกิน ~80 ตัวอักษร.";
+
+/**
+ * gen 7 คำทำนาย overall (1 call) + validate strict ; ไม่ผ่าน → regen ทั้งชุด 1 ครั้งพร้อม feedback →
+ * ยังไม่ผ่าน throw (caller → FAILED) [ตู๋ P1.B]
+ */
+export async function genDaily7Days(targetDate: string): Promise<DayFortune[]> {
+  const label = deriveThaiDateLabel(targetDate);
+  let lastErr = "";
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const system = attempt === 0 ? DRAFT_SYSTEM : `${DRAFT_SYSTEM}\n\n(รอบก่อนไม่ผ่าน: ${lastErr} — แก้ให้ครบ 7 วันไม่ซ้ำ ไม่มีช่องว่าง)`;
+    const obj = await genObject({ schema: draftGenSchema, system, prompt: `วันที่ ${label}: เขียนดวงรายวันภาพรวมครบ 7 วันเกิด` });
+    try {
+      return canonicalizeDays(obj.days);
+    } catch (e) {
+      lastErr = e instanceof Error ? e.message : String(e);
+    }
+  }
+  throw new Error(`gen 7 วันไม่ผ่านกติกาหลัง regen: ${lastErr}`);
+}
 
 const OUT = 1080; // การ์ดสี่เหลี่ยมจัตุรัส (bg pool เป็น 1:1)
 const ROW_H = 88; // ความสูง slot คงที่ → layout golden นิ่งไม่ว่าคำทำนายยาว/สั้น
@@ -73,13 +140,15 @@ export const daily7: CompositionTemplate = {
         'คุณคือ "หมอมี่" หมอดูสายฟีลกู้ด พูดน่ารักเป็นกันเอง (พี่หมี่, ฟีลลิ่ง, ซัพพอร์ต, ปังมาก, แม่). ' +
         "เขียนแคปชั่น Facebook สำหรับ 'ดวงรายวัน 7 วันเกิด' สั้นกระชับ ชวนให้คนมองหา 'วันเกิดของตัวเอง' ในภาพ " +
         "และดูว่าวันนี้ของเขาเป็นยังไง. จบด้วย #ดวงรายวัน #หมอมี่ (CTA link จะถูกเติมให้)",
-      prompt: `วันนี้${d.dateLabel ? ` (${d.dateLabel})` : ""} เปิดดวงครบทั้ง 7 วันเกิด\nเขียนแคปชั่นเชิญชวน:`,
+      prompt: `วันที่ ${deriveThaiDateLabel(d.targetDate)} เปิดดวงครบทั้ง 7 วันเกิด\nเขียนแคปชั่นเชิญชวน:`,
     };
   },
   async renderImage(data, ctx: RenderContext): Promise<Uint8Array> {
     const d = daily7Schema.parse(data);
-    const { bytes } = loadBackgroundForSeed(ctx.seed);
+    // by-id (finalized) → ผลคงที่ถาวร ปลดล็อกขยาย pool ; ไม่มี id → fallback seed hash (S6b path)
+    const { bytes } = d.backgroundId ? loadBackgroundById(d.backgroundId) : loadBackgroundForSeed(ctx.seed);
     const bgUri = `data:image/png;base64,${Buffer.from(bytes).toString("base64")}`;
+    const dateLabel = deriveThaiDateLabel(d.targetDate);
 
     const byDay = new Map(d.days.map((x) => [x.day, x.fortune] as const));
     const rows = WEEKDAYS.map((day) => ({ day, color: DAY_COLOR[day], fortune: truncate(byDay.get(day) ?? "", MAX_FORTUNE) }));
@@ -95,7 +164,7 @@ export const daily7: CompositionTemplate = {
             {/* title panel */}
             <div style={{ display: "flex", flexDirection: "column", alignSelf: "flex-start", backgroundColor: "rgba(74,44,90,0.82)", borderRadius: 22, padding: "16px 26px", marginBottom: 18 }}>
               <div style={{ display: "flex", fontSize: 44, fontWeight: 700, color: "#FFFFFF" }}>ดวงรายวัน 7 วันเกิด</div>
-              {d.dateLabel ? <div style={{ display: "flex", fontSize: 24, color: "#FFD9F0", marginTop: 4 }}>{d.dateLabel}</div> : null}
+              <div style={{ display: "flex", fontSize: 24, color: "#FFD9F0", marginTop: 4 }}>{dateLabel}</div>
             </div>
 
             {/* 7 day rows (ซ้าย) — fixed geometry กัน worst-case Thai ไม่มี space ล้น panel [ตู๋ P1]:


### PR DESCRIPTION
## สร้างอะไร
backend ของ **S6c — ปิด daily-7 ให้ครบ**: draft prep + แก้ + regen + finalize → สร้าง contentPost.
ต่อจาก S6b (renderer). flow:

`สร้าง draft → gen 7 คำทำนาย overall (Gemini) → ฟีมแก้ได้ → finalize (เลือก bg) → contentPost (PENDING)`

(edit UI เต็ม = S6c.2 ต่อไป — PR นี้คือ backend + dev playground ที่ปรับ targetDate)

## ตาม guardrails ตู๋ (design review S6c)
- **(A) table แยก** `content_drafts` (migration 0005) — mutable workspace, **ไม่ปน** contentPosts state machine. finalize = atomic snapshot → contentPost. **double-finalize กัน 3 ชั้น**: finalizeKey replay + `contentPostId IS NULL` guard + `contentPosts.requestKey` unique (`draft:<id>`)
- **(B) gen 7 strict** — structured output (`genObject`) + `canonicalizeDays` (ครบ7/ไม่ซ้ำ/เรียง/trim) ; ไม่ผ่าน → regen **ทั้งชุด** 1 ครั้ง → FAILED (ไม่ patch ทีละ slot)
- **(C) targetDate** (ISO, freeze Asia/Bangkok ตอนสร้าง — ไม่ derive ใหม่ทุก retry) ; FinalInput เก็บ targetDate, **renderer derive Thai dateLabel เอง** deterministic ; scheduler execution park S4b
- **(D) concurrency** — `revision` optimistic lock + `generationToken` (เขียนกลับเฉพาะ token+state ตรง → กัน stale regen ทับ user edits) + `attemptKey` (regen idempotency แยกจาก requestKey retry) ; stale GENERATING lease ยึดต่อได้ (กัน stuck)
- **bg** — finalize validate `backgroundId` ใน manifest → persist → renderer **by-id** (ปลดล็อกขยาย pool) ; ไม่มี id → fallback seed hash

## APIs
`POST /api/daily/draft` · `PATCH /:id` · `POST /:id/regenerate` · `POST /:id/finalize`
(idempotency: requestKey / attemptKey / finalizeKey แยกหน้าที่ ; mutate ทุกครั้งผ่าน optimistic revision)

## ควรตรวจเป็นพิเศษ
- `content-creator/db/drafts.ts` — lifecycle + concurrency (หัวใจ) : claimRegen stale-lease, finalize transaction
- `content-creator/daily7-service.ts` — gen regen-once→FAILED, finalize strict validate
- targetDate freeze semantics (ข้ามเที่ยงคืน) + by-id render

## Verify
- tsc 0 · vitest **196 passed** — drafts lifecycle 18 + service 7 **adversarial** (stale-regen overwrite ไม่ทับ user edit, double-finalize, optimistic revision mismatch, finalize incomplete→reject)
- next build compiled
- **ยิง endpoint จริงผ่าน dev (Gemini gen 7 จริง)**: create→READY (ภาษาหมอมี่), retry→idempotent (ไม่ gen ซ้ำ), payload-ต่าง→409, finalize→contentPost PENDING, double-finalize→409 · render by-id ออก PNG 1080 จริง

## ยังไม่อยู่ใน PR นี้ (S6c.2)
edit UI เต็ม (wire playground → load draft/regen/finalize + bg picker) · S4b scheduler (date tension)

🤖 ตอบโดย goo จาก [ฟีม] → goo-oracle