### PR TITLE
feat(content-creator): manual workflow — mark posted / copy caption (Phase 1)

### DIFF
--- a/app/content-creator/api/approve/route.ts
+++ b/app/content-creator/api/approve/route.ts
@@ -1,14 +1,15 @@
 /**
- * POST /content-creator/api/approve — ฟีม approve/cancel โพสต์ที่ gen เสร็จ [S3]
- * body: { id, action: "approve" | "cancel" }
- *   approve → GENERATED → APPROVED (เข้าคิวรอ publish — S4)
+ * POST /content-creator/api/approve — ฟีมจัดการโพสต์ที่ gen เสร็จ (GENERATED) [S3 / PR#100]
+ * body: { id, action: "approve" | "cancel" | "posted" }
+ *   posted  → GENERATED → POSTED (manual: ฟีมโพสต์ FB เองแล้วบันทึกว่าโพสต์แล้ว — fbPostId=null) [PR#100]
  *   cancel  → GENERATED → CANCELED (terminal)
- * ใช้ tryTransition (atomic conditional) → ถ้า row ไม่ใช่ GENERATED แล้ว (จัดการไปแล้ว/race) คืน 409
+ *   approve → GENERATED → APPROVED (auto path เดิม — เก็บไว้แต่ไม่ใช้ใน UX ใหม่)
+ * ใช้ atomic conditional → ถ้า row ไม่ใช่ GENERATED แล้ว (จัดการไปแล้ว/race) คืน 409
  */
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { getContentDb } from "@/content-creator/db/client";
-import { tryTransition } from "@/content-creator/db/transition";
+import { markPostedManual, tryTransition } from "@/content-creator/db/transition";
 import { isContentCreatorEnabled } from "@/content-creator/lib/enabled";
 
 export const runtime = "nodejs";
@@ -16,7 +17,7 @@ export const dynamic = "force-dynamic";
 
 const BodySchema = z.object({
   id: z.string().min(1),
-  action: z.enum(["approve", "cancel"]),
+  action: z.enum(["approve", "cancel", "posted"]),
 });
 
 export async function POST(request: Request) {
@@ -29,8 +30,25 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: false, error: "invalid body (ต้องมี id + action)" }, { status: 400 });
   }
 
-  const to = body.action === "approve" ? "APPROVED" : "CANCELED";
   const db = getContentDb();
+
+  // manual mark posted [PR#100] — domain result (fence/replay) → HTTP
+  if (body.action === "posted") {
+    const result = markPostedManual(db, body.id);
+    if (result === "ok") return NextResponse.json({ ok: true, id: body.id, status: "POSTED" });
+    if (result === "fence") {
+      return NextResponse.json(
+        { ok: false, error: "วันนี้มีโพสต์ daily-7 แล้ว (1 โพสต์/วัน)" },
+        { status: 409 },
+      );
+    }
+    return NextResponse.json(
+      { ok: false, error: "โพสต์ไม่อยู่สถานะ GENERATED (อาจถูกจัดการไปแล้ว หรือไม่พบ id)" },
+      { status: 409 },
+    );
+  }
+
+  const to = body.action === "approve" ? "APPROVED" : "CANCELED";
   // atomic: เปลี่ยนเฉพาะถ้ายังเป็น GENERATED จริง — กัน double-approve / จัดการชน
   const ok = tryTransition(db, body.id, "GENERATED", to);
   if (!ok) {

--- a/app/content-creator/page.tsx
+++ b/app/content-creator/page.tsx
@@ -100,30 +100,9 @@ export default function ContentCreatorPage() {
     }
   }, []);
 
-  const publishPost = useCallback(
-    async (id: string) => {
-      if (!confirm("เผยแพร่ขึ้นเพจ Facebook จริง? (โพสต์จะขึ้นหน้าเพจ)")) return;
-      setBusyId(id);
-      setError(null);
-      try {
-        const res = await fetch("/content-creator/api/publish", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ id }),
-        });
-        const d = await res.json().catch(() => ({}));
-        if (!res.ok || !d.ok) {
-          throw new Error(d.error ?? `publish ไม่สำเร็จ (${res.status})`);
-        }
-        await load();
-      } catch (e) {
-        setError(e instanceof Error ? e.message : "publish ล้ม");
-      } finally {
-        setBusyId(null);
-      }
-    },
-    [load],
-  );
+  // NOTE [PR#100]: auto-publish (publishPost → /api/publish) ถูกตัดออกจาก UX
+  // เพราะ Graph public auto-post ตัน (no-company). route/service ยังอยู่ใน code แต่ไม่ expose ที่นี่
+  // กัน​ฟีมเผลอกดยิง FB. legacy APPROVED row แสดงเป็น info เฉยๆ (ไม่มีปุ่มยิง FB)
 
   const pending = posts.filter((p) => p.status === "GENERATED");
   const approved = posts.filter((p) => p.status === "APPROVED");
@@ -238,10 +217,11 @@ export default function ContentCreatorPage() {
 
       {approved.length > 0 && (
         <section className="mt-8">
-          <h2 className="mb-2 text-sm font-semibold text-gray-500">รอเผยแพร่ (APPROVED {approved.length})</h2>
+          <h2 className="mb-2 text-sm font-semibold text-gray-500">APPROVED (legacy {approved.length})</h2>
+          <p className="mb-2 text-xs text-amber-700">⚠️ row เก่าจาก auto-publish ที่ปิดไปแล้ว — workflow มือไม่ใช้สถานะนี้ (ไม่มีปุ่มยิง FB)</p>
           <div className="space-y-4">
             {approved.map((p) => (
-              <article key={p.id} className="overflow-hidden rounded-xl border shadow-sm">
+              <article key={p.id} className="overflow-hidden rounded-xl border border-amber-200 shadow-sm">
                 {p.imageUrl && (
                   // eslint-disable-next-line @next/next/no-img-element -- admin tool, local fs media
                   <img src={p.imageUrl} alt="approved" className="aspect-square w-full bg-gray-100 object-cover" />
@@ -254,13 +234,6 @@ export default function ContentCreatorPage() {
                     <span className="text-xs text-gray-400">{p.templateId}</span>
                   </div>
                   <p className="whitespace-pre-wrap text-sm">{p.caption}</p>
-                  <button
-                    onClick={() => publishPost(p.id)}
-                    disabled={busyId === p.id}
-                    className="w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
-                  >
-                    {busyId === p.id ? "กำลังเผยแพร่…" : "🚀 เผยแพร่ขึ้นเพจ (Publish)"}
-                  </button>
                 </div>
               </article>
             ))}

--- a/app/content-creator/page.tsx
+++ b/app/content-creator/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 /**
- * /content-creator — approve UI (admin tool ของฟีม) [S3]
- * แสดงโพสต์ที่ gen เสร็จ (GENERATED) → ฟีมกด approve/cancel.
+ * /content-creator — manual workflow UI (admin tool ของฟีม) [S3 / PR#100]
+ * แสดงโพสต์ที่ gen เสร็จ (GENERATED) → ฟีม copy caption + โหลดรูป → โพสต์ FB เอง → กด "โพสต์แล้ว"/"ลบ".
+ * (auto approve→publish เก็บ code ไว้แต่ไม่ใช้ใน UX นี้ — Meta App Review ตัน สำหรับ no-company)
  * route ถูก guard ด้วย middleware (404 ถ้า CONTENT_CREATOR_ENABLED ไม่เปิด/บน production)
  */
 import { useCallback, useEffect, useState } from "react";
@@ -35,6 +36,7 @@ export default function ContentCreatorPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
   // daily-7 scheduler status (modal/banner แจ้งเตือน) [S4b]
   const [d7, setD7] = useState<{ today: string; posted: boolean; pending: number; staleCanceled: number; stuckPublishing: number } | null>(null);
   const [d7Dismissed, setD7Dismissed] = useState(false);
@@ -65,7 +67,7 @@ export default function ContentCreatorPage() {
   }, [load]);
 
   const act = useCallback(
-    async (id: string, action: "approve" | "cancel") => {
+    async (id: string, action: "approve" | "cancel" | "posted") => {
       setBusyId(id);
       setError(null);
       try {
@@ -85,6 +87,18 @@ export default function ContentCreatorPage() {
     },
     [load],
   );
+
+  // copy caption ไปโพสต์ FB เอง [PR#100]
+  const copyCaption = useCallback(async (id: string, caption: string | null) => {
+    if (!caption) return;
+    try {
+      await navigator.clipboard.writeText(caption);
+      setCopiedId(id);
+      setTimeout(() => setCopiedId((c) => (c === id ? null : c)), 1500);
+    } catch {
+      setError("copy ไม่สำเร็จ (เบราว์เซอร์ไม่อนุญาต clipboard)");
+    }
+  }, []);
 
   const publishPost = useCallback(
     async (id: string) => {
@@ -120,7 +134,7 @@ export default function ContentCreatorPage() {
       <header className="mb-6 flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold">Content Creator</h1>
-          <p className="text-sm text-gray-500">รอ approve {pending.length} โพสต์</p>
+          <p className="text-sm text-gray-500">รอโพสต์เอง {pending.length} โพสต์</p>
         </div>
         <div className="flex items-center gap-2">
           <Link
@@ -151,7 +165,7 @@ export default function ContentCreatorPage() {
           <div>
             {d7.stuckPublishing > 0 && <div>🛑 มี daily-7 {d7.stuckPublishing} โพสต์ค้าง PUBLISHING (อาจขึ้นเพจแล้ว) — เช็คเพจ + reconcile มือ ห้าม publish ซ้ำ</div>}
             {d7.staleCanceled > 0 && <div>⚠️ มี daily-7 {d7.staleCanceled} โพสต์ถูกยกเลิก (เลยวันแล้ว — scheduler ไม่โพสต์ของผิดวัน)</div>}
-            {!d7.posted && d7.pending === 0 && <div>📭 วันนี้ ({d7.today}) ยังไม่มี daily-7 ในคิว — สร้าง+approve เพื่อให้ scheduler โพสต์</div>}
+            {!d7.posted && d7.pending === 0 && <div>📭 วันนี้ ({d7.today}) ยังไม่มี daily-7 — กด &quot;+ สร้างใหม่&quot; เพื่อ gen แล้วโพสต์เอง</div>}
           </div>
           <button onClick={() => setD7Dismissed(true)} className="shrink-0 rounded px-2 text-amber-600 hover:bg-amber-100">✕</button>
         </div>
@@ -164,7 +178,7 @@ export default function ContentCreatorPage() {
 
       {!loading && pending.length === 0 && (
         <p className="rounded-lg bg-gray-50 px-4 py-8 text-center text-gray-500">
-          ไม่มีโพสต์รอ approve
+          ไม่มีโพสต์รอโพสต์
         </p>
       )}
 
@@ -183,20 +197,38 @@ export default function ContentCreatorPage() {
                 <span className="text-xs text-gray-400">{p.templateId}</span>
               </div>
               <p className="whitespace-pre-wrap text-sm">{p.caption}</p>
-              <div className="flex gap-2 pt-1">
+              {/* manual workflow [PR#100]: copy caption + โหลดรูป → โพสต์ FB เอง → กด "โพสต์แล้ว"/"ลบ" */}
+              <div className="grid grid-cols-2 gap-2 pt-1">
                 <button
-                  onClick={() => act(p.id, "approve")}
-                  disabled={busyId === p.id}
-                  className="flex-1 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
-                >
-                  {busyId === p.id ? "…" : "Approve"}
-                </button>
-                <button
-                  onClick={() => act(p.id, "cancel")}
-                  disabled={busyId === p.id}
+                  onClick={() => copyCaption(p.id, p.caption)}
+                  disabled={!p.caption}
                   className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
                 >
-                  Cancel
+                  {copiedId === p.id ? "✓ คัดลอกแล้ว" : "📋 คัดลอก caption"}
+                </button>
+                <a
+                  href={p.imageUrl ?? undefined}
+                  download={`daily7-${p.id}.png`}
+                  aria-disabled={!p.imageUrl}
+                  className={`rounded-lg border border-gray-300 px-4 py-2 text-center text-sm font-medium text-gray-700 hover:bg-gray-50 ${p.imageUrl ? "" : "pointer-events-none opacity-50"}`}
+                >
+                  ⬇️ โหลดรูป
+                </a>
+                <button
+                  onClick={() => act(p.id, "posted")}
+                  disabled={busyId === p.id}
+                  className="rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50"
+                >
+                  {busyId === p.id ? "…" : "✓ โพสต์แล้ว"}
+                </button>
+                <button
+                  onClick={() => {
+                    if (confirm("ลบโพสต์นี้? (รูป + caption จะถูกยกเลิก กู้ไม่ได้)")) act(p.id, "cancel");
+                  }}
+                  disabled={busyId === p.id}
+                  className="rounded-lg border border-red-300 px-4 py-2 text-sm font-medium text-red-700 hover:bg-red-50 disabled:opacity-50"
+                >
+                  🗑 ลบ
                 </button>
               </div>
             </div>

--- a/content-creator/__tests__/db.test.ts
+++ b/content-creator/__tests__/db.test.ts
@@ -5,7 +5,8 @@ import { join } from "node:path";
 import { eq } from "drizzle-orm";
 import { createContentDb } from "../db/client";
 import { contentPosts } from "../db/schema";
-import { transition, tryTransition, claimForPublish, markPosted, releaseClaim } from "../db/transition";
+import { transition, tryTransition, claimForPublish, markPosted, releaseClaim, markPostedManual } from "../db/transition";
+import { canTransition } from "../db/state";
 
 const tmpDirs: string[] = [];
 function tmpDbPath() {
@@ -83,6 +84,66 @@ describe("[altitude] PUBLISHING claim — กัน scheduler concurrent ยิ�
     const db = createContentDb(":memory:");
     db.insert(contentPosts).values({ id: "q", templateId: "t", inputData: {} }).run();
     expect(tryTransition(db, "q", "APPROVED", "PUBLISHING")).toBe(false); // status เป็น PENDING
+  });
+});
+
+describe("[PR#100] manual mark posted — ฟีมโพสต์ FB เอง [ตู๋ P1]", () => {
+  function genDaily7(db: ReturnType<typeof createContentDb>, id: string, targetDate: string) {
+    db.insert(contentPosts)
+      .values({ id, templateId: "daily-7", inputData: { targetDate, days: [] }, status: "GENERATED", caption: "c", imagePath: `/m/${id}.png` })
+      .run();
+  }
+  const statusOf = (db: ReturnType<typeof createContentDb>, id: string) =>
+    db.select().from(contentPosts).where(eq(contentPosts.id, id)).get()?.status;
+
+  it("GENERATED→POSTED สำเร็จ + fbPostId=null (ไม่ใช่ publish ผ่าน API)", () => {
+    const db = createContentDb(":memory:");
+    genDaily7(db, "g", "2026-06-21");
+    expect(markPostedManual(db, "g")).toBe("ok");
+    const row = db.select().from(contentPosts).where(eq(contentPosts.id, "g")).get();
+    expect(row!.status).toBe("POSTED");
+    expect(row!.fbPostId).toBeNull(); // manual: ไม่มี fbPostId
+    expect(row!.postedAt).not.toBeNull();
+  });
+
+  it("[P1.3] same-row replay (กดซ้ำ/response หาย) → ok idempotent ไม่ทำซ้ำ", () => {
+    const db = createContentDb(":memory:");
+    genDaily7(db, "g", "2026-06-21");
+    expect(markPostedManual(db, "g")).toBe("ok");
+    expect(markPostedManual(db, "g")).toBe("ok"); // replay
+    expect(statusOf(db, "g")).toBe("POSTED");
+  });
+
+  it("[P1.1] two rows same targetDate → row 1 ok, row 2 fence + status ไม่เปลี่ยน (atomic)", () => {
+    const db = createContentDb(":memory:");
+    genDaily7(db, "a", "2026-06-20");
+    genDaily7(db, "b", "2026-06-20");
+    expect(markPostedManual(db, "a")).toBe("ok");
+    expect(markPostedManual(db, "b")).toBe("fence"); // a อยู่ POSTED วันเดียวกัน → unique index ชน
+    expect(statusOf(db, "b")).toBe("GENERATED"); // rollback — ไม่เปลี่ยน
+  });
+
+  it("non-GENERATED (CANCELED / ghost id) → stale ไม่แตะ", () => {
+    const db = createContentDb(":memory:");
+    db.insert(contentPosts).values({ id: "c", templateId: "daily-7", inputData: { targetDate: "2026-06-22" }, status: "CANCELED" }).run();
+    expect(markPostedManual(db, "c")).toBe("stale");
+    expect(markPostedManual(db, "ghost")).toBe("stale");
+    expect(statusOf(db, "c")).toBe("CANCELED");
+  });
+
+  it("ลบ: GENERATED→CANCELED ยังทำงาน (manual delete)", () => {
+    const db = createContentDb(":memory:");
+    genDaily7(db, "d", "2026-06-23");
+    expect(tryTransition(db, "d", "GENERATED", "CANCELED")).toBe(true);
+    expect(statusOf(db, "d")).toBe("CANCELED");
+  });
+
+  it("[P1.4] auto path เดิม GENERATED→APPROVED→PUBLISHING→POSTED ไม่ regress", () => {
+    expect(canTransition("GENERATED", "APPROVED")).toBe(true);
+    expect(canTransition("APPROVED", "PUBLISHING")).toBe(true);
+    expect(canTransition("PUBLISHING", "POSTED")).toBe(true);
+    // และ manual transition ใหม่ก็ allowed จาก GENERATED
+    expect(canTransition("GENERATED", "POSTED")).toBe(true);
   });
 });
 

--- a/content-creator/__tests__/db.test.ts
+++ b/content-creator/__tests__/db.test.ts
@@ -123,6 +123,17 @@ describe("[PR#100] manual mark posted — ฟีมโพสต์ FB เอง 
     expect(statusOf(db, "b")).toBe("GENERATED"); // rollback — ไม่เปลี่ยน
   });
 
+  it("[P2] auto-posted row (fbPostId มีค่า) → stale ไม่ถูก manual-mark กลืน", () => {
+    const db = createContentDb(":memory:");
+    // จำลอง row ที่ publish ผ่าน auto path สำเร็จ (POSTED + fbPostId)
+    db.insert(contentPosts)
+      .values({ id: "auto", templateId: "daily-7", inputData: { targetDate: "2026-06-24" }, status: "POSTED", fbPostId: "fb_123", postedAt: new Date() })
+      .run();
+    expect(markPostedManual(db, "auto")).toBe("stale"); // ไม่ใช่ replay ของ manual → ไม่คืน ok
+    const row = db.select().from(contentPosts).where(eq(contentPosts.id, "auto")).get();
+    expect(row!.fbPostId).toBe("fb_123"); // ไม่ถูกแตะ
+  });
+
   it("non-GENERATED (CANCELED / ghost id) → stale ไม่แตะ", () => {
     const db = createContentDb(":memory:");
     db.insert(contentPosts).values({ id: "c", templateId: "daily-7", inputData: { targetDate: "2026-06-22" }, status: "CANCELED" }).run();

--- a/content-creator/db/state.ts
+++ b/content-creator/db/state.ts
@@ -2,6 +2,7 @@
  * content-creator state machine — transitions ที่อนุญาตของ ContentPost.status
  *
  * PENDING ─claim→ GENERATING ─gen สำเร็จ→ GENERATED ─approve(คน)→ APPROVED ─claim→ PUBLISHING ─post→ POSTED (terminal)
+ *   GENERATED ─mark posted(คน)→ POSTED   (manual workflow: ฟีมโพสต์ FB เอง แล้วบันทึกว่าโพสต์แล้ว — fbPostId=null) [PR#100]
  *   GENERATING ─recovery→ FAILED / PENDING   (gen ล้ม/ปล่อย claim)
  *   PUBLISHING ─recovery→ FAILED / APPROVED   (ยิง FB ล้ม/ปล่อย claim)
  *   (active state) ─→ CANCELED (terminal) ; ─error→ FAILED ─retry→ PENDING
@@ -16,7 +17,7 @@ import type { ContentStatus } from "./schema";
 const ALLOWED: Record<ContentStatus, readonly ContentStatus[]> = {
   PENDING: ["GENERATING", "CANCELED", "FAILED"], // GENERATING = claim ก่อนเรียก Gemini
   GENERATING: ["GENERATED", "FAILED"], // GENERATED=สำเร็จ ; FAILED=ล้ม. (ถอด →PENDING: reclaim ต้อง expiry+token ก่อน [ตู๋ P1] — ตอนนี้ retry ผ่าน FAILED→PENDING)
-  GENERATED: ["APPROVED", "CANCELED", "FAILED"], // APPROVED = human gate
+  GENERATED: ["APPROVED", "CANCELED", "FAILED", "POSTED"], // APPROVED = human gate (auto path) ; POSTED = manual mark (ฟีมโพสต์เอง) [PR#100]
   APPROVED: ["PUBLISHING", "CANCELED", "FAILED"], // PUBLISHING = claim ก่อนยิง FB
   PUBLISHING: ["POSTED", "FAILED", "APPROVED"], // POSTED=สำเร็จ ; FAILED/APPROVED=recovery (ปล่อย claim)
   POSTED: [], // terminal

--- a/content-creator/db/transition.ts
+++ b/content-creator/db/transition.ts
@@ -175,12 +175,14 @@ export function markPostedManual(db: ContentDb, id: string): ManualPostResult {
     throw e;
   }
   // changes 0: row ไม่ใช่ GENERATED — เช็ค same-row idempotent replay (P1.3)
+  // ok เฉพาะ POSTED แบบ manual (fbPostId=null) เท่านั้น — auto-posted row (fbPostId มีค่า) = stale
+  // กันไม่ให้ manual-mark กลืน auto-posted row [ตู๋ P2]
   const row = db
-    .select({ status: contentPosts.status })
+    .select({ status: contentPosts.status, fbPostId: contentPosts.fbPostId })
     .from(contentPosts)
     .where(eq(contentPosts.id, id))
     .get();
-  return row?.status === "POSTED" ? "ok" : "stale";
+  return row?.status === "POSTED" && row.fbPostId == null ? "ok" : "stale";
 }
 
 /** ยิง FB ล้ม/ต้องปล่อย claim: PUBLISHING → FAILED (default) หรือ APPROVED (คืนคิว) + เคลียร์ lease marker */

--- a/content-creator/db/transition.ts
+++ b/content-creator/db/transition.ts
@@ -153,6 +153,36 @@ export function markPosted(db: ContentDb, id: string, fbPostId: string): void {
   transition(db, id, "PUBLISHING", "POSTED", { fbPostId, postedAt: new Date() });
 }
 
+/** ผลของ markPostedManual (manual workflow) — domain result ไม่ throw [PR#100 ตู๋ P1] */
+export type ManualPostResult =
+  | "ok" // GENERATED → POSTED สำเร็จ (หรือ same-row replay = idempotent)
+  | "fence" // per-day fence ชน: daily-7 วันเดียวกันมี POSTED/PUBLISHING แล้ว (1 โพสต์/วัน)
+  | "stale"; // row ไม่ใช่ GENERATED และไม่ใช่ POSTED (cancel/ไม่พบ id)
+
+/**
+ * manual mark posted [PR#100 ตู๋ P1] — ฟีมโพสต์ FB เองด้วยมือ แล้วบันทึกว่าโพสต์แล้ว.
+ * GENERATED → POSTED โดย **ไม่ set fbPostId** (null = แยกจาก auto path ที่ publish ผ่าน API).
+ *  - P1.1/1.2: per-day fence (idx 0006) ครอบ POSTED ด้วย → ถ้า daily-7 วันเดียวกันมี POSTED/PUBLISHING แล้ว
+ *    UPDATE จะชน unique → catch เป็น "fence" (atomic: statement ชน = ไม่เปลี่ยน status), ไม่ throw 500
+ *  - P1.3: กดซ้ำ/response หาย → row เป็น POSTED อยู่แล้ว → คืน "ok" (idempotent ไม่ทำซ้ำ)
+ *  - ห้ามแตะ APPROVED/PUBLISHING (auto path เดิม) — เฉพาะ GENERATED เท่านั้น
+ */
+export function markPostedManual(db: ContentDb, id: string): ManualPostResult {
+  try {
+    if (tryTransition(db, id, "GENERATED", "POSTED", { postedAt: new Date() })) return "ok";
+  } catch (e) {
+    if (isUniqueViolation(e)) return "fence"; // วันนี้มีโพสต์ daily-7 แล้ว
+    throw e;
+  }
+  // changes 0: row ไม่ใช่ GENERATED — เช็ค same-row idempotent replay (P1.3)
+  const row = db
+    .select({ status: contentPosts.status })
+    .from(contentPosts)
+    .where(eq(contentPosts.id, id))
+    .get();
+  return row?.status === "POSTED" ? "ok" : "stale";
+}
+
 /** ยิง FB ล้ม/ต้องปล่อย claim: PUBLISHING → FAILED (default) หรือ APPROVED (คืนคิว) + เคลียร์ lease marker */
 export function releaseClaim(db: ContentDb, id: string, to: "FAILED" | "APPROVED" = "FAILED"): void {
   transition(db, id, "PUBLISHING", to, { publishStartedAt: null, feedAttemptedAt: null });


### PR DESCRIPTION
## สรุป
Pivot **daily-7** จาก auto-publish → **manual workflow**. เหตุผล: ฟีมไม่มีบริษัท → Meta App Review (Business Verification) สำหรับ `pages_manage_posts` Advanced Access ตัน → full-auto public posting ทำไม่ได้. แทนที่ด้วย: ระบบ gen content → **ฟีมโพสต์ FB เองด้วยมือ** → กลับมากด "โพสต์แล้ว" หรือ "ลบ".

auto path เดิม (`GENERATED→APPROVED→PUBLISHING→POSTED` + scheduler + publish-service) **เก็บไว้ครบ** ไม่ลบ — เผื่ออนาคตจดทะเบียนธุรกิจแล้วเปิด auto กลับ.

## เปลี่ยนอะไร
| ไฟล์ | เปลี่ยน |
|---|---|
| `content-creator/db/state.ts` | + transition `GENERATED→POSTED` (manual mark) |
| `content-creator/db/transition.ts` | + `markPostedManual()` → domain result `ok`/`fence`/`stale` |
| `app/content-creator/api/approve/route.ts` | + action `"posted"` (map fence/stale→409, ok→200) |
| `app/content-creator/page.tsx` | การ์ด GENERATED → ปุ่ม **[📋 copy caption] [⬇️ โหลดรูป] [✓ โพสต์แล้ว] [🗑 ลบ]** ; ตัด approve/publish จาก UX |
| `content-creator/__tests__/db.test.ts` | +6 tests |

## ทำตาม design review ของตู๋ (4 P1)
- **P1.1** per-day fence (1 daily-7/วัน = business invariant) **เก็บไว้** → ครอบ POSTED ด้วย → unique violation = domain result `"fence"` ("วันนี้มีโพสต์ daily-7 แล้ว") ไม่ throw 500
- **P1.2** `markPostedManual` = atomic conditional `status=GENERATED` + catch unique violation → ถ้าชน fence statement rollback, status ไม่เปลี่ยน
- **P1.3** same-row replay (กดซ้ำ / response หาย) = `ok` idempotent ; different row same day = 409 fence
- **P1.4** `fbPostId=null` (manual) แยกจาก auto path ที่ publish ผ่าน API ; ห้ามแตะ APPROVED/PUBLISHING

## ตรงไหนควรตรวจเป็นพิเศษ
1. `markPostedManual` fence-vs-replay branching (`transition.ts`) — ลำดับ catch unique → select status
2. การ์ด GENERATED ใน `page.tsx` — copy caption (clipboard), download (anchor), confirm ตอนลบ
3. POSTED manual ใน UI/history ไม่ควร imply ว่า publish ผ่าน API (fbPostId null)

## Test
- **+6 ใหม่ผ่านหมด**: GENERATED→POSTED · same-row replay · two-row same-date fence · non-GENERATED reject · cancel · auto-path regression
- regression = 0 (full suite: เท่าเดิม 7 fail pre-existing — payment UI + 1 date-dependent scheduler test ที่ fail บน main อยู่แล้ว ไม่เกี่ยว PR นี้)
- typecheck (tsc --noEmit) ✅

> Phase 2 (auto-gen เที่ยงคืน — reuse scheduler reconcile, ไม่แตะ FB) จะแยก PR ทีหลัง

🤖 ตอบโดย goo จาก [ฟีม] → goo-oracle