### PR TITLE
feat(content-creator): daily-7 active fence — 1 publication artifact/วัน (Phase 2 foundation)

### DIFF
--- a/content-creator/__tests__/daily7-service.test.ts
+++ b/content-creator/__tests__/daily7-service.test.ts
@@ -88,4 +88,14 @@ describe("finalizeDaily7Draft validation [ตู๋ P1.A/B]", () => {
     expect(() => finalizeDaily7Draft(db, d.id, "fk", edited.revision, VALID_BG)).toThrow();
     expect(getDraft(db, d.id)!.status).toBe("READY"); // ไม่ถูก finalize
   });
+
+  it("[fence 0008 / P1.2] finalize draft ที่ 2 (targetDate เดียวกัน) → DraftConflictError ไม่ใช่ 500 ; draft ยัง READY", async () => {
+    // 2 draft คนละ requestKey วันเดียวกัน (manual parallel ทำได้) — fence บังคับตอน finalize → contentPost
+    const d1 = await createDaily7Draft(db, "rk1", "2026-06-15");
+    finalizeDaily7Draft(db, d1.id, "fk1", d1.revision, VALID_BG); // PENDING post #1 (non-canceled)
+    const d2 = await createDaily7Draft(db, "rk2", "2026-06-15");
+    expect(() => finalizeDaily7Draft(db, d2.id, "fk2", d2.revision, VALID_BG)).toThrow(/วันนี้/); // DraftConflictError → 409
+    expect(getDraft(db, d2.id)!.status).toBe("READY"); // transaction rollback — ไม่ถูก finalize
+    expect(db.select().from(contentPosts).all()).toHaveLength(1); // post เดียว (ตัวที่ 2 ไม่ถูกสร้าง)
+  });
 });

--- a/content-creator/__tests__/db.test.ts
+++ b/content-creator/__tests__/db.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { eq } from "drizzle-orm";
 import { createContentDb } from "../db/client";
 import { contentPosts } from "../db/schema";
-import { transition, tryTransition, claimForPublish, markPosted, releaseClaim, markPostedManual } from "../db/transition";
+import { transition, tryTransition, claimForPublish, markPosted, releaseClaim, markPostedManual, isDaily7ActiveFenceViolation } from "../db/transition";
 import { canTransition } from "../db/state";
 
 const tmpDirs: string[] = [];
@@ -129,6 +129,21 @@ describe("[PR#100] manual mark posted — ฟีมโพสต์ FB เอง 
     tryTransition(db, "old", "GENERATED", "CANCELED"); // ยกเลิกตัวเดิม
     expect(() => genDaily7(db, "new", "2026-06-25")).not.toThrow(); // วันเดียวกันสร้างใหม่ได้
     expect(statusOf(db, "new")).toBe("GENERATED");
+  });
+
+  it("[ตู๋ P1] isDaily7ActiveFenceViolation match เฉพาะ uniq_daily7_active — ไม่กลืน unique อื่น", () => {
+    expect(isDaily7ActiveFenceViolation(new Error("UNIQUE constraint failed: index 'uniq_daily7_active'"))).toBe(true);
+    expect(isDaily7ActiveFenceViolation(new Error("UNIQUE constraint failed: content_posts.request_key"))).toBe(false);
+    expect(isDaily7ActiveFenceViolation(new Error("some other error"))).toBe(false);
+  });
+
+  it("[ตู๋ P2] daily-7 ไม่มี targetDate (malformed) → fence ไม่บังคับ (NULL ซ้ำได้)", () => {
+    const db = createContentDb(":memory:");
+    // 2 row ไม่มี targetDate → index partial WHERE targetDate IS NOT NULL ไม่ครอบ → insert ได้ทั้งคู่
+    db.insert(contentPosts).values({ id: "n1", templateId: "daily-7", inputData: { days: [] }, status: "GENERATED" }).run();
+    expect(() =>
+      db.insert(contentPosts).values({ id: "n2", templateId: "daily-7", inputData: { days: [] }, status: "GENERATED" }).run(),
+    ).not.toThrow();
   });
 
   it("[P2] auto-posted row (fbPostId มีค่า) → stale ไม่ถูก manual-mark กลืน", () => {

--- a/content-creator/__tests__/db.test.ts
+++ b/content-creator/__tests__/db.test.ts
@@ -114,13 +114,21 @@ describe("[PR#100] manual mark posted — ฟีมโพสต์ FB เอง 
     expect(statusOf(db, "g")).toBe("POSTED");
   });
 
-  it("[P1.1] two rows same targetDate → row 1 ok, row 2 fence + status ไม่เปลี่ยน (atomic)", () => {
+  it("[fence 0008] DB block insert daily-7 ตัวที่ 2 วันเดียวกัน (non-canceled) → row แรกยัง mark posted ได้", () => {
     const db = createContentDb(":memory:");
     genDaily7(db, "a", "2026-06-20");
-    genDaily7(db, "b", "2026-06-20");
-    expect(markPostedManual(db, "a")).toBe("ok");
-    expect(markPostedManual(db, "b")).toBe("fence"); // a อยู่ POSTED วันเดียวกัน → unique index ชน
-    expect(statusOf(db, "b")).toBe("GENERATED"); // rollback — ไม่เปลี่ยน
+    // broad fence (idx 0008): 1 non-canceled artifact/วัน → ตัวที่ 2 ถูก block ตั้งแต่ insert
+    expect(() => genDaily7(db, "b", "2026-06-20")).toThrow(/UNIQUE constraint/);
+    expect(markPostedManual(db, "a")).toBe("ok"); // row เดียว → mark posted ปกติ
+    expect(statusOf(db, "a")).toBe("POSTED");
+  });
+
+  it("[fence 0008] CANCELED ไม่นับใน fence → สร้างใหม่วันเดียวกันได้หลังยกเลิกตัวเดิม", () => {
+    const db = createContentDb(":memory:");
+    genDaily7(db, "old", "2026-06-25");
+    tryTransition(db, "old", "GENERATED", "CANCELED"); // ยกเลิกตัวเดิม
+    expect(() => genDaily7(db, "new", "2026-06-25")).not.toThrow(); // วันเดียวกันสร้างใหม่ได้
+    expect(statusOf(db, "new")).toBe("GENERATED");
   });
 
   it("[P2] auto-posted row (fbPostId มีค่า) → stale ไม่ถูก manual-mark กลืน", () => {

--- a/content-creator/__tests__/publish-service.test.ts
+++ b/content-creator/__tests__/publish-service.test.ts
@@ -31,15 +31,11 @@ function approvedDaily7(targetDate: string, opts: { mediaFbid?: string | null } 
 const statusOf = (id: string) => db.select().from(contentPosts).where(eq(contentPosts.id, id)).get()?.status;
 
 describe("publish-service — per-day fence + point-of-no-return [S4b ตู๋ P1]", () => {
-  it("two rows same day → row 2 SKIPPED (per-day fence) ; ยิง FB ครั้งเดียว", async () => {
-    const a = approvedDaily7(TODAY);
-    const b = approvedDaily7(TODAY);
-    const r1 = await publishApprovedPost(db, a, deps);
-    const r2 = await publishApprovedPost(db, b, deps);
-    expect(r1.status).toBe("POSTED");
-    expect(r2.status).toBe("SKIPPED"); // fence ชน (a อยู่ POSTED วันเดียวกัน)
-    expect(mockPublish).toHaveBeenCalledTimes(1);
-    expect(statusOf(b)).toBe("APPROVED"); // b ไม่ถูกแตะ (claim ไม่ผ่าน fence)
+  it("[fence 0008] daily-7 วันเดียวกันตัวที่ 2 (non-canceled) ถูก DB block ตั้งแต่ insert → โพสต์คู่เป็นไปไม่ได้", () => {
+    // broad fence (idx 0008): 1 non-canceled artifact/วัน → ไม่มีทางมี 2 APPROVED วันเดียวกันให้ publish คู่
+    // (claimForPublish fence-catch เดิมกลายเป็น defensive — invariant ถูกบังคับตั้งแต่ create แล้ว)
+    approvedDaily7(TODAY);
+    expect(() => approvedDaily7(TODAY)).toThrow(/UNIQUE constraint/);
   });
 
   it("two workers same row → ครั้งที่ 2 SKIPPED (ไม่โพสต์ซ้ำ)", async () => {

--- a/content-creator/db/drafts.ts
+++ b/content-creator/db/drafts.ts
@@ -13,7 +13,7 @@
 import { and, eq, sql } from "drizzle-orm";
 import type { ContentDb } from "./client";
 import { contentDrafts, contentPosts, type ContentDraft } from "./schema";
-import { isUniqueViolation } from "./transition";
+import { isDaily7ActiveFenceViolation } from "./transition";
 
 export type { ContentDraft } from "./schema";
 
@@ -191,9 +191,9 @@ export function finalizeDraft(
         .values({ id: postId, requestKey: `draft:${id}`, templateId, inputData: finalInput, status: "PENDING" })
         .run(); // requestKey unique = backstop กัน 2 post จาก draft เดียว
     } catch (e) {
-      // daily-7 active fence (idx 0008): มี non-canceled artifact ของ targetDate เดียวกันแล้ว
-      // → domain result 409 (ไม่ใช่ 500). shared ทั้ง manual + auto finalize [PR#101 ตู๋ P1.2]
-      if (isUniqueViolation(e)) {
+      // เฉพาะ daily-7 active fence (idx uniq_daily7_active) → domain result 409 (ไม่ใช่ 500) [PR#101 ตู๋ P1.2]
+      // unique อื่น (เช่น request_key) / error อื่น → throw เดิม ไม่กลืน domain [ตู๋ P1 re-review]
+      if (isDaily7ActiveFenceViolation(e)) {
         throw new DraftConflictError("มี content ของวันนี้อยู่แล้ว (daily-7 = 1 โพสต์/วัน) — ยกเลิกตัวเดิมก่อน");
       }
       throw e;

--- a/content-creator/db/drafts.ts
+++ b/content-creator/db/drafts.ts
@@ -13,6 +13,7 @@
 import { and, eq, sql } from "drizzle-orm";
 import type { ContentDb } from "./client";
 import { contentDrafts, contentPosts, type ContentDraft } from "./schema";
+import { isUniqueViolation } from "./transition";
 
 export type { ContentDraft } from "./schema";
 
@@ -185,9 +186,18 @@ export function finalizeDraft(
       throw new DraftStaleError(`finalize ไม่ได้: status=${cur.status} revision=${cur.revision} (expected ${expectedRevision})`);
     }
     const postId = crypto.randomUUID();
-    tx.insert(contentPosts)
-      .values({ id: postId, requestKey: `draft:${id}`, templateId, inputData: finalInput, status: "PENDING" })
-      .run(); // requestKey unique = backstop กัน 2 post จาก draft เดียว
+    try {
+      tx.insert(contentPosts)
+        .values({ id: postId, requestKey: `draft:${id}`, templateId, inputData: finalInput, status: "PENDING" })
+        .run(); // requestKey unique = backstop กัน 2 post จาก draft เดียว
+    } catch (e) {
+      // daily-7 active fence (idx 0008): มี non-canceled artifact ของ targetDate เดียวกันแล้ว
+      // → domain result 409 (ไม่ใช่ 500). shared ทั้ง manual + auto finalize [PR#101 ตู๋ P1.2]
+      if (isUniqueViolation(e)) {
+        throw new DraftConflictError("มี content ของวันนี้อยู่แล้ว (daily-7 = 1 โพสต์/วัน) — ยกเลิกตัวเดิมก่อน");
+      }
+      throw e;
+    }
     const res = tx
       .update(contentDrafts)
       .set({ status: "FINALIZED", contentPostId: postId, finalizeKey, revision: sql`${contentDrafts.revision} + 1`, updatedAt: new Date() })

--- a/content-creator/db/migrations/0008_daily7_active_fence.sql
+++ b/content-creator/db/migrations/0008_daily7_active_fence.sql
@@ -17,9 +17,12 @@ WHERE `id` IN (
     ) AS rn
     FROM `content_posts`
     WHERE `template_id` = 'daily-7' AND `status` != 'CANCELED'
+      AND json_extract(`input_data`, '$.targetDate') IS NOT NULL
   ) WHERE `rn` > 1
 );--> statement-breakpoint
 -- step 2: drop fence เดิม (narrow) แล้วสร้าง fence ใหม่ (broad: non-canceled) แทน
+-- targetDate IS NOT NULL: invariant คือ "1 row ต่อ targetDate" — malformed row ที่ไม่มี targetDate
+-- ไม่ถูกบังคับ (และ data-fix ข้างบนก็ไม่ collapse partition NULL) [ตู๋ P2]
 DROP INDEX IF EXISTS `uniq_daily7_per_day`;--> statement-breakpoint
 CREATE UNIQUE INDEX `uniq_daily7_active` ON `content_posts` (json_extract(`input_data`, '$.targetDate'))
-WHERE `template_id` = 'daily-7' AND `status` != 'CANCELED';
+WHERE `template_id` = 'daily-7' AND `status` != 'CANCELED' AND json_extract(`input_data`, '$.targetDate') IS NOT NULL;

--- a/content-creator/db/migrations/0008_daily7_active_fence.sql
+++ b/content-creator/db/migrations/0008_daily7_active_fence.sql
@@ -1,0 +1,25 @@
+-- daily-7 active fence [PR#101 ตู๋ P1.1]: daily-7 มี publication artifact ได้ ≤1 row ต่อ targetDate
+-- เดิม 0006 ครอบแค่ PUBLISHING/POSTED → ยังสร้าง 2 row (PENDING/GENERATED) วันเดียวกันได้
+-- แล้วไปชนตอน manual mark posted / auto-gen. ขยายเป็น "non-canceled" (รวม FAILED) = invariant 1/วัน.
+--
+-- step 1: resolve duplicate ที่มีอยู่ใน db จริง ก่อนสร้าง unique index (ไม่งั้น CREATE INDEX fail)
+--   เก็บ row สถานะก้าวหน้าสุด/ใหม่สุด ต่อ targetDate, cancel ที่เหลือ. (no-op ถ้า db สะอาด)
+UPDATE `content_posts` SET `status` = 'CANCELED', `updated_at` = unixepoch()
+WHERE `id` IN (
+  SELECT `id` FROM (
+    SELECT `id`, row_number() OVER (
+      PARTITION BY json_extract(`input_data`, '$.targetDate')
+      ORDER BY CASE `status`
+        WHEN 'POSTED' THEN 7 WHEN 'PUBLISHING' THEN 6 WHEN 'APPROVED' THEN 5
+        WHEN 'GENERATED' THEN 4 WHEN 'GENERATING' THEN 3 WHEN 'PENDING' THEN 2
+        WHEN 'FAILED' THEN 1 ELSE 0 END DESC,
+        `created_at` DESC
+    ) AS rn
+    FROM `content_posts`
+    WHERE `template_id` = 'daily-7' AND `status` != 'CANCELED'
+  ) WHERE `rn` > 1
+);--> statement-breakpoint
+-- step 2: drop fence เดิม (narrow) แล้วสร้าง fence ใหม่ (broad: non-canceled) แทน
+DROP INDEX IF EXISTS `uniq_daily7_per_day`;--> statement-breakpoint
+CREATE UNIQUE INDEX `uniq_daily7_active` ON `content_posts` (json_extract(`input_data`, '$.targetDate'))
+WHERE `template_id` = 'daily-7' AND `status` != 'CANCELED';

--- a/content-creator/db/migrations/meta/_journal.json
+++ b/content-creator/db/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1781700000000,
       "tag": "0007_clammy_black_tarantula",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1781800000000,
+      "tag": "0008_daily7_active_fence",
+      "breakpoints": true
     }
   ]
 }

--- a/content-creator/db/transition.ts
+++ b/content-creator/db/transition.ts
@@ -97,6 +97,15 @@ export function isUniqueViolation(e: unknown): boolean {
 }
 
 /**
+ * เฉพาะ daily-7 active fence (idx uniq_daily7_active) ชน — ไม่รวม unique อื่น (เช่น content_posts.request_key)
+ * [PR#101 ตู๋ P1]: finalizeDraft เป็น generic ต่อ template → ห้ามแปลง unique อื่นเป็น "daily-7 conflict" ผิด domain.
+ */
+export function isDaily7ActiveFenceViolation(e: unknown): boolean {
+  const msg = e instanceof Error ? e.message : String(e);
+  return /uniq_daily7_active/.test(msg);
+}
+
+/**
  * claim โพสต์เพื่อยิง Facebook (APPROVED → PUBLISHING แบบ atomic).
  * คืน true = worker นี้ claim ได้ (ยิง FB ต่อได้คนเดียว); false = claim ไม่ได้ — ได้ 2 กรณี:
  *   (a) row ไม่ใช่ APPROVED (worker อื่น claim ไป) — changes 0

--- a/content-creator/db/transition.ts
+++ b/content-creator/db/transition.ts
@@ -91,7 +91,7 @@ export function releaseGenerate(db: ContentDb, id: string, token: string): boole
 }
 
 /** unique-constraint violation ของ better-sqlite3 (per-day fence ชน) */
-function isUniqueViolation(e: unknown): boolean {
+export function isUniqueViolation(e: unknown): boolean {
   const msg = e instanceof Error ? e.message : String(e);
   return (e as { code?: string })?.code === "SQLITE_CONSTRAINT_UNIQUE" || /UNIQUE constraint failed/i.test(msg);
 }


### PR DESCRIPTION
## สรุป
**Phase 2 foundation** (แยกจาก auto-gen worker เพื่อ review สะอาด). สร้าง **DB business fence** ที่ตู๋ require ก่อนทำ auto-gen (P1.1/P1.2).

**ปัญหา:** fence เดิม (idx 0006) ครอบแค่ `PUBLISHING/POSTED` → ยังสร้าง daily-7 2 row (PENDING/GENERATED) วันเดียวกันได้ → ชนตอน manual mark posted (PR#100) หรือ auto-gen. **แก้:** ขยาย invariant เป็น **1 non-canceled artifact ต่อ targetDate**.

## เปลี่ยนอะไร
| ไฟล์ | เปลี่ยน |
|---|---|
| `db/migrations/0008_daily7_active_fence.sql` | data-fix dup → drop 0006 → `uniq_daily7_active` (broad: status != CANCELED) |
| `db/migrations/meta/_journal.json` | + idx 8 (when monotonic) |
| `db/drafts.ts` | finalizeDraft catch unique violation → `DraftConflictError` (409) ไม่ throw 500 |
| `db/transition.ts` | export `isUniqueViolation` (ใช้ร่วม) |
| tests ×3 | fence tests + ปรับ ripple (insert ตัวที่ 2 block) |

## ⚠️ Migration verified บน prod db จริง (ไม่ใช่แค่ :memory:)
prod content.db มี **duplicate จริง** (2026-06-16: PENDING + POSTED) → broad index จะสร้างไม่ได้ถ้าไม่ data-fix ก่อน. รัน migrate runner (drizzle incremental) บน **copy ของ prod db**:
- applied 8 → 9 (0008 incremental, ไม่มี ordering bug)
- dup resolved: PENDING → CANCELED, POSTED เก็บไว้ (keep สถานะก้าวหน้าสุด/ใหม่สุด)
- old idx dropped, `uniq_daily7_active` created

> data-fix เป็น no-op ถ้า db สะอาด (window function row_number เก็บ rank สูงสุดต่อวัน)

## ผลต่อ invariant
- ไม่มีทางมี daily-7 2 row non-canceled วันเดียวกัน (บังคับตั้งแต่ create/finalize)
- markPostedManual (PR#100) fence-catch กลายเป็น **defensive** (invariant บังคับก่อนแล้ว) — เก็บไว้ belt-and-suspenders
- claimForPublish fence-catch (legacy publish path) ก็ defensive เช่นกัน

## ตรงไหนควรตรวจเป็นพิเศษ
1. migration data-fix ranking (POSTED>PUBLISHING>APPROVED>GENERATED>GENERATING>PENDING>FAILED) — keep ตัวถูกต้องไหม
2. finalizeDraft catch — unique violation → DraftConflictError เฉพาะ (ไม่กลืน error อื่น)
3. broad index ครอบ FAILED ด้วย (ตู๋ระบุ) → FAILED row กันสร้างใหม่วันเดียวกัน (ต้อง manual cancel/resolve ก่อน)

## Test
- DB fence block insert ตัวที่ 2 (db.test + publish-service) · CANCELED ไม่นับ · finalize ที่ 2 → DraftConflictError · real-db migration verified
- regression 0 (เหลือ 7 fail pre-existing: payment UI + 1 scheduler date-dependent ที่ fail บน main เดิม) · typecheck ✅

> Phase 2b (auto-gen worker: gen-scheduler + gen-worker + ecosystem + precheck CTA + FAILED visibility) จะตามใน PR ถัดไป ใช้ fence นี้เป็นฐาน

🤖 ตอบโดย goo จาก [ฟีม] → goo-oracle