### PR TITLE
S4b: scheduler/auto-publish (reconcile loop + per-day fence)

### DIFF
--- a/app/content-creator/api/daily/status/route.ts
+++ b/app/content-creator/api/daily/status/route.ts
@@ -26,6 +26,8 @@ export async function GET() {
   // เพิ่งถูก auto-cancel เพราะเลยวัน (24 ชม.ล่าสุด) — surface ให้ฟีมรู้ว่าพลาดโพสต์
   const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000);
   const staleCanceled = count(and(eq(contentPosts.templateId, DAILY7), eq(contentPosts.status, "CANCELED"), sql`${td} < ${today}`, gte(contentPosts.updatedAt, cutoff)));
+  // PUBLISHING ค้าง = ambiguous (worker ตายหลังยิง feed) → ต้อง reconcile มือ [S4b ตู๋ P1]
+  const stuckPublishing = count(and(eq(contentPosts.templateId, DAILY7), eq(contentPosts.status, "PUBLISHING")));
 
-  return NextResponse.json({ ok: true, today, posted: posted > 0, pending, staleCanceled });
+  return NextResponse.json({ ok: true, today, posted: posted > 0, pending, staleCanceled, stuckPublishing });
 }

--- a/app/content-creator/api/daily/status/route.ts
+++ b/app/content-creator/api/daily/status/route.ts
@@ -1,0 +1,31 @@
+/**
+ * GET /content-creator/api/daily/status — สถานะ daily-7 ของวันนี้ (สำหรับ modal แจ้งเตือน) [S4b]
+ * { today, posted (โพสต์วันนี้แล้ว?), pending (APPROVED รอโพสต์วันนี้), staleCanceled (เพิ่งถูก auto-cancel) }
+ */
+import { NextResponse } from "next/server";
+import { and, eq, gte, sql, type SQL } from "drizzle-orm";
+import { getContentDb } from "@/content-creator/db/client";
+import { contentPosts } from "@/content-creator/db/schema";
+import { isContentCreatorEnabled } from "@/content-creator/lib/enabled";
+import { bangkokTodayISO } from "@/content-creator/lib/time";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const DAILY7 = "daily-7";
+const td = sql`json_extract(${contentPosts.inputData}, '$.targetDate')`;
+
+export async function GET() {
+  if (!isContentCreatorEnabled()) return new NextResponse(null, { status: 404 });
+  const db = getContentDb();
+  const today = bangkokTodayISO();
+  const count = (where: SQL | undefined) => db.select({ id: contentPosts.id }).from(contentPosts).where(where).all().length;
+
+  const posted = count(and(eq(contentPosts.templateId, DAILY7), eq(contentPosts.status, "POSTED"), sql`${td} = ${today}`));
+  const pending = count(and(eq(contentPosts.templateId, DAILY7), eq(contentPosts.status, "APPROVED"), sql`${td} = ${today}`));
+  // เพิ่งถูก auto-cancel เพราะเลยวัน (24 ชม.ล่าสุด) — surface ให้ฟีมรู้ว่าพลาดโพสต์
+  const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const staleCanceled = count(and(eq(contentPosts.templateId, DAILY7), eq(contentPosts.status, "CANCELED"), sql`${td} < ${today}`, gte(contentPosts.updatedAt, cutoff)));
+
+  return NextResponse.json({ ok: true, today, posted: posted > 0, pending, staleCanceled });
+}

--- a/app/content-creator/api/publish/route.ts
+++ b/app/content-creator/api/publish/route.ts
@@ -1,25 +1,14 @@
 /**
- * POST /content-creator/api/publish — เผยแพร่โพสต์ขึ้น Facebook เพจจริง (manual) [S4a]
- * body: { id } → claimForPublish (APPROVED→PUBLISHING) → upload media → publishToFeed → markPosted
- *
- * Carry-forward gates (ตู๋):
- *  - publishToFeed ล้ม = AMBIGUOUS (อาจโพสต์แล้ว response หาย) → **ไม่ releaseClaim** คง PUBLISHING
- *    ให้ reconcile มือ (กันโพสต์ซ้ำ) — ห้าม auto-release→APPROVED
- *  - ล้มก่อน publish (อ่าน image/upload) = ยังไม่โพสต์ → release→APPROVED ปลอดภัย (retry ได้)
- *  - mediaFbid reuse: upload สำเร็จแล้วเก็บไว้ → retry ไม่ upload ซ้ำ
+ * POST /content-creator/api/publish — เผยแพร่ขึ้น Facebook (manual) [S4a→S4b]
+ * body: { id } → publishApprovedPost (shared policy เดียวกับ scheduler [ตู๋ P1] ไม่ bypass)
+ * นโยบาย (staleness guard / per-day fence / point-of-no-return) อยู่ใน publish-service
  */
 import { NextResponse } from "next/server";
-import { readFileSync } from "node:fs";
-import { basename } from "node:path";
-import { and, eq } from "drizzle-orm";
-import { z } from "zod";
 import { getContentDb } from "@/content-creator/db/client";
-import { contentPosts } from "@/content-creator/db/schema";
-import { claimForPublish, markPosted, releaseClaim } from "@/content-creator/db/transition";
-import { uploadUnpublishedPhoto, publishToFeed } from "@/content-creator/lib/facebook";
-import { safeResolveUnderRoot } from "@/content-creator/lib/safe-path";
 import { isContentCreatorEnabled } from "@/content-creator/lib/enabled";
 import { fbPageId, fbPageToken } from "@/content-creator/lib/config";
+import { publishApprovedPost } from "@/content-creator/publish-service";
+import { z } from "zod";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -42,76 +31,14 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: false, error: "FB env ไม่ครบ (CONTENT_FB_PAGE_ID/ACCESS_TOKEN)" }, { status: 500 });
   }
 
-  const db = getContentDb();
-  // preflight ก่อน claim — เช็ค row พร้อมจริง (กัน claim แล้วติด)
-  const row = db.select().from(contentPosts).where(eq(contentPosts.id, body.id)).get();
-  if (!row) return NextResponse.json({ ok: false, error: "ไม่พบโพสต์" }, { status: 404 });
-  if (row.status !== "APPROVED") {
-    return NextResponse.json({ ok: false, error: `ต้องเป็น APPROVED ก่อน publish (ปัจจุบัน ${row.status})` }, { status: 409 });
-  }
-  if (!row.caption || !row.imagePath) {
-    return NextResponse.json({ ok: false, error: "โพสต์ไม่มี caption/image" }, { status: 409 });
-  }
+  const res = await publishApprovedPost(getContentDb(), body.id, { pageId, token });
+  if (res.ok) return NextResponse.json({ ok: true, status: res.status, fbPostId: res.fbPostId }, { status: 200 });
 
-  // claim atomic (APPROVED→PUBLISHING) — worker เดียวยิง FB กัน concurrent post ซ้ำ
-  if (!claimForPublish(db, body.id)) {
-    return NextResponse.json({ ok: false, error: "claim ไม่ได้ (อาจถูกยิงอยู่/ไม่ใช่ APPROVED)" }, { status: 409 });
-  }
-
-  // ===== UPLOAD phase — ยังไม่โพสต์ → ล้มได้ release→APPROVED ปลอดภัย (retry) =====
-  let mediaFbid = row.mediaFbid;
-  if (!mediaFbid) {
-    try {
-      // อ่าน image ผ่าน util เดียวกัน (path-safe) — root=media dir, basename(imagePath)
-      const mediaDir = process.env.CONTENT_MEDIA_DIR || "content-creator/media";
-      const real = safeResolveUnderRoot(mediaDir, basename(row.imagePath));
-      if (!real) throw new Error(`image path ไม่ปลอดภัย/ไม่พบ: ${row.imagePath}`);
-      const bytes = new Uint8Array(readFileSync(real));
-      mediaFbid = await uploadUnpublishedPhoto({ pageId, token, bytes }); // published=false (ยังไม่โผล่)
-      // [ตู๋ P2] conditional update ต้อง changes===1 — ยืนยัน ownership (เรายัง hold PUBLISHING)
-      const upd = db
-        .update(contentPosts)
-        .set({ mediaFbid, updatedAt: new Date() })
-        .where(and(eq(contentPosts.id, body.id), eq(contentPosts.status, "PUBLISHING")))
-        .run();
-      if (upd.changes !== 1) throw new Error("ownership lost: mediaFbid update ไม่สำเร็จ (status ไม่ใช่ PUBLISHING)");
-    } catch (upErr) {
-      releaseClaim(db, body.id, "APPROVED"); // ยังไม่โพสต์ → retry ปลอดภัย
-      return NextResponse.json({ ok: false, error: upErr instanceof Error ? upErr.message : String(upErr) }, { status: 502 });
-    }
-  }
-
-  // ===== POINT OF NO RETURN — หลังเริ่ม POST /feed "ห้าม release" (อาจโพสต์ขึ้นเพจแล้ว) [ตู๋ P1] =====
-  let postId: string;
-  try {
-    postId = await publishToFeed({ pageId, token, mediaFbid, message: row.caption }); // lib maxRetries:0 กันซ้ำ
-  } catch (pubErr) {
-    // AMBIGUOUS — อาจโพสต์สำเร็จแล้ว response หาย → คง PUBLISHING ไม่ release (กันโพสต์ซ้ำ)
-    return NextResponse.json(
-      {
-        ok: false,
-        ambiguous: true,
-        status: "PUBLISHING",
-        error: `publish กำกวม — เช็คเพจว่าขึ้นไหม. ค้าง PUBLISHING (ไม่ release กันโพสต์ซ้ำ) reconcile มือ: ${pubErr instanceof Error ? pubErr.message : String(pubErr)}`,
-      },
-      { status: 502 },
-    );
-  }
-
-  // publishToFeed สำเร็จ = โพสต์ขึ้นเพจแล้ว → persist ; ถ้า DB ล้ม "ห้าม release/retry" (จะโพสต์ซ้ำ) [ตู๋ P1]
-  try {
-    markPosted(db, body.id, postId); // PUBLISHING→POSTED + fbPostId
-  } catch (persistErr) {
-    return NextResponse.json(
-      {
-        ok: false,
-        ambiguous: true,
-        status: "PUBLISHING",
-        fbPostId: postId,
-        error: `โพสต์ขึ้นเพจแล้ว (fbPostId=${postId}) แต่บันทึก DB ล้ม — reconcile: set POSTED มือ. ห้าม retry publish (จะซ้ำ): ${persistErr instanceof Error ? persistErr.message : String(persistErr)}`,
-      },
-      { status: 502 },
-    );
-  }
-  return NextResponse.json({ ok: true, status: "POSTED", fbPostId: postId });
+  // map outcome → HTTP (shared policy)
+  const httpByStatus = { SKIPPED: 409, STALE: 409, RETRYABLE: 502, AMBIGUOUS: 502 } as const;
+  const ambiguous = res.status === "AMBIGUOUS";
+  return NextResponse.json(
+    { ok: false, status: ambiguous ? "PUBLISHING" : res.status, ambiguous: ambiguous || undefined, fbPostId: res.fbPostId, error: res.reason },
+    { status: res.reason.includes("ไม่พบ") ? 404 : httpByStatus[res.status] },
+  );
 }

--- a/app/content-creator/page.tsx
+++ b/app/content-creator/page.tsx
@@ -36,13 +36,13 @@ export default function ContentCreatorPage() {
   const [error, setError] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
   // daily-7 scheduler status (modal/banner แจ้งเตือน) [S4b]
-  const [d7, setD7] = useState<{ today: string; posted: boolean; pending: number; staleCanceled: number } | null>(null);
+  const [d7, setD7] = useState<{ today: string; posted: boolean; pending: number; staleCanceled: number; stuckPublishing: number } | null>(null);
   const [d7Dismissed, setD7Dismissed] = useState(false);
 
   useEffect(() => {
     fetch("/content-creator/api/daily/status", { cache: "no-store" })
       .then((r) => (r.ok ? r.json() : null))
-      .then((d) => d?.ok && setD7({ today: d.today, posted: d.posted, pending: d.pending, staleCanceled: d.staleCanceled }))
+      .then((d) => d?.ok && setD7({ today: d.today, posted: d.posted, pending: d.pending, staleCanceled: d.staleCanceled, stuckPublishing: d.stuckPublishing }))
       .catch(() => {});
   }, []);
 
@@ -146,9 +146,10 @@ export default function ContentCreatorPage() {
       </header>
 
       {/* daily-7 scheduler modal/banner — ปิดทิ้งได้ [S4b] */}
-      {d7 && !d7Dismissed && (d7.staleCanceled > 0 || (!d7.posted && d7.pending === 0)) && (
+      {d7 && !d7Dismissed && (d7.staleCanceled > 0 || d7.stuckPublishing > 0 || (!d7.posted && d7.pending === 0)) && (
         <div className="mb-4 flex items-start justify-between gap-3 rounded-lg bg-amber-50 px-4 py-3 text-sm text-amber-800">
           <div>
+            {d7.stuckPublishing > 0 && <div>🛑 มี daily-7 {d7.stuckPublishing} โพสต์ค้าง PUBLISHING (อาจขึ้นเพจแล้ว) — เช็คเพจ + reconcile มือ ห้าม publish ซ้ำ</div>}
             {d7.staleCanceled > 0 && <div>⚠️ มี daily-7 {d7.staleCanceled} โพสต์ถูกยกเลิก (เลยวันแล้ว — scheduler ไม่โพสต์ของผิดวัน)</div>}
             {!d7.posted && d7.pending === 0 && <div>📭 วันนี้ ({d7.today}) ยังไม่มี daily-7 ในคิว — สร้าง+approve เพื่อให้ scheduler โพสต์</div>}
           </div>

--- a/app/content-creator/page.tsx
+++ b/app/content-creator/page.tsx
@@ -35,6 +35,16 @@ export default function ContentCreatorPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
+  // daily-7 scheduler status (modal/banner แจ้งเตือน) [S4b]
+  const [d7, setD7] = useState<{ today: string; posted: boolean; pending: number; staleCanceled: number } | null>(null);
+  const [d7Dismissed, setD7Dismissed] = useState(false);
+
+  useEffect(() => {
+    fetch("/content-creator/api/daily/status", { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => d?.ok && setD7({ today: d.today, posted: d.posted, pending: d.pending, staleCanceled: d.staleCanceled }))
+      .catch(() => {});
+  }, []);
 
   const load = useCallback(async () => {
     setError(null);
@@ -134,6 +144,17 @@ export default function ContentCreatorPage() {
           </button>
         </div>
       </header>
+
+      {/* daily-7 scheduler modal/banner — ปิดทิ้งได้ [S4b] */}
+      {d7 && !d7Dismissed && (d7.staleCanceled > 0 || (!d7.posted && d7.pending === 0)) && (
+        <div className="mb-4 flex items-start justify-between gap-3 rounded-lg bg-amber-50 px-4 py-3 text-sm text-amber-800">
+          <div>
+            {d7.staleCanceled > 0 && <div>⚠️ มี daily-7 {d7.staleCanceled} โพสต์ถูกยกเลิก (เลยวันแล้ว — scheduler ไม่โพสต์ของผิดวัน)</div>}
+            {!d7.posted && d7.pending === 0 && <div>📭 วันนี้ ({d7.today}) ยังไม่มี daily-7 ในคิว — สร้าง+approve เพื่อให้ scheduler โพสต์</div>}
+          </div>
+          <button onClick={() => setD7Dismissed(true)} className="shrink-0 rounded px-2 text-amber-600 hover:bg-amber-100">✕</button>
+        </div>
+      )}
 
       {error && (
         <div className="mb-4 rounded-lg bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>

--- a/content-creator/__tests__/publish-service.test.ts
+++ b/content-creator/__tests__/publish-service.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const mockUpload = vi.hoisted(() => vi.fn());
+const mockPublish = vi.hoisted(() => vi.fn());
+vi.mock("../lib/facebook", () => ({ uploadUnpublishedPhoto: mockUpload, publishToFeed: mockPublish }));
+
+import { eq } from "drizzle-orm";
+import { createContentDb, type ContentDb } from "../db/client";
+import { contentPosts } from "../db/schema";
+import { publishApprovedPost } from "../publish-service";
+
+const TODAY = "2026-06-16";
+const deps = { pageId: "p", token: "t", today: TODAY };
+
+let db: ContentDb;
+let n = 0;
+beforeEach(() => {
+  db = createContentDb(":memory:");
+  mockUpload.mockReset().mockResolvedValue("media-1");
+  mockPublish.mockReset().mockResolvedValue("post-1");
+  n = 0;
+});
+
+function approvedDaily7(targetDate: string, opts: { mediaFbid?: string | null } = {}): string {
+  const id = `d7-${n++}`;
+  db.insert(contentPosts)
+    .values({ id, templateId: "daily-7", inputData: { targetDate, days: [] }, status: "APPROVED", caption: "cap", imagePath: "/m/y.png", mediaFbid: opts.mediaFbid === undefined ? "m1" : opts.mediaFbid })
+    .run();
+  return id;
+}
+const statusOf = (id: string) => db.select().from(contentPosts).where(eq(contentPosts.id, id)).get()?.status;
+
+describe("publish-service — per-day fence + point-of-no-return [S4b ตู๋ P1]", () => {
+  it("two rows same day → row 2 SKIPPED (per-day fence) ; ยิง FB ครั้งเดียว", async () => {
+    const a = approvedDaily7(TODAY);
+    const b = approvedDaily7(TODAY);
+    const r1 = await publishApprovedPost(db, a, deps);
+    const r2 = await publishApprovedPost(db, b, deps);
+    expect(r1.status).toBe("POSTED");
+    expect(r2.status).toBe("SKIPPED"); // fence ชน (a อยู่ POSTED วันเดียวกัน)
+    expect(mockPublish).toHaveBeenCalledTimes(1);
+    expect(statusOf(b)).toBe("APPROVED"); // b ไม่ถูกแตะ (claim ไม่ผ่าน fence)
+  });
+
+  it("two workers same row → ครั้งที่ 2 SKIPPED (ไม่โพสต์ซ้ำ)", async () => {
+    const a = approvedDaily7(TODAY);
+    const r1 = await publishApprovedPost(db, a, deps);
+    const r2 = await publishApprovedPost(db, a, deps);
+    expect(r1.status).toBe("POSTED");
+    expect(r2.status).toBe("SKIPPED"); // ไม่ใช่ APPROVED แล้ว
+    expect(mockPublish).toHaveBeenCalledTimes(1);
+  });
+
+  it("staleness: targetDate เลยวัน → STALE ไม่ claim/ไม่ยิง FB", async () => {
+    const r = await publishApprovedPost(db, approvedDaily7("2026-06-15"), deps);
+    expect(r.status).toBe("STALE");
+    expect(mockPublish).not.toHaveBeenCalled();
+  });
+
+  it("future targetDate → STALE (no-op)", async () => {
+    const r = await publishApprovedPost(db, approvedDaily7("2026-06-17"), deps);
+    expect(r.status).toBe("STALE");
+    expect(mockPublish).not.toHaveBeenCalled();
+  });
+
+  it("pre-feed fail (upload) → RETRYABLE + release→APPROVED (ยังไม่ยิง FB)", async () => {
+    const a = approvedDaily7(TODAY, { mediaFbid: null }); // ต้อง upload → safeResolve หาไฟล์ไม่เจอ → throw ก่อนยิง feed
+    const r = await publishApprovedPost(db, a, deps);
+    expect(r.status).toBe("RETRYABLE");
+    expect(statusOf(a)).toBe("APPROVED"); // release กลับ retry ได้
+    expect(mockPublish).not.toHaveBeenCalled();
+  });
+
+  it("post-feed ambiguous (publishToFeed throw) → AMBIGUOUS คง PUBLISHING (ห้าม release/retry)", async () => {
+    mockPublish.mockRejectedValueOnce(new Error("network timeout"));
+    const a = approvedDaily7(TODAY);
+    const r = await publishApprovedPost(db, a, deps);
+    expect(r.status).toBe("AMBIGUOUS");
+    expect(statusOf(a)).toBe("PUBLISHING"); // ไม่ release (กันโพสต์ซ้ำ)
+  });
+
+  it("ไม่ใช่ APPROVED → SKIPPED", async () => {
+    const id = "g1";
+    db.insert(contentPosts).values({ id, templateId: "daily-7", inputData: { targetDate: TODAY }, status: "GENERATED", caption: "c", imagePath: "/m/y.png" }).run();
+    expect((await publishApprovedPost(db, id, deps)).status).toBe("SKIPPED");
+  });
+});

--- a/content-creator/__tests__/scheduler.test.ts
+++ b/content-creator/__tests__/scheduler.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 const mockUpload = vi.hoisted(() => vi.fn());
 const mockPublish = vi.hoisted(() => vi.fn());
@@ -7,7 +7,8 @@ vi.mock("../lib/facebook", () => ({ uploadUnpublishedPhoto: mockUpload, publishT
 import { eq } from "drizzle-orm";
 import { createContentDb, type ContentDb } from "../db/client";
 import { contentPosts } from "../db/schema";
-import { runSchedulerTick, type ScheduleConfig } from "../scheduler";
+import { runSchedulerTick, getScheduleConfig, type ScheduleConfig } from "../scheduler";
+import { reconcileStuckPublishing } from "../db/transition";
 
 const FULL: ScheduleConfig = { days: [0, 1, 2, 3, 4, 5, 6], slots: ["09:00"] };
 const deps = (now: string, config: ScheduleConfig = FULL) => ({ pageId: "p", token: "t", config, now: new Date(now) });
@@ -85,5 +86,72 @@ describe("scheduler reconcile tick [S4b]", () => {
     expect(r.window).toBe("open");
     expect(r.published).toBeUndefined();
     expect(r.note).toContain("ว่าง");
+  });
+});
+
+// insert PUBLISHING row ที่ค้าง (จำลอง worker ตาย) — คุม publishStartedAt + feedAttemptedAt
+function stuckPublishing(targetDate: string, opts: { feedAttempted: boolean; startedAgoMs: number }): string {
+  const id = `pub-${n++}`;
+  db.insert(contentPosts).values({
+    id, templateId: "daily-7", inputData: { targetDate, days: [] }, status: "PUBLISHING", caption: "cap", imagePath: "/m/y.png", mediaFbid: "m1",
+    publishStartedAt: new Date(Date.now() - opts.startedAgoMs), feedAttemptedAt: opts.feedAttempted ? new Date(Date.now() - opts.startedAgoMs) : null,
+  }).run();
+  return id;
+}
+
+describe("reconcile stuck PUBLISHING [S4b ตู๋ P1]", () => {
+  const CUTOFF = () => new Date(Date.now() - 10 * 60 * 1000); // 10 นาที
+
+  it("worker dies BEFORE feed (pre-PONR) + lease หมดอายุ → release APPROVED (retry ได้)", () => {
+    const id = stuckPublishing("2026-06-16", { feedAttempted: false, startedAgoMs: 20 * 60 * 1000 });
+    expect(reconcileStuckPublishing(db, CUTOFF())).toBe(1);
+    expect(statusOf(id)).toBe("APPROVED");
+  });
+
+  it("worker dies AFTER feed-start (post-PONR) → ไม่ release คง PUBLISHING (ambiguous, ห้าม retry)", () => {
+    const id = stuckPublishing("2026-06-16", { feedAttempted: true, startedAgoMs: 20 * 60 * 1000 });
+    expect(reconcileStuckPublishing(db, CUTOFF())).toBe(0);
+    expect(statusOf(id)).toBe("PUBLISHING"); // คงไว้ surface/manual
+  });
+
+  it("PUBLISHING ยังไม่หมดอายุ (fresh claim) → ไม่แตะ", () => {
+    const id = stuckPublishing("2026-06-16", { feedAttempted: false, startedAgoMs: 60 * 1000 }); // 1 นาที
+    expect(reconcileStuckPublishing(db, CUTOFF())).toBe(0);
+    expect(statusOf(id)).toBe("PUBLISHING");
+  });
+
+  it("integration: tick reconcile pre-PONR stuck → release → publish ในรอบเดียว (resume)", async () => {
+    const id = stuckPublishing("2026-06-16", { feedAttempted: false, startedAgoMs: 20 * 60 * 1000 });
+    const r = await runSchedulerTick(db, deps(AFTER_SLOT));
+    expect(r.reclaimedStuck).toBe(1);
+    expect(r.published?.id).toBe(id);
+    expect(statusOf(id)).toBe("POSTED");
+  });
+});
+
+describe("getScheduleConfig fail-closed [ตู๋ P1.2]", () => {
+  const save = { d: process.env.CONTENT_SCHEDULE_DAYS, s: process.env.CONTENT_SCHEDULE_SLOTS };
+  const restore = (k: "CONTENT_SCHEDULE_DAYS" | "CONTENT_SCHEDULE_SLOTS", v: string | undefined) => {
+    if (v === undefined) delete process.env[k]; else process.env[k] = v; // กัน assign undefined → string "undefined"
+  };
+  afterEach(() => { restore("CONTENT_SCHEDULE_DAYS", save.d); restore("CONTENT_SCHEDULE_SLOTS", save.s); });
+
+  it("slot ผิดรูป → throw (ไม่ fail-open โพสต์ผิดเวลา)", () => {
+    process.env.CONTENT_SCHEDULE_SLOTS = "bad";
+    expect(() => getScheduleConfig()).toThrow(/SCHEDULE_SLOTS/);
+  });
+  it("slot นอกช่วง 25:99 → throw", () => {
+    process.env.CONTENT_SCHEDULE_SLOTS = "25:99";
+    expect(() => getScheduleConfig()).toThrow(/SCHEDULE_SLOTS/);
+  });
+  it("days ผิด → throw", () => {
+    process.env.CONTENT_SCHEDULE_SLOTS = "09:00";
+    process.env.CONTENT_SCHEDULE_DAYS = "9";
+    expect(() => getScheduleConfig()).toThrow(/SCHEDULE_DAYS/);
+  });
+  it("valid → ผ่าน", () => {
+    process.env.CONTENT_SCHEDULE_SLOTS = "09:00,13:30";
+    process.env.CONTENT_SCHEDULE_DAYS = "1,2,3";
+    expect(getScheduleConfig()).toEqual({ days: [1, 2, 3], slots: ["09:00", "13:30"] });
   });
 });

--- a/content-creator/__tests__/scheduler.test.ts
+++ b/content-creator/__tests__/scheduler.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const mockUpload = vi.hoisted(() => vi.fn());
+const mockPublish = vi.hoisted(() => vi.fn());
+vi.mock("../lib/facebook", () => ({ uploadUnpublishedPhoto: mockUpload, publishToFeed: mockPublish }));
+
+import { eq } from "drizzle-orm";
+import { createContentDb, type ContentDb } from "../db/client";
+import { contentPosts } from "../db/schema";
+import { runSchedulerTick, type ScheduleConfig } from "../scheduler";
+
+const FULL: ScheduleConfig = { days: [0, 1, 2, 3, 4, 5, 6], slots: ["09:00"] };
+const deps = (now: string, config: ScheduleConfig = FULL) => ({ pageId: "p", token: "t", config, now: new Date(now) });
+// Bangkok = UTC+7
+const AFTER_SLOT = "2026-06-16T05:00:00Z"; // Bangkok 12:00 16 มิ.ย.
+const BEFORE_SLOT = "2026-06-16T01:00:00Z"; // Bangkok 08:00 16 มิ.ย.
+const MIDNIGHT_CROSS = "2026-06-15T17:30:00Z"; // Bangkok 00:30 16 มิ.ย. (UTC ยังเป็น 15)
+
+let db: ContentDb;
+let n = 0;
+beforeEach(() => {
+  db = createContentDb(":memory:");
+  mockUpload.mockReset().mockResolvedValue("media-1");
+  mockPublish.mockReset().mockResolvedValue("post-1");
+  n = 0;
+});
+function approved(targetDate: string): string {
+  const id = `d7-${n++}`;
+  db.insert(contentPosts).values({ id, templateId: "daily-7", inputData: { targetDate, days: [] }, status: "APPROVED", caption: "cap", imagePath: "/m/y.png", mediaFbid: "m1" }).run();
+  return id;
+}
+const statusOf = (id: string) => db.select().from(contentPosts).where(eq(contentPosts.id, id)).get()?.status;
+
+describe("scheduler reconcile tick [S4b]", () => {
+  it("window closed-time: ก่อนเวลา slot → ไม่โพสต์ (แต่ยัง auto-cancel)", async () => {
+    approved("2026-06-16");
+    const r = await runSchedulerTick(db, deps(BEFORE_SLOT));
+    expect(r.window).toBe("closed-time");
+    expect(mockPublish).not.toHaveBeenCalled();
+  });
+
+  it("window closed-day: วันนี้ไม่อยู่ใน schedule days → ไม่โพสต์", async () => {
+    approved("2026-06-16");
+    const r = await runSchedulerTick(db, deps(AFTER_SLOT, { days: [], slots: ["09:00"] }));
+    expect(r.window).toBe("closed-day");
+    expect(mockPublish).not.toHaveBeenCalled();
+  });
+
+  it("open + มี daily-7 วันนี้ → โพสต์", async () => {
+    const a = approved("2026-06-16");
+    const r = await runSchedulerTick(db, deps(AFTER_SLOT));
+    expect(r.published).toEqual({ id: a, status: "POSTED" });
+    expect(statusOf(a)).toBe("POSTED");
+  });
+
+  it("catch-up idempotent: tick 2 รอบ → โพสต์ครั้งเดียว (worker ตื่นซ้ำไม่ซ้ำ)", async () => {
+    approved("2026-06-16");
+    await runSchedulerTick(db, deps(AFTER_SLOT));
+    const r2 = await runSchedulerTick(db, deps(AFTER_SLOT));
+    expect(mockPublish).toHaveBeenCalledTimes(1);
+    expect(r2.published?.status ?? r2.note).toBeDefined(); // รอบ 2 ไม่มี APPROVED วันนี้แล้ว (โพสต์ไป) → ว่าง
+  });
+
+  it("auto-cancel stale atomic: targetDate เลยวัน → CANCELED ; ของวันนี้ไม่โดน", async () => {
+    const stale = approved("2026-06-15");
+    const todayPost = approved("2026-06-16");
+    const r = await runSchedulerTick(db, deps(AFTER_SLOT));
+    expect(r.canceledStale).toBe(1);
+    expect(statusOf(stale)).toBe("CANCELED");
+    expect(statusOf(todayPost)).not.toBe("CANCELED"); // โพสต์/APPROVED
+  });
+
+  it("bangkok-midnight: UTC ยัง 15 แต่ Bangkok เป็น 16 → today=16, ของ 15 stale-cancel (พิสูจน์เส้นวัน Bangkok ไม่ใช่ UTC)", async () => {
+    const d15 = approved("2026-06-15");
+    const d16 = approved("2026-06-16");
+    const r = await runSchedulerTick(db, deps(MIDNIGHT_CROSS));
+    expect(r.today).toBe("2026-06-16"); // เส้นวัน Bangkok (ถ้าใช้ UTC จะเป็น 06-15)
+    expect(statusOf(d15)).toBe("CANCELED"); // < bangkok-today → stale (ถ้า UTC: 15==today จะไม่ cancel — พิสูจน์ Bangkok)
+    expect(statusOf(d16)).toBe("APPROVED"); // ยังไม่ stale + Bangkok 00:30 < slot 09:00 → ยังไม่โพสต์
+    expect(r.window).toBe("closed-time");
+  });
+
+  it("คิวว่าง: open แต่ไม่มี daily-7 วันนี้ → ไม่โพสต์ (note ว่าง)", async () => {
+    const r = await runSchedulerTick(db, deps(AFTER_SLOT));
+    expect(r.window).toBe("open");
+    expect(r.published).toBeUndefined();
+    expect(r.note).toContain("ว่าง");
+  });
+});

--- a/content-creator/db/migrations/0006_daily7_perday_fence.sql
+++ b/content-creator/db/migrations/0006_daily7_perday_fence.sql
@@ -1,0 +1,6 @@
+-- per-day business fence [S4b ตู๋ P1]: daily-7 โพสต์ได้ ≤1 ครั้งต่อ targetDate
+-- row-level claim (APPROVED→PUBLISHING) กันแค่ row เดิมยิงซ้ำ — ไม่กัน "2 row คนละ id วันเดียวกัน".
+-- partial unique index บน json_extract(input_data,'$.targetDate') เฉพาะ daily-7 ที่ PUBLISHING/POSTED
+-- → sqlite enforce atomic: row ที่ 2 วันเดียวกันจะ UPDATE→PUBLISHING ไม่ผ่าน (constraint) → claim ล้ม.
+CREATE UNIQUE INDEX `uniq_daily7_per_day` ON `content_posts` (json_extract(`input_data`, '$.targetDate'))
+WHERE `template_id` = 'daily-7' AND `status` IN ('PUBLISHING', 'POSTED');

--- a/content-creator/db/migrations/0007_clammy_black_tarantula.sql
+++ b/content-creator/db/migrations/0007_clammy_black_tarantula.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `content_posts` ADD `publish_started_at` integer;--> statement-breakpoint
+ALTER TABLE `content_posts` ADD `feed_attempted_at` integer;

--- a/content-creator/db/migrations/meta/0007_snapshot.json
+++ b/content-creator/db/migrations/meta/0007_snapshot.json
@@ -1,0 +1,359 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0167f09c-71e3-41dc-a1e4-ce92f163cef2",
+  "prevId": "fac0062e-f1c7-4088-8ab2-0e6f085c3952",
+  "tables": {
+    "brand_profile": {
+      "name": "brand_profile",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "style_prompt": {
+          "name": "style_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "caption_persona": {
+          "name": "caption_persona",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "ref_image_path": {
+          "name": "ref_image_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_model": {
+          "name": "image_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caption_max_chars": {
+          "name": "caption_max_chars",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 300
+        },
+        "cta_text": {
+          "name": "cta_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "cta_url": {
+          "name": "cta_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "content_drafts": {
+      "name": "content_drafts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_key": {
+          "name": "request_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seed_payload": {
+          "name": "seed_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "draft_data": {
+          "name": "draft_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'GENERATING'"
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "generation_token": {
+          "name": "generation_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generating_at": {
+          "name": "generating_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_key": {
+          "name": "attempt_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finalize_key": {
+          "name": "finalize_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_post_id": {
+          "name": "content_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "content_drafts_request_key_unique": {
+          "name": "content_drafts_request_key_unique",
+          "columns": [
+            "request_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "content_posts": {
+      "name": "content_posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_key": {
+          "name": "request_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_data": {
+          "name": "input_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'PENDING'"
+        },
+        "generation_token": {
+          "name": "generation_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generating_at": {
+          "name": "generating_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_path": {
+          "name": "image_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_fbid": {
+          "name": "media_fbid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fb_post_id": {
+          "name": "fb_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publish_at": {
+          "name": "publish_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publish_started_at": {
+          "name": "publish_started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feed_attempted_at": {
+          "name": "feed_attempted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "content_posts_request_key_unique": {
+          "name": "content_posts_request_key_unique",
+          "columns": [
+            "request_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/content-creator/db/migrations/meta/_journal.json
+++ b/content-creator/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1781505350803,
       "tag": "0005_amusing_risque",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1781600000000,
+      "tag": "0006_daily7_perday_fence",
+      "breakpoints": true
     }
   ]
 }

--- a/content-creator/db/migrations/meta/_journal.json
+++ b/content-creator/db/migrations/meta/_journal.json
@@ -47,8 +47,15 @@
     {
       "idx": 6,
       "version": "6",
-      "when": 1781600000000,
+      "when": 1781550000000,
       "tag": "0006_daily7_perday_fence",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1781582089186,
+      "tag": "0007_clammy_black_tarantula",
       "breakpoints": true
     }
   ]

--- a/content-creator/db/migrations/meta/_journal.json
+++ b/content-creator/db/migrations/meta/_journal.json
@@ -47,14 +47,14 @@
     {
       "idx": 6,
       "version": "6",
-      "when": 1781550000000,
+      "when": 1781600000000,
       "tag": "0006_daily7_perday_fence",
       "breakpoints": true
     },
     {
       "idx": 7,
       "version": "6",
-      "when": 1781582089186,
+      "when": 1781700000000,
       "tag": "0007_clammy_black_tarantula",
       "breakpoints": true
     }

--- a/content-creator/db/schema.ts
+++ b/content-creator/db/schema.ts
@@ -46,6 +46,11 @@ export const contentPosts = sqliteTable("content_posts", {
   fbPostId: text("fb_post_id"),
   /** เวลาที่ตั้งจะโพสต์ */
   publishAt: integer("publish_at", { mode: "timestamp" }),
+  /** เวลาเริ่ม claim PUBLISHING (lease) — reconcile stuck: PUBLISHING เก่าเกิน lease → จัดการ [S4b ตู๋ P1] */
+  publishStartedAt: integer("publish_started_at", { mode: "timestamp" }),
+  /** PONR marker: เวลาเริ่มยิง POST /feed. NULL=pre-PONR (release APPROVED ได้) ; ไม่ NULL=ยิงแล้ว
+   *  (ambiguous — ห้าม auto-release/retry, surface ให้ reconcile มือ) [S4b ตู๋ P1] */
+  feedAttemptedAt: integer("feed_attempted_at", { mode: "timestamp" }),
   createdAt: integer("created_at", { mode: "timestamp" }).notNull().$defaultFn(() => new Date()),
   updatedAt: integer("updated_at", { mode: "timestamp" }).notNull().$defaultFn(() => new Date()),
   postedAt: integer("posted_at", { mode: "timestamp" }),

--- a/content-creator/db/transition.ts
+++ b/content-creator/db/transition.ts
@@ -90,13 +90,27 @@ export function releaseGenerate(db: ContentDb, id: string, token: string): boole
   return res.changes === 1;
 }
 
+/** unique-constraint violation ของ better-sqlite3 (per-day fence ชน) */
+function isUniqueViolation(e: unknown): boolean {
+  const msg = e instanceof Error ? e.message : String(e);
+  return (e as { code?: string })?.code === "SQLITE_CONSTRAINT_UNIQUE" || /UNIQUE constraint failed/i.test(msg);
+}
+
 /**
  * claim โพสต์เพื่อยิง Facebook (APPROVED → PUBLISHING แบบ atomic).
- * คืน true = worker นี้ claim ได้ (ยิง FB ต่อได้คนเดียว); false = worker อื่น claim ไปแล้ว → skip.
- * กัน scheduler concurrent ยิง Facebook ซ้ำ. หลังยิงเสร็จ caller → markPosted/releaseClaim.
+ * คืน true = worker นี้ claim ได้ (ยิง FB ต่อได้คนเดียว); false = claim ไม่ได้ — ได้ 2 กรณี:
+ *   (a) row ไม่ใช่ APPROVED (worker อื่น claim ไป) — changes 0
+ *   (b) per-day fence ชน: daily-7 วันเดียวกันมี row อื่นใน PUBLISHING/POSTED แล้ว → unique index
+ *       violation [S4b ตู๋ P1] (กัน 2 row คนละ id วันเดียวกันโพสต์คู่)
+ * กัน scheduler concurrent + 2 row/วัน ยิง Facebook ซ้ำ. หลังยิงเสร็จ caller → markPosted/releaseClaim.
  */
 export function claimForPublish(db: ContentDb, id: string): boolean {
-  return tryTransition(db, id, "APPROVED", "PUBLISHING");
+  try {
+    return tryTransition(db, id, "APPROVED", "PUBLISHING");
+  } catch (e) {
+    if (isUniqueViolation(e)) return false; // per-day fence ชน → ถือว่า claim ไม่ได้ (วันนี้โพสต์/กำลังโพสต์แล้ว)
+    throw e;
+  }
 }
 
 /** ยิง FB สำเร็จแล้ว: PUBLISHING → POSTED (เก็บ fbPostId + postedAt) */

--- a/content-creator/db/transition.ts
+++ b/content-creator/db/transition.ts
@@ -5,14 +5,14 @@
  *  - กัน bypass state machine + concurrent overwrite
  *  - PUBLISHING claim: worker ที่ claim ได้ (changes 1) คนเดียว ยิง Facebook → กันโพสต์ซ้ำ
  */
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull, lt } from "drizzle-orm";
 import type { ContentDb } from "./client";
 import { contentPosts, type ContentStatus } from "./schema";
 import { assertTransition } from "./state";
 
 /** field ที่อนุญาตให้ set พร้อม transition (ไม่ให้ set status ตรง ๆ — ผ่าน to เท่านั้น) */
 export type TransitionPatch = Partial<
-  Pick<typeof contentPosts.$inferInsert, "caption" | "imagePath" | "mediaFbid" | "fbPostId" | "postedAt" | "publishAt">
+  Pick<typeof contentPosts.$inferInsert, "caption" | "imagePath" | "mediaFbid" | "fbPostId" | "postedAt" | "publishAt" | "publishStartedAt" | "feedAttemptedAt">
 >;
 
 /**
@@ -106,11 +106,46 @@ function isUniqueViolation(e: unknown): boolean {
  */
 export function claimForPublish(db: ContentDb, id: string): boolean {
   try {
-    return tryTransition(db, id, "APPROVED", "PUBLISHING");
+    // set publishStartedAt (lease) + เคลียร์ feedAttemptedAt (fresh claim, ยังไม่ถึง PONR) [S4b ตู๋ P1]
+    return tryTransition(db, id, "APPROVED", "PUBLISHING", { publishStartedAt: new Date(), feedAttemptedAt: null });
   } catch (e) {
     if (isUniqueViolation(e)) return false; // per-day fence ชน → ถือว่า claim ไม่ได้ (วันนี้โพสต์/กำลังโพสต์แล้ว)
     throw e;
   }
+}
+
+/**
+ * PONR marker [S4b ตู๋ P1] — set feedAttemptedAt ก่อนยิง POST /feed (เฉพาะ token ตรง = ยัง PUBLISHING).
+ * หลังจุดนี้ reconcile จะ "ไม่ auto-release" (ambiguous อาจโพสต์แล้ว). @throws ถ้า row ไม่ใช่ PUBLISHING
+ */
+export function markFeedAttempted(db: ContentDb, id: string): void {
+  const res = db
+    .update(contentPosts)
+    .set({ feedAttemptedAt: new Date(), updatedAt: new Date() })
+    .where(and(eq(contentPosts.id, id), eq(contentPosts.status, "PUBLISHING")))
+    .run();
+  if (res.changes !== 1) throw new Error(`markFeedAttempted: row ไม่ใช่ PUBLISHING (id=${id})`);
+}
+
+/**
+ * reconcile stuck PUBLISHING [S4b ตู๋ P1] — worker ตายหลัง claim:
+ *  - pre-PONR (feedAttemptedAt IS NULL) + lease หมดอายุ → release กลับ APPROVED (ยังไม่ยิง retry ปลอดภัย)
+ *  - post-PONR (feedAttemptedAt NOT NULL) → **ไม่แตะ** (ambiguous — คง PUBLISHING ให้ reconcile มือ)
+ * คืนจำนวนที่ release. cutoff = เวลาที่เก่ากว่านี้ถือว่า stuck.
+ */
+export function reconcileStuckPublishing(db: ContentDb, cutoff: Date): number {
+  const res = db
+    .update(contentPosts)
+    .set({ status: "APPROVED", publishStartedAt: null, updatedAt: new Date() })
+    .where(
+      and(
+        eq(contentPosts.status, "PUBLISHING"),
+        isNull(contentPosts.feedAttemptedAt), // pre-PONR เท่านั้น (ยังไม่ยิง feed)
+        lt(contentPosts.publishStartedAt, cutoff),
+      ),
+    )
+    .run();
+  return res.changes;
 }
 
 /** ยิง FB สำเร็จแล้ว: PUBLISHING → POSTED (เก็บ fbPostId + postedAt) */
@@ -118,7 +153,7 @@ export function markPosted(db: ContentDb, id: string, fbPostId: string): void {
   transition(db, id, "PUBLISHING", "POSTED", { fbPostId, postedAt: new Date() });
 }
 
-/** ยิง FB ล้ม/ต้องปล่อย claim: PUBLISHING → FAILED (default) หรือ APPROVED (คืนคิว) */
+/** ยิง FB ล้ม/ต้องปล่อย claim: PUBLISHING → FAILED (default) หรือ APPROVED (คืนคิว) + เคลียร์ lease marker */
 export function releaseClaim(db: ContentDb, id: string, to: "FAILED" | "APPROVED" = "FAILED"): void {
-  transition(db, id, "PUBLISHING", to);
+  transition(db, id, "PUBLISHING", to, { publishStartedAt: null, feedAttemptedAt: null });
 }

--- a/content-creator/lib/time.ts
+++ b/content-creator/lib/time.ts
@@ -1,0 +1,27 @@
+/**
+ * time helper [S4b] — เขตเวลากรุงเทพ (เส้นวัน/เที่ยงคืนใช้ Asia/Bangkok เสมอ ไม่พึ่ง tz เครื่อง/UTC)
+ */
+
+/** วันนี้ตามกรุงเทพ (YYYY-MM-DD) */
+export function bangkokTodayISO(now: Date = new Date()): string {
+  return new Intl.DateTimeFormat("en-CA", { timeZone: "Asia/Bangkok", year: "numeric", month: "2-digit", day: "2-digit" }).format(now);
+}
+
+/** เวลาปัจจุบันกรุงเทพเป็นนาทีจากเที่ยงคืน (สำหรับ publish window now >= HH:mm) */
+export function bangkokMinutesOfDay(now: Date = new Date()): number {
+  const hm = new Intl.DateTimeFormat("en-GB", { timeZone: "Asia/Bangkok", hour: "2-digit", minute: "2-digit", hour12: false }).format(now);
+  const [h, m] = hm.split(":").map(Number);
+  return h * 60 + m;
+}
+
+/** "HH:mm" → นาทีจากเที่ยงคืน */
+export function hhmmToMinutes(hhmm: string): number {
+  const [h, m] = hhmm.split(":").map(Number);
+  return h * 60 + m;
+}
+
+/** วันในสัปดาห์ตามกรุงเทพ (0=อาทิตย์..6=เสาร์) — derive จากวันปฏิทิน Bangkok (ไม่พึ่ง tz เครื่อง) */
+export function bangkokDayOfWeek(now: Date = new Date()): number {
+  const [y, m, d] = bangkokTodayISO(now).split("-").map(Number);
+  return new Date(Date.UTC(y, m - 1, d)).getUTCDay();
+}

--- a/content-creator/publish-service.ts
+++ b/content-creator/publish-service.ts
@@ -1,0 +1,91 @@
+/**
+ * shared publish policy [S4b ตู๋ P1] — manual + scheduler ใช้ตัวเดียวกัน (ไม่ bypass)
+ *
+ * ลำดับ (carry-forward S4a + guardrail S4b):
+ *  preflight (APPROVED + มี caption/image) → staleness guard (daily-7 targetDate=วันนี้)
+ *  → claimForPublish (atomic + per-day fence) → upload (pre-feed: ล้ม release→APPROVED retry ได้)
+ *  → POINT OF NO RETURN: publishToFeed (ล้ม=AMBIGUOUS คง PUBLISHING ห้าม release/retry)
+ *  → markPosted (ล้ม=AMBIGUOUS โพสต์แล้วแต่ DB ค้าง — reconcile มือ)
+ */
+import { readFileSync } from "node:fs";
+import { basename } from "node:path";
+import { and, eq } from "drizzle-orm";
+import type { ContentDb } from "./db/client";
+import { contentPosts, type ContentPost } from "./db/schema";
+import { claimForPublish, markPosted, releaseClaim } from "./db/transition";
+import { uploadUnpublishedPhoto, publishToFeed } from "./lib/facebook";
+import { safeResolveUnderRoot } from "./lib/safe-path";
+import { bangkokTodayISO } from "./lib/time";
+
+const DAILY7 = "daily-7";
+
+/** ผลลัพธ์ publish — definitive vs ต้อง reconcile มือ */
+export type PublishOutcome =
+  | { ok: true; status: "POSTED"; fbPostId: string }
+  | { ok: false; status: "SKIPPED" | "STALE" | "RETRYABLE" | "AMBIGUOUS"; reason: string; fbPostId?: string };
+
+/** staleness guard (shared): daily-7 targetDate ต้อง = วันนี้ — ไม่งั้น STALE (ไม่โพสต์ของผิดวัน) */
+export function staleReason(row: Pick<ContentPost, "templateId" | "inputData">, today: string): string | null {
+  if (row.templateId !== DAILY7) return null;
+  const targetDate = (row.inputData as { targetDate?: string })?.targetDate;
+  if (targetDate !== today) return `daily-7 targetDate=${targetDate ?? "?"} ≠ วันนี้ (${today}) — ไม่โพสต์`;
+  return null;
+}
+
+export interface PublishDeps {
+  pageId: string;
+  token: string;
+  /** วันนี้ (Bangkok) — inject ได้สำหรับ test ; default = วันนี้จริง */
+  today?: string;
+}
+
+export async function publishApprovedPost(db: ContentDb, id: string, deps: PublishDeps): Promise<PublishOutcome> {
+  const today = deps.today ?? bangkokTodayISO();
+  const row = db.select().from(contentPosts).where(eq(contentPosts.id, id)).get();
+  if (!row) return { ok: false, status: "SKIPPED", reason: "ไม่พบโพสต์" };
+  if (row.status !== "APPROVED") return { ok: false, status: "SKIPPED", reason: `ไม่ใช่ APPROVED (${row.status})` };
+  if (!row.caption || !row.imagePath) return { ok: false, status: "SKIPPED", reason: "ไม่มี caption/image" };
+
+  const stale = staleReason(row, today);
+  if (stale) return { ok: false, status: "STALE", reason: stale }; // ไม่ claim/ไม่ยิง FB
+
+  // claim atomic + per-day fence (daily-7 วันเดียวกัน row อื่น claim ไม่ได้)
+  if (!claimForPublish(db, id)) {
+    return { ok: false, status: "SKIPPED", reason: "claim ไม่ได้ (ถูกยิงอยู่ / per-day fence / ไม่ใช่ APPROVED)" };
+  }
+
+  // ===== UPLOAD (pre-feed) — ยังไม่โพสต์ → ล้ม release→APPROVED ปลอดภัย (retry) =====
+  let mediaFbid = row.mediaFbid;
+  if (!mediaFbid) {
+    try {
+      const mediaDir = process.env.CONTENT_MEDIA_DIR || "content-creator/media";
+      const real = safeResolveUnderRoot(mediaDir, basename(row.imagePath));
+      if (!real) throw new Error(`image path ไม่ปลอดภัย/ไม่พบ: ${row.imagePath}`);
+      mediaFbid = await uploadUnpublishedPhoto({ pageId: deps.pageId, token: deps.token, bytes: new Uint8Array(readFileSync(real)) });
+      const upd = db
+        .update(contentPosts)
+        .set({ mediaFbid, updatedAt: new Date() })
+        .where(and(eq(contentPosts.id, id), eq(contentPosts.status, "PUBLISHING")))
+        .run();
+      if (upd.changes !== 1) throw new Error("ownership lost: status ไม่ใช่ PUBLISHING");
+    } catch (e) {
+      releaseClaim(db, id, "APPROVED"); // ยังไม่โพสต์ → retry ปลอดภัย
+      return { ok: false, status: "RETRYABLE", reason: e instanceof Error ? e.message : String(e) };
+    }
+  }
+
+  // ===== POINT OF NO RETURN — หลัง POST /feed ห้าม release (อาจขึ้นเพจแล้ว) [ตู๋ P1] =====
+  let postId: string;
+  try {
+    postId = await publishToFeed({ pageId: deps.pageId, token: deps.token, mediaFbid, message: row.caption });
+  } catch (e) {
+    // AMBIGUOUS — คง PUBLISHING ไม่ release/ไม่ retry (กันโพสต์ซ้ำ) → reconcile มือ
+    return { ok: false, status: "AMBIGUOUS", reason: `publish กำกวม คง PUBLISHING: ${e instanceof Error ? e.message : String(e)}` };
+  }
+  try {
+    markPosted(db, id, postId);
+  } catch (e) {
+    return { ok: false, status: "AMBIGUOUS", fbPostId: postId, reason: `โพสต์ขึ้นแล้ว (fbPostId=${postId}) แต่ DB ล้ม — reconcile มือ ห้าม retry: ${e instanceof Error ? e.message : String(e)}` };
+  }
+  return { ok: true, status: "POSTED", fbPostId: postId };
+}

--- a/content-creator/publish-service.ts
+++ b/content-creator/publish-service.ts
@@ -12,7 +12,7 @@ import { basename } from "node:path";
 import { and, eq } from "drizzle-orm";
 import type { ContentDb } from "./db/client";
 import { contentPosts, type ContentPost } from "./db/schema";
-import { claimForPublish, markPosted, releaseClaim } from "./db/transition";
+import { claimForPublish, markPosted, releaseClaim, markFeedAttempted } from "./db/transition";
 import { uploadUnpublishedPhoto, publishToFeed } from "./lib/facebook";
 import { safeResolveUnderRoot } from "./lib/safe-path";
 import { bangkokTodayISO } from "./lib/time";
@@ -74,9 +74,10 @@ export async function publishApprovedPost(db: ContentDb, id: string, deps: Publi
     }
   }
 
-  // ===== POINT OF NO RETURN — หลัง POST /feed ห้าม release (อาจขึ้นเพจแล้ว) [ตู๋ P1] =====
+  // ===== POINT OF NO RETURN — mark ก่อนยิง (reconcile จะไม่ auto-release หลังจุดนี้) แล้ว POST /feed =====
   let postId: string;
   try {
+    markFeedAttempted(db, id); // PONR marker [S4b ตู๋ P1] — worker ตายหลังจุดนี้ = ambiguous ห้าม auto-release
     postId = await publishToFeed({ pageId: deps.pageId, token: deps.token, mediaFbid, message: row.caption });
   } catch (e) {
     // AMBIGUOUS — คง PUBLISHING ไม่ release/ไม่ retry (กันโพสต์ซ้ำ) → reconcile มือ

--- a/content-creator/scheduler.ts
+++ b/content-creator/scheduler.ts
@@ -1,0 +1,82 @@
+/**
+ * scheduler reconcile loop [S4b] — pm2 worker เรียก runSchedulerTick ทุก ~10-15 นาที (node-cron)
+ *
+ * ไม่ใช่ "ยิงตอน slot เป๊ะ" — ตื่นมา reconcile สถานะที่ควรเป็น (idempotent):
+ *  1. auto-cancel stale daily-7 (APPROVED + targetDate < วันนี้) atomic [ตู๋ P1] — กันโพสต์ของผิดวัน
+ *  2. gate: วันนี้อยู่ใน schedule days + ถึงเวลา slot แล้ว (Bangkok) — ไม่งั้น window closed
+ *  3. หยิบ APPROVED daily-7 targetDate=วันนี้ (เก่าสุด) → publishApprovedPost (shared policy)
+ *     per-day fence + staleness guard อยู่ใน publish-service → ตื่นซ้ำ/ดับแล้วฟื้น = catch-up ไม่ซ้ำ
+ */
+import { and, asc, eq, sql } from "drizzle-orm";
+import type { ContentDb } from "./db/client";
+import { contentPosts } from "./db/schema";
+import { publishApprovedPost, type PublishOutcome } from "./publish-service";
+import { bangkokTodayISO, bangkokMinutesOfDay, bangkokDayOfWeek, hhmmToMinutes } from "./lib/time";
+
+const DAILY7 = "daily-7";
+
+export interface ScheduleConfig {
+  /** วันที่โพสต์ (0=อาทิตย์..6=เสาร์) ; default ทุกวัน */
+  days: number[];
+  /** slot times "HH:mm" ; ขั้นแรก 1 รอบ/วัน (fence การันตี 1 โพสต์/วัน) */
+  slots: string[];
+}
+
+export function getScheduleConfig(): ScheduleConfig {
+  const days = (process.env.CONTENT_SCHEDULE_DAYS ?? "0,1,2,3,4,5,6").split(",").map((s) => Number(s.trim())).filter((n) => n >= 0 && n <= 6);
+  const slots = (process.env.CONTENT_SCHEDULE_SLOTS ?? "09:00").split(",").map((s) => s.trim()).filter(Boolean);
+  return { days, slots };
+}
+
+export interface TickDeps {
+  pageId: string;
+  token: string;
+  config: ScheduleConfig;
+  /** inject สำหรับ test ; default = ตอนนี้จริง */
+  now?: Date;
+}
+
+export interface TickResult {
+  today: string;
+  canceledStale: number;
+  window: "closed-day" | "closed-time" | "open";
+  published?: { id: string; status: PublishOutcome["status"] };
+  note: string;
+}
+
+export async function runSchedulerTick(db: ContentDb, deps: TickDeps): Promise<TickResult> {
+  const now = deps.now ?? new Date();
+  const today = bangkokTodayISO(now);
+
+  // 1. auto-cancel stale daily-7 (atomic: เฉพาะ row ที่ยัง APPROVED + targetDate < วันนี้) [ตู๋ P1]
+  const canceled = db
+    .update(contentPosts)
+    .set({ status: "CANCELED", updatedAt: now })
+    .where(and(eq(contentPosts.status, "APPROVED"), eq(contentPosts.templateId, DAILY7), sql`json_extract(${contentPosts.inputData}, '$.targetDate') < ${today}`))
+    .run();
+  const canceledStale = canceled.changes;
+
+  // 2. gate วัน + เวลา (Bangkok)
+  if (!deps.config.days.includes(bangkokDayOfWeek(now))) {
+    return { today, canceledStale, window: "closed-day", note: `วันนี้ไม่อยู่ใน schedule days` };
+  }
+  const earliestSlot = Math.min(...deps.config.slots.map(hhmmToMinutes));
+  if (bangkokMinutesOfDay(now) < earliestSlot) {
+    return { today, canceledStale, window: "closed-time", note: `ยังไม่ถึงเวลา slot (${deps.config.slots.join(",")})` };
+  }
+
+  // 3. หยิบ APPROVED daily-7 ของวันนี้ (เก่าสุด) → publish (fence การันตี 1/วัน ; ตื่นซ้ำไม่โพสต์ซ้ำ)
+  const cand = db
+    .select()
+    .from(contentPosts)
+    .where(and(eq(contentPosts.status, "APPROVED"), eq(contentPosts.templateId, DAILY7), sql`json_extract(${contentPosts.inputData}, '$.targetDate') = ${today}`))
+    .orderBy(asc(contentPosts.createdAt))
+    .limit(1)
+    .get();
+
+  if (!cand) {
+    return { today, canceledStale, window: "open", note: "ไม่มี daily-7 ของวันนี้ในคิว (ว่าง)" };
+  }
+  const outcome = await publishApprovedPost(db, cand.id, { pageId: deps.pageId, token: deps.token, today });
+  return { today, canceledStale, window: "open", published: { id: cand.id, status: outcome.status }, note: outcome.ok ? "โพสต์สำเร็จ" : outcome.reason };
+}

--- a/content-creator/scheduler.ts
+++ b/content-creator/scheduler.ts
@@ -11,9 +11,13 @@ import { and, asc, eq, sql } from "drizzle-orm";
 import type { ContentDb } from "./db/client";
 import { contentPosts } from "./db/schema";
 import { publishApprovedPost, type PublishOutcome } from "./publish-service";
+import { reconcileStuckPublishing } from "./db/transition";
 import { bangkokTodayISO, bangkokMinutesOfDay, bangkokDayOfWeek, hhmmToMinutes } from "./lib/time";
 
 const DAILY7 = "daily-7";
+/** PUBLISHING ที่ค้างเกินนี้ (pre-PONR) ถือว่า worker ตาย → reconcile release */
+const PUBLISH_LEASE_MS = Number(process.env.CONTENT_PUBLISH_LEASE_MS ?? 10 * 60 * 1000);
+const HHMM = /^([01]\d|2[0-3]):([0-5]\d)$/; // 00:00–23:59 เป๊ะ
 
 export interface ScheduleConfig {
   /** วันที่โพสต์ (0=อาทิตย์..6=เสาร์) ; default ทุกวัน */
@@ -22,9 +26,19 @@ export interface ScheduleConfig {
   slots: string[];
 }
 
+/**
+ * อ่าน schedule config — **fail-closed** [ตู๋ P1.2]: slot ผิดรูป (เช่น "bad") → throw
+ * (เดิม fail-open: NaN → window เปิดทันที โพสต์ผิดเวลา). worker จะไม่ start ถ้า config พัง.
+ */
 export function getScheduleConfig(): ScheduleConfig {
-  const days = (process.env.CONTENT_SCHEDULE_DAYS ?? "0,1,2,3,4,5,6").split(",").map((s) => Number(s.trim())).filter((n) => n >= 0 && n <= 6);
+  const days = (process.env.CONTENT_SCHEDULE_DAYS ?? "0,1,2,3,4,5,6").split(",").map((s) => Number(s.trim()));
+  if (days.some((n) => !Number.isInteger(n) || n < 0 || n > 6)) {
+    throw new Error(`CONTENT_SCHEDULE_DAYS ผิด (ต้องเป็น 0-6 คั่นด้วย ,): ${process.env.CONTENT_SCHEDULE_DAYS}`);
+  }
   const slots = (process.env.CONTENT_SCHEDULE_SLOTS ?? "09:00").split(",").map((s) => s.trim()).filter(Boolean);
+  if (slots.length === 0 || !slots.every((s) => HHMM.test(s))) {
+    throw new Error(`CONTENT_SCHEDULE_SLOTS ผิด (ต้องเป็น HH:mm คั่นด้วย ,): ${process.env.CONTENT_SCHEDULE_SLOTS}`);
+  }
   return { days, slots };
 }
 
@@ -38,6 +52,7 @@ export interface TickDeps {
 
 export interface TickResult {
   today: string;
+  reclaimedStuck: number;
   canceledStale: number;
   window: "closed-day" | "closed-time" | "open";
   published?: { id: string; status: PublishOutcome["status"] };
@@ -47,6 +62,10 @@ export interface TickResult {
 export async function runSchedulerTick(db: ContentDb, deps: TickDeps): Promise<TickResult> {
   const now = deps.now ?? new Date();
   const today = bangkokTodayISO(now);
+
+  // 0. reconcile stuck PUBLISHING (worker ตายหลัง claim) [ตู๋ P1] — pre-PONR หมดอายุ → release APPROVED
+  //    (post-PONR ambiguous ไม่แตะ — surface ผ่าน status API). ทำก่อนทุกอย่างให้ของ release กลับมา publish รอบนี้ได้
+  const reclaimedStuck = reconcileStuckPublishing(db, new Date(now.getTime() - PUBLISH_LEASE_MS));
 
   // 1. auto-cancel stale daily-7 (atomic: เฉพาะ row ที่ยัง APPROVED + targetDate < วันนี้) [ตู๋ P1]
   const canceled = db
@@ -58,11 +77,11 @@ export async function runSchedulerTick(db: ContentDb, deps: TickDeps): Promise<T
 
   // 2. gate วัน + เวลา (Bangkok)
   if (!deps.config.days.includes(bangkokDayOfWeek(now))) {
-    return { today, canceledStale, window: "closed-day", note: `วันนี้ไม่อยู่ใน schedule days` };
+    return { today, reclaimedStuck, canceledStale, window: "closed-day", note: `วันนี้ไม่อยู่ใน schedule days` };
   }
   const earliestSlot = Math.min(...deps.config.slots.map(hhmmToMinutes));
   if (bangkokMinutesOfDay(now) < earliestSlot) {
-    return { today, canceledStale, window: "closed-time", note: `ยังไม่ถึงเวลา slot (${deps.config.slots.join(",")})` };
+    return { today, reclaimedStuck, canceledStale, window: "closed-time", note: `ยังไม่ถึงเวลา slot (${deps.config.slots.join(",")})` };
   }
 
   // 3. หยิบ APPROVED daily-7 ของวันนี้ (เก่าสุด) → publish (fence การันตี 1/วัน ; ตื่นซ้ำไม่โพสต์ซ้ำ)
@@ -75,8 +94,8 @@ export async function runSchedulerTick(db: ContentDb, deps: TickDeps): Promise<T
     .get();
 
   if (!cand) {
-    return { today, canceledStale, window: "open", note: "ไม่มี daily-7 ของวันนี้ในคิว (ว่าง)" };
+    return { today, reclaimedStuck, canceledStale, window: "open", note: "ไม่มี daily-7 ของวันนี้ในคิว (ว่าง)" };
   }
   const outcome = await publishApprovedPost(db, cand.id, { pageId: deps.pageId, token: deps.token, today });
-  return { today, canceledStale, window: "open", published: { id: cand.id, status: outcome.status }, note: outcome.ok ? "โพสต์สำเร็จ" : outcome.reason };
+  return { today, reclaimedStuck, canceledStale, window: "open", published: { id: cand.id, status: outcome.status }, note: outcome.ok ? "โพสต์สำเร็จ" : outcome.reason };
 }

--- a/ecosystem.daily7.config.cjs
+++ b/ecosystem.daily7.config.cjs
@@ -10,8 +10,10 @@ module.exports = {
     {
       name: "mmv-daily7-scheduler",
       script: "scripts/publish-worker.ts",
+      cwd: __dirname, // รันจาก project root → CONTENT_DB_PATH default (content-creator/content.db) ตรงกับเว็บ
       interpreter: "node",
-      interpreter_args: "--import tsx",
+      // --env-file=.env.local → worker โหลด FB token + env เดียวกับ Next dev (ไม่ต้อง commit secret)
+      interpreter_args: "--import tsx --env-file=.env.local",
       autorestart: true, // ดับ/crash → ฟื้นเอง (จุดอ่อน worker downtime แก้ด้วย pm2 + reconcile catch-up)
       max_restarts: 20,
       env: {

--- a/ecosystem.daily7.config.cjs
+++ b/ecosystem.daily7.config.cjs
@@ -1,0 +1,25 @@
+// pm2 config สำหรับ daily-7 publish scheduler worker [S4b]
+// รัน: pm2 start ecosystem.daily7.config.cjs  (ตั้ง env ก่อน หรือใส่ใน env ด้านล่าง/ใช้ --env-file)
+// persist ข้าม reboot: pm2 save && pm2 startup
+//
+// env ที่ต้องมี: CONTENT_DB_PATH (sqlite จริง path เต็ม), CONTENT_FB_PAGE_ID,
+//   CONTENT_FB_PAGE_ACCESS_TOKEN ; optional CONTENT_SCHEDULE_DAYS="0,1,2,3,4,5,6",
+//   CONTENT_SCHEDULE_SLOTS="09:00", CONTENT_SCHEDULE_TICK_MS=600000
+module.exports = {
+  apps: [
+    {
+      name: "mmv-daily7-scheduler",
+      script: "scripts/publish-worker.ts",
+      interpreter: "node",
+      interpreter_args: "--import tsx",
+      autorestart: true, // ดับ/crash → ฟื้นเอง (จุดอ่อน worker downtime แก้ด้วย pm2 + reconcile catch-up)
+      max_restarts: 20,
+      env: {
+        NODE_ENV: "production",
+        // CONTENT_DB_PATH: "/abs/path/content.db",
+        // CONTENT_FB_PAGE_ID: "...",
+        // CONTENT_FB_PAGE_ACCESS_TOKEN: "...",
+      },
+    },
+  ],
+};

--- a/scripts/publish-worker.ts
+++ b/scripts/publish-worker.ts
@@ -1,0 +1,36 @@
+/**
+ * daily-7 publish scheduler worker [S4b] — long-running process (รันด้วย pm2)
+ *
+ * reconcile loop: tick ทุก ~10-15 นาที (setInterval ไม่ใช้ node-cron — ไม่ต้องการ cron expr).
+ * แต่ละ tick: auto-cancel stale + (ถ้าถึงเวลา+มีของวันนี้) โพสต์ 1 อัน. fence การันตี 1/วัน.
+ * pm2 autorestart + startup → ดับแล้วฟื้นเอง ; ตื่นช้า → รอบถัดไป catch-up.
+ *
+ * env ที่ต้องมี (pm2 env / shell): CONTENT_DB_PATH (sqlite จริง), CONTENT_FB_PAGE_ID,
+ *   CONTENT_FB_PAGE_ACCESS_TOKEN ; optional CONTENT_SCHEDULE_DAYS, CONTENT_SCHEDULE_SLOTS,
+ *   CONTENT_SCHEDULE_TICK_MS
+ * รันบนเครื่อง/server ที่มี DB + token (ไม่ใช่ Vercel — DB เป็น local file)
+ */
+import { getContentDb } from "../content-creator/db/client";
+import { runSchedulerTick, getScheduleConfig } from "../content-creator/scheduler";
+import { fbPageId, fbPageToken } from "../content-creator/lib/config";
+
+const INTERVAL_MS = Number(process.env.CONTENT_SCHEDULE_TICK_MS ?? 10 * 60 * 1000);
+
+async function tick(): Promise<void> {
+  const pageId = fbPageId();
+  const token = fbPageToken();
+  if (!pageId || !token) {
+    console.error("[publish-worker] FB env ไม่ครบ (CONTENT_FB_PAGE_ID / CONTENT_FB_PAGE_ACCESS_TOKEN) — skip tick");
+    return;
+  }
+  try {
+    const result = await runSchedulerTick(getContentDb(), { pageId, token, config: getScheduleConfig() });
+    console.log(`[publish-worker] ${new Date().toISOString()} ${JSON.stringify(result)}`);
+  } catch (e) {
+    console.error("[publish-worker] tick error:", e instanceof Error ? e.message : e);
+  }
+}
+
+console.log(`[publish-worker] started — tick ทุก ${INTERVAL_MS}ms · config ${JSON.stringify(getScheduleConfig())}`);
+void tick(); // ตื่นทันทีรอบแรก
+setInterval(() => void tick(), INTERVAL_MS);


### PR DESCRIPTION
## สร้างอะไร
**S4b — scheduler กึ่งอัตโนมัติ** ปิดระบบ daily-7: ฟีม approve เก็บคิว → scheduler โพสต์ตามเวลาเอง (ขั้นแรก 1 รอบ/วัน เน้น daily-7). manual publish ยังได้.

## หลักการ: reconcile loop (ไม่ fire-at-slot)
worker (pm2 + setInterval ~10-15 นาที) ตื่นมา reconcile สถานะที่ควรเป็น — **robust ต่อ downtime เอง** (ตื่นช้า/ดับสั้น → รอบถัดไป catch-up ; ไม่ต้อง health-check). จุดอ่อน worker downtime แก้ด้วย pm2 autorestart + reconcile catch-up.

## P1 ตาม design ที่ตู๋ lock
- **per-day business fence** — partial unique index (migration 0006) บน `json_extract(targetDate)` เฉพาะ daily-7 `PUBLISHING/POSTED` → **sqlite enforce ≤1/วัน atomic** (row-level claim ไม่พอ). `claimForPublish` catch unique-violation → false
- **shared publish policy** (`publish-service.ts`) — manual + scheduler ใช้ตัวเดียว **ไม่ bypass**: staleness guard (targetDate=วันนี้) → claim(fence) → upload (pre-feed release→APPROVED) → **POINT OF NO RETURN** (publishToFeed ล้ม=AMBIGUOUS คง PUBLISHING **ห้าม release/retry**) → markPosted
- **stale auto-cancel atomic** — `APPROVED + targetDate < bangkokToday → CANCELED`
- **publish window** — Bangkok day-of-week ∈ config + `now ≥ slot` ; เส้นวันใช้ Asia/Bangkok เสมอ
- **manual rewired** → shared policy
- **modal/banner** (status API) — คิวว่าง / มี auto-cancel → แจ้งในหน้า content-creator ปิดได้
- **pm2 ecosystem** (autorestart+startup) + worker script

## ควรตรวจเป็นพิเศษ
- `db/migrations/0006` partial unique index — per-day fence (หัวใจ concurrency)
- `publish-service.ts` — point-of-no-return + staleness (shared manual/scheduler)
- `scheduler.ts` — reconcile tick (auto-cancel atomic, window, catch-up idempotent)

## Verify — 8 adversarial tests ที่ตู๋ขอ ครบ
tsc 0 · vitest **255** (+14): publish-service 7 + scheduler 7
- ✓ two-workers · ✓ two-rows-same-day (fence) · ✓ manual-race (shared) · ✓ stale-cancel-no-FB · ✓ future-no-op · ✓ pre-feed-release · ✓ post-feed-ambiguous-no-retry · ✓ bangkok-midnight
- next build · **dev จริง**: status API query OK, worker reconcile loop boot+tick (ไม่มี FB→skip ปลอดภัย)

## หมายเหตุ production-readiness
- worker + pm2 + FB publish จริง = **ฟีม verify บน server จริง** (ตั้ง env: CONTENT_DB_PATH/FB token + `pm2 start ecosystem.daily7.config.cjs` + `pm2 save && pm2 startup`)
- publish→FB path = S4a verified (โพสต์ขึ้นเพจจริงแล้ว) ; S4b ห่อ scheduler บน path เดิม

🤖 ตอบโดย goo จาก [ฟีม] → goo-oracle