### PR TITLE
feat(content-creator): auto-gen daily-7 worker — gen-only reconcile (Phase 2b)

### DIFF
--- a/app/content-creator/api/daily/status/route.ts
+++ b/app/content-creator/api/daily/status/route.ts
@@ -3,9 +3,9 @@
  * { today, posted (โพสต์วันนี้แล้ว?), pending (APPROVED รอโพสต์วันนี้), staleCanceled (เพิ่งถูก auto-cancel) }
  */
 import { NextResponse } from "next/server";
-import { and, eq, gte, sql, type SQL } from "drizzle-orm";
+import { and, eq, gte, like, sql, type SQL } from "drizzle-orm";
 import { getContentDb } from "@/content-creator/db/client";
-import { contentPosts } from "@/content-creator/db/schema";
+import { contentPosts, contentDrafts } from "@/content-creator/db/schema";
 import { isContentCreatorEnabled } from "@/content-creator/lib/enabled";
 import { bangkokTodayISO } from "@/content-creator/lib/time";
 
@@ -29,7 +29,14 @@ export async function GET() {
   // PUBLISHING ค้าง = ambiguous (worker ตายหลังยิง feed) → ต้อง reconcile มือ [S4b ตู๋ P1]
   const stuckPublishing = count(and(eq(contentPosts.templateId, DAILY7), eq(contentPosts.status, "PUBLISHING")));
   // auto-gen วันนี้ FAILED → surface ให้ฟีมรู้ว่าต้อง manual (ไม่เงียบ) [Phase 2b ตู๋ P2]
-  const failedToday = count(and(eq(contentPosts.templateId, DAILY7), eq(contentPosts.status, "FAILED"), sql`${td} = ${today}`));
+  // นับทั้ง contentPost FAILED + auto draft FAILED (gen 7 ล้ม ก่อนมี contentPost — ไม่งั้นเงียบ) [ตู๋ P2.1]
+  const postFailed = count(and(eq(contentPosts.templateId, DAILY7), eq(contentPosts.status, "FAILED"), sql`${td} = ${today}`));
+  const draftFailed = db
+    .select({ id: contentDrafts.id })
+    .from(contentDrafts)
+    .where(and(eq(contentDrafts.status, "FAILED"), like(contentDrafts.requestKey, `auto-daily7-${today}-%`)))
+    .all().length;
+  const failedToday = postFailed + draftFailed;
 
   return NextResponse.json({ ok: true, today, posted: posted > 0, pending, staleCanceled, stuckPublishing, failedToday });
 }

--- a/app/content-creator/api/daily/status/route.ts
+++ b/app/content-creator/api/daily/status/route.ts
@@ -28,6 +28,8 @@ export async function GET() {
   const staleCanceled = count(and(eq(contentPosts.templateId, DAILY7), eq(contentPosts.status, "CANCELED"), sql`${td} < ${today}`, gte(contentPosts.updatedAt, cutoff)));
   // PUBLISHING ค้าง = ambiguous (worker ตายหลังยิง feed) → ต้อง reconcile มือ [S4b ตู๋ P1]
   const stuckPublishing = count(and(eq(contentPosts.templateId, DAILY7), eq(contentPosts.status, "PUBLISHING")));
+  // auto-gen วันนี้ FAILED → surface ให้ฟีมรู้ว่าต้อง manual (ไม่เงียบ) [Phase 2b ตู๋ P2]
+  const failedToday = count(and(eq(contentPosts.templateId, DAILY7), eq(contentPosts.status, "FAILED"), sql`${td} = ${today}`));
 
-  return NextResponse.json({ ok: true, today, posted: posted > 0, pending, staleCanceled, stuckPublishing });
+  return NextResponse.json({ ok: true, today, posted: posted > 0, pending, staleCanceled, stuckPublishing, failedToday });
 }

--- a/app/content-creator/page.tsx
+++ b/app/content-creator/page.tsx
@@ -145,7 +145,7 @@ export default function ContentCreatorPage() {
             {d7.stuckPublishing > 0 && <div>🛑 มี daily-7 {d7.stuckPublishing} โพสต์ค้าง PUBLISHING (อาจขึ้นเพจแล้ว) — เช็คเพจ + reconcile มือ ห้าม publish ซ้ำ</div>}
             {d7.failedToday > 0 && <div>⚠️ auto-gen วันนี้ ({d7.today}) FAILED {d7.failedToday} ตัว — กด &quot;+ สร้างใหม่&quot; ลองเอง หรือยกเลิกตัวที่ FAILED</div>}
             {d7.staleCanceled > 0 && <div>⚠️ มี daily-7 {d7.staleCanceled} โพสต์ถูกยกเลิก (เลยวันแล้ว — scheduler ไม่โพสต์ของผิดวัน)</div>}
-            {!d7.posted && d7.pending === 0 && <div>📭 วันนี้ ({d7.today}) ยังไม่มี daily-7 — กด &quot;+ สร้างใหม่&quot; เพื่อ gen แล้วโพสต์เอง</div>}
+            {!d7.posted && d7.pending === 0 && d7.failedToday === 0 && <div>📭 วันนี้ ({d7.today}) ยังไม่มี daily-7 — กด &quot;+ สร้างใหม่&quot; เพื่อ gen แล้วโพสต์เอง</div>}
           </div>
           <button onClick={() => setD7Dismissed(true)} className="shrink-0 rounded px-2 text-amber-600 hover:bg-amber-100">✕</button>
         </div>

--- a/app/content-creator/page.tsx
+++ b/app/content-creator/page.tsx
@@ -38,13 +38,13 @@ export default function ContentCreatorPage() {
   const [busyId, setBusyId] = useState<string | null>(null);
   const [copiedId, setCopiedId] = useState<string | null>(null);
   // daily-7 scheduler status (modal/banner แจ้งเตือน) [S4b]
-  const [d7, setD7] = useState<{ today: string; posted: boolean; pending: number; staleCanceled: number; stuckPublishing: number } | null>(null);
+  const [d7, setD7] = useState<{ today: string; posted: boolean; pending: number; staleCanceled: number; stuckPublishing: number; failedToday: number } | null>(null);
   const [d7Dismissed, setD7Dismissed] = useState(false);
 
   useEffect(() => {
     fetch("/content-creator/api/daily/status", { cache: "no-store" })
       .then((r) => (r.ok ? r.json() : null))
-      .then((d) => d?.ok && setD7({ today: d.today, posted: d.posted, pending: d.pending, staleCanceled: d.staleCanceled, stuckPublishing: d.stuckPublishing }))
+      .then((d) => d?.ok && setD7({ today: d.today, posted: d.posted, pending: d.pending, staleCanceled: d.staleCanceled, stuckPublishing: d.stuckPublishing, failedToday: d.failedToday ?? 0 }))
       .catch(() => {});
   }, []);
 
@@ -139,10 +139,11 @@ export default function ContentCreatorPage() {
       </header>
 
       {/* daily-7 scheduler modal/banner — ปิดทิ้งได้ [S4b] */}
-      {d7 && !d7Dismissed && (d7.staleCanceled > 0 || d7.stuckPublishing > 0 || (!d7.posted && d7.pending === 0)) && (
+      {d7 && !d7Dismissed && (d7.staleCanceled > 0 || d7.stuckPublishing > 0 || d7.failedToday > 0 || (!d7.posted && d7.pending === 0)) && (
         <div className="mb-4 flex items-start justify-between gap-3 rounded-lg bg-amber-50 px-4 py-3 text-sm text-amber-800">
           <div>
             {d7.stuckPublishing > 0 && <div>🛑 มี daily-7 {d7.stuckPublishing} โพสต์ค้าง PUBLISHING (อาจขึ้นเพจแล้ว) — เช็คเพจ + reconcile มือ ห้าม publish ซ้ำ</div>}
+            {d7.failedToday > 0 && <div>⚠️ auto-gen วันนี้ ({d7.today}) FAILED {d7.failedToday} ตัว — กด &quot;+ สร้างใหม่&quot; ลองเอง หรือยกเลิกตัวที่ FAILED</div>}
             {d7.staleCanceled > 0 && <div>⚠️ มี daily-7 {d7.staleCanceled} โพสต์ถูกยกเลิก (เลยวันแล้ว — scheduler ไม่โพสต์ของผิดวัน)</div>}
             {!d7.posted && d7.pending === 0 && <div>📭 วันนี้ ({d7.today}) ยังไม่มี daily-7 — กด &quot;+ สร้างใหม่&quot; เพื่อ gen แล้วโพสต์เอง</div>}
           </div>

--- a/content-creator/__tests__/gen-scheduler.test.ts
+++ b/content-creator/__tests__/gen-scheduler.test.ts
@@ -16,7 +16,7 @@ import { createContentDb, type ContentDb } from "../db/client";
 import { contentPosts } from "../db/schema";
 import { tryTransition } from "../db/transition";
 import { updateBrandProfile } from "../db/brand";
-import { runGenTick, getGenConfig, precheckGenReady, type GenConfig } from "../gen-scheduler";
+import { runGenTick, getGenConfig, getGenTickMs, precheckGenReady, type GenConfig } from "../gen-scheduler";
 
 // 2026-06-20 12:00 Bangkok (UTC+7) → today=2026-06-20, minutesOfDay=720
 const NOW = new Date("2026-06-20T05:00:00Z");
@@ -48,6 +48,7 @@ beforeEach(() => {
 afterEach(() => {
   delete process.env.CONTENT_GEN_SLOT;
   delete process.env.CONTENT_GEN_DAYS;
+  delete process.env.CONTENT_GEN_TICK_MS;
 });
 
 describe("getGenConfig — fail-closed", () => {
@@ -61,6 +62,20 @@ describe("getGenConfig — fail-closed", () => {
   it("days ผิด → throw", () => {
     process.env.CONTENT_GEN_DAYS = "9";
     expect(() => getGenConfig()).toThrow(/CONTENT_GEN_DAYS/);
+  });
+});
+
+describe("getGenTickMs — fail-closed [ตู๋ P2.2]", () => {
+  it("default → 10 นาที", () => expect(getGenTickMs()).toBe(600000));
+  it("positive int → ใช้ค่านั้น", () => {
+    process.env.CONTENT_GEN_TICK_MS = "60000";
+    expect(getGenTickMs()).toBe(60000);
+  });
+  it("NaN/0/ลบ → throw (ไม่ fail-open setInterval รัว)", () => {
+    for (const bad of ["abc", "0", "-5", "1.5"]) {
+      process.env.CONTENT_GEN_TICK_MS = bad;
+      expect(() => getGenTickMs()).toThrow(/CONTENT_GEN_TICK_MS/);
+    }
   });
 });
 
@@ -170,5 +185,31 @@ describe("runGenTick — existing states", () => {
     insertDaily7("c", "CANCELED");
     const r = await runGenTick(db, { config: ALL_DAYS, now: NOW });
     expect(r.action).toBe("generated"); // CANCELED ไม่บล็อก → สร้างใหม่
+  });
+
+  it("[ตู๋ P1.1] sequence: tick→generated → ฟีมลบ(CANCELED) → tick สร้าง post ใหม่ (ไม่ติด replay key เดิม)", async () => {
+    setCta();
+    // tick 1 → post A GENERATED
+    const r1 = await runGenTick(db, { config: ALL_DAYS, now: NOW });
+    expect(r1.action).toBe("generated");
+    const a = db.select().from(contentPosts).all();
+    expect(a).toHaveLength(1);
+    const idA = a[0].id;
+
+    // ฟีมลบ A → CANCELED (ผ่าน manual workflow)
+    tryTransition(db, idA, "GENERATED", "CANCELED");
+
+    // tick 2 → ต้องสร้าง post ใหม่ (epoch เปลี่ยนเพราะ canceledCount=1 → key ใหม่ → draft+gen ใหม่)
+    const r2 = await runGenTick(db, { config: ALL_DAYS, now: NOW });
+    expect(r2.action).toBe("generated"); // ไม่ใช่ skip/replay
+    expect(r2.status).toBe("GENERATED");
+
+    const all = db.select().from(contentPosts).all();
+    expect(all).toHaveLength(2); // A (CANCELED) + B (GENERATED) — ของจริงคนละ row
+    expect(all.filter((p) => p.status === "CANCELED")).toHaveLength(1);
+    expect(all.filter((p) => p.status === "GENERATED")).toHaveLength(1);
+    expect(all.find((p) => p.status === "GENERATED")!.id).not.toBe(idA);
+    expect(mockGenObject).toHaveBeenCalledTimes(2); // draft ใหม่ (key ต่าง epoch) → gen 7 ใหม่
+    expect(mockGenerate).toHaveBeenCalledTimes(2);
   });
 });

--- a/content-creator/__tests__/gen-scheduler.test.ts
+++ b/content-creator/__tests__/gen-scheduler.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { eq } from "drizzle-orm";
+
+const WEEKDAYS = ["จันทร์", "อังคาร", "พุธ", "พฤหัสบดี", "ศุกร์", "เสาร์", "อาทิตย์"] as const;
+const full = () => ({ days: WEEKDAYS.map((day) => ({ day, fortune: `${day} วันนี้ดีมาก` })) });
+
+// mock genObject (gen 7 คำทำนาย) — createDaily7Draft เรียกจริง แต่ไม่ยิง Gemini
+const { mockGenObject } = vi.hoisted(() => ({ mockGenObject: vi.fn() }));
+vi.mock("../lib/gemini", () => ({ genObject: mockGenObject }));
+
+// mock engine.generate — controllable (จำลอง PENDING→GENERATED/FAILED) ; ไม่ render รูปจริง
+const { mockGenerate } = vi.hoisted(() => ({ mockGenerate: vi.fn() }));
+vi.mock("../engine", () => ({ generate: mockGenerate }));
+
+import { createContentDb, type ContentDb } from "../db/client";
+import { contentPosts } from "../db/schema";
+import { tryTransition } from "../db/transition";
+import { updateBrandProfile } from "../db/brand";
+import { runGenTick, getGenConfig, precheckGenReady, type GenConfig } from "../gen-scheduler";
+
+// 2026-06-20 12:00 Bangkok (UTC+7) → today=2026-06-20, minutesOfDay=720
+const NOW = new Date("2026-06-20T05:00:00Z");
+const TODAY = "2026-06-20";
+const ALL_DAYS: GenConfig = { days: [0, 1, 2, 3, 4, 5, 6], slot: "00:00" };
+
+let db: ContentDb;
+
+function genSuccess() {
+  mockGenerate.mockImplementation(async (d: ContentDb, id: string) => {
+    tryTransition(d, id, "PENDING", "GENERATING");
+    tryTransition(d, id, "GENERATING", "GENERATED", { caption: "cap", imagePath: "/m/x.png" });
+    return { ok: true, status: "GENERATED" };
+  });
+}
+function setCta() {
+  updateBrandProfile(db, { ctaUrl: "https://maemormimi.com/" });
+}
+function insertDaily7(id: string, status: string, targetDate = TODAY) {
+  db.insert(contentPosts).values({ id, templateId: "daily-7", inputData: { targetDate, days: [] }, status: status as never }).run();
+}
+
+beforeEach(() => {
+  db = createContentDb(":memory:");
+  mockGenObject.mockReset().mockResolvedValue(full());
+  mockGenerate.mockReset();
+  genSuccess();
+});
+afterEach(() => {
+  delete process.env.CONTENT_GEN_SLOT;
+  delete process.env.CONTENT_GEN_DAYS;
+});
+
+describe("getGenConfig — fail-closed", () => {
+  it("default → ทุกวัน + slot 00:00", () => {
+    expect(getGenConfig()).toEqual({ days: [0, 1, 2, 3, 4, 5, 6], slot: "00:00" });
+  });
+  it("slot ผิดรูป → throw (ไม่ fail-open)", () => {
+    process.env.CONTENT_GEN_SLOT = "bad";
+    expect(() => getGenConfig()).toThrow(/CONTENT_GEN_SLOT/);
+  });
+  it("days ผิด → throw", () => {
+    process.env.CONTENT_GEN_DAYS = "9";
+    expect(() => getGenConfig()).toThrow(/CONTENT_GEN_DAYS/);
+  });
+});
+
+describe("runGenTick — gate", () => {
+  it("วันนี้ไม่อยู่ใน days → closed-day ไม่ gen", async () => {
+    setCta();
+    const r = await runGenTick(db, { config: { days: [], slot: "00:00" }, now: NOW });
+    expect(r.window).toBe("closed-day");
+    expect(mockGenObject).not.toHaveBeenCalled();
+  });
+  it("ยังไม่ถึง slot → closed-time ไม่ gen", async () => {
+    setCta();
+    const r = await runGenTick(db, { config: { days: [0, 1, 2, 3, 4, 5, 6], slot: "23:00" }, now: NOW });
+    expect(r.window).toBe("closed-time");
+    expect(mockGenObject).not.toHaveBeenCalled();
+  });
+});
+
+describe("runGenTick — precheck [ตู๋ P1.4]", () => {
+  it("CTA ว่าง → skip-precheck + ไม่จ่าย Gemini เลย", async () => {
+    // ไม่ setCta() → ctaUrl ว่าง
+    const r = await runGenTick(db, { config: ALL_DAYS, now: NOW });
+    expect(r.action).toBe("skip-precheck");
+    expect(mockGenObject).not.toHaveBeenCalled(); // ไม่ burn 7 คำทำนาย
+    expect(mockGenerate).not.toHaveBeenCalled();
+    expect(db.select().from(contentPosts).all()).toHaveLength(0);
+  });
+  it("precheckGenReady: CTA set + manifest + font → ok", () => {
+    setCta();
+    expect(precheckGenReady(db).ok).toBe(true);
+  });
+});
+
+describe("runGenTick — create→finalize→generate", () => {
+  it("ยังไม่มีของวันนี้ → gen → GENERATED (1 post)", async () => {
+    setCta();
+    const r = await runGenTick(db, { config: ALL_DAYS, now: NOW });
+    expect(r.action).toBe("generated");
+    expect(r.status).toBe("GENERATED");
+    expect(mockGenObject).toHaveBeenCalledTimes(1);
+    expect(mockGenerate).toHaveBeenCalledTimes(1);
+    expect(db.select().from(contentPosts).all()).toHaveLength(1);
+  });
+
+  it("idempotent: tick 2 รอบ → 1 post (รอบ 2 skip-exists, ไม่ gen ซ้ำ)", async () => {
+    setCta();
+    await runGenTick(db, { config: ALL_DAYS, now: NOW });
+    const r2 = await runGenTick(db, { config: ALL_DAYS, now: NOW });
+    expect(r2.action).toBe("skip-exists");
+    expect(r2.status).toBe("GENERATED");
+    expect(mockGenerate).toHaveBeenCalledTimes(1); // ไม่ gen ซ้ำ
+    expect(db.select().from(contentPosts).all()).toHaveLength(1);
+  });
+
+  it("gen ล้ม → gen-failed + status FAILED", async () => {
+    setCta();
+    mockGenerate.mockImplementation(async (d: ContentDb, id: string) => {
+      tryTransition(d, id, "PENDING", "GENERATING");
+      tryTransition(d, id, "GENERATING", "FAILED");
+      return { ok: false, status: "FAILED", error: "boom" };
+    });
+    const r = await runGenTick(db, { config: ALL_DAYS, now: NOW });
+    expect(r.action).toBe("gen-failed");
+    expect(r.status).toBe("FAILED");
+  });
+});
+
+describe("runGenTick — existing states", () => {
+  it("resume PENDING (worker ตายก่อน gen เสร็จ) → gen ต่อ → GENERATED", async () => {
+    setCta();
+    insertDaily7("p", "PENDING");
+    const r = await runGenTick(db, { config: ALL_DAYS, now: NOW });
+    expect(r.action).toBe("resumed");
+    expect(r.status).toBe("GENERATED");
+    expect(mockGenObject).not.toHaveBeenCalled(); // ไม่สร้าง draft ใหม่ (resume ของเดิม)
+    expect(mockGenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it("FAILED วันนี้ → skip-failed ไม่ retry (กัน loop burn) [ตู๋ P2]", async () => {
+    setCta();
+    insertDaily7("f", "FAILED");
+    const r = await runGenTick(db, { config: ALL_DAYS, now: NOW });
+    expect(r.action).toBe("skip-failed");
+    expect(mockGenerate).not.toHaveBeenCalled();
+    expect(mockGenObject).not.toHaveBeenCalled();
+  });
+
+  it("GENERATED วันนี้แล้ว (มือ/รอบก่อน) → skip-exists", async () => {
+    setCta();
+    insertDaily7("g", "GENERATED");
+    const r = await runGenTick(db, { config: ALL_DAYS, now: NOW });
+    expect(r.action).toBe("skip-exists");
+    expect(mockGenerate).not.toHaveBeenCalled();
+  });
+
+  it("POSTED วันนี้แล้ว → skip-exists (ไม่ gen ทับ)", async () => {
+    setCta();
+    insertDaily7("posted", "POSTED");
+    const r = await runGenTick(db, { config: ALL_DAYS, now: NOW });
+    expect(r.action).toBe("skip-exists");
+    expect(r.status).toBe("POSTED");
+    expect(mockGenObject).not.toHaveBeenCalled();
+  });
+
+  it("CANCELED วันนี้ (ไม่นับใน fence) → gen ใหม่ได้", async () => {
+    setCta();
+    insertDaily7("c", "CANCELED");
+    const r = await runGenTick(db, { config: ALL_DAYS, now: NOW });
+    expect(r.action).toBe("generated"); // CANCELED ไม่บล็อก → สร้างใหม่
+  });
+});

--- a/content-creator/gen-scheduler.ts
+++ b/content-creator/gen-scheduler.ts
@@ -11,12 +11,12 @@
  *  - findExisting guard + DraftConflictError catch (race manual/auto) → skip ไม่จ่าย gen ซ้ำ
  */
 import { and, asc, eq, ne, sql } from "drizzle-orm";
-import { existsSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { ContentDb } from "./db/client";
 import { contentPosts, type ContentStatus } from "./db/schema";
 import { getBrandProfile } from "./db/brand";
-import { loadManifest } from "./lib/bg-pool";
+import { loadManifest, loadBackgroundById } from "./lib/bg-pool";
 import { createDaily7Draft, finalizeDaily7Draft, DAILY7_TEMPLATE_ID } from "./daily7-service";
 import { DraftConflictError } from "./db/drafts";
 import { generate } from "./engine";
@@ -45,6 +45,15 @@ export function getGenConfig(): GenConfig {
   return { days, slot };
 }
 
+/** tick interval (ms) — fail-closed: ต้อง positive int [ตู๋ P2.2] (NaN → setInterval รัว) */
+export function getGenTickMs(): number {
+  const raw = process.env.CONTENT_GEN_TICK_MS;
+  if (raw === undefined) return 10 * 60 * 1000; // default 10 นาที
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n <= 0) throw new Error(`CONTENT_GEN_TICK_MS ต้องเป็น positive int (ms): ${raw}`);
+  return n;
+}
+
 /**
  * precheck ก่อนจ่าย Gemini (gen 7 คำทำนาย = paid) [ตู๋ P1.4]: CTA/brand/bg/font ต้องพร้อม
  * ไม่งั้น gen จะไป FAIL ตอน engine.generate (CTA ว่าง) หรือ render (bg/font หาย) — เสีย Gemini cost ฟรี.
@@ -52,13 +61,31 @@ export function getGenConfig(): GenConfig {
 export function precheckGenReady(db: ContentDb): { ok: boolean; reason?: string } {
   const brand = getBrandProfile(db);
   if (!brand.ctaUrl.trim()) return { ok: false, reason: "CTA ว่าง — ตั้ง ctaUrl ใน Settings ก่อน (engine บังคับ CTA)" };
+  // อ่าน bg bytes จริง (sha256 + dim) ของ id ที่ render จะใช้ — ไม่ใช่แค่ manifest.length [ตู๋ P1.2]
+  // (corrupt/missing/sha ไม่ตรง → throw ที่นี่ แทนที่จะ burn gen 7 คำทำนายก่อน fail ตอน render)
   try {
-    if (loadManifest().length === 0) return { ok: false, reason: "bg pool ว่าง (manifest ไม่มี entry)" };
+    const manifest = loadManifest();
+    if (manifest.length === 0) return { ok: false, reason: "bg pool ว่าง (manifest ไม่มี entry)" };
+    loadBackgroundById(manifest[0].id); // = path ที่ runGenTick ใช้ (manifest[0])
   } catch (e) {
-    return { ok: false, reason: `bg manifest โหลดไม่ได้: ${e instanceof Error ? e.message : String(e)}` };
+    return { ok: false, reason: `bg ใช้ไม่ได้: ${e instanceof Error ? e.message : String(e)}` };
   }
-  if (!existsSync(FONT_PATH)) return { ok: false, reason: `font ไม่พบ: ${FONT_PATH}` };
+  // อ่าน font bytes จริง (เหมือน render loadFont) — ไม่ใช่แค่ existsSync [ตู๋ P1.2]
+  try {
+    readFileSync(FONT_PATH);
+  } catch {
+    return { ok: false, reason: `font อ่านไม่ได้: ${FONT_PATH}` };
+  }
   return { ok: true };
+}
+
+/** จำนวน daily-7 CANCELED ของ targetDate (= epoch) — เปลี่ยน gen key หลัง cancel เพื่อ gen ใหม่ได้ [ตู๋ P1.1] */
+export function countCanceledDaily7(db: ContentDb, targetDate: string): number {
+  return db
+    .select({ id: contentPosts.id })
+    .from(contentPosts)
+    .where(and(eq(contentPosts.templateId, DAILY7_TEMPLATE_ID), eq(contentPosts.status, "CANCELED"), sql`${td} = ${targetDate}`))
+    .all().length;
 }
 
 /** daily-7 ของ targetDate ที่ยังไม่ถูกยกเลิก (fence การันตี ≤1 row) — null ถ้ายังไม่มี */
@@ -124,14 +151,17 @@ export async function runGenTick(db: ContentDb, deps: GenTickDeps): Promise<GenT
   }
 
   // ยังไม่มี → create draft (gen 7) → finalize (สร้าง contentPost) → generate (รูป+caption)
-  const draft = await createDaily7Draft(db, `auto-daily7-${today}`, today);
+  // epoch = จำนวน CANCELED ของวันนี้ → key เปลี่ยนหลังลบ → gen ใหม่ได้ (ไม่ติด replay draft/finalize เดิม) [ตู๋ P1.1]
+  // ภายใน epoch เดิม (retry ไม่มี cancel เพิ่ม) → key เดิม → idempotent ไม่ gen ซ้ำ
+  const epoch = countCanceledDaily7(db, today);
+  const draft = await createDaily7Draft(db, `auto-daily7-${today}-${epoch}`, today);
   if (draft.status === "FAILED") {
     return { today, window: "open", action: "gen-failed", note: `draft gen FAILED: ${draft.error ?? "unknown"}` };
   }
   const bgId = loadManifest()[0].id; // precheck การันตีว่า manifest ไม่ว่างแล้ว
   let contentPostId: string;
   try {
-    contentPostId = finalizeDaily7Draft(db, draft.id, `auto-finalize-${today}`, draft.revision, bgId).contentPostId;
+    contentPostId = finalizeDaily7Draft(db, draft.id, `auto-finalize-${today}-${epoch}`, draft.revision, bgId).contentPostId;
   } catch (e) {
     // race: manual/auto path อื่นสร้าง daily-7 วันนี้ระหว่าง findExisting→finalize → fence ชน → idempotent skip
     if (e instanceof DraftConflictError) {

--- a/content-creator/gen-scheduler.ts
+++ b/content-creator/gen-scheduler.ts
@@ -1,0 +1,150 @@
+/**
+ * auto-gen reconcile loop [Phase 2b] — gen-worker เรียก runGenTick ทุก ~10 นาที
+ *
+ * pivot: ไม่ auto-publish (Meta App Review ตัน no-company) → auto-**generate** อย่างเดียว
+ * (ไม่แตะ FB เลย). ตื่นมา reconcile: "วันนี้มี daily-7 แล้วยัง? ถ้ายัง → gen ทิ้งไว้ GENERATED
+ * ให้ฟีมโพสต์ FB เอง". reconcile model = เปิดเครื่องเช้า worker ตื่น gen ของวันนี้ให้ (ไม่ต้อง caffeinate ทั้งคืน).
+ *
+ * idempotent วันละ 1:
+ *  - DB business fence (idx uniq_daily7_active [PR#101]) = 1 non-canceled artifact/targetDate
+ *  - deterministic key ต่อวัน (requestKey/finalizeKey = "auto-*-<today>") → create/finalize idempotent
+ *  - findExisting guard + DraftConflictError catch (race manual/auto) → skip ไม่จ่าย gen ซ้ำ
+ */
+import { and, asc, eq, ne, sql } from "drizzle-orm";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import type { ContentDb } from "./db/client";
+import { contentPosts, type ContentStatus } from "./db/schema";
+import { getBrandProfile } from "./db/brand";
+import { loadManifest } from "./lib/bg-pool";
+import { createDaily7Draft, finalizeDaily7Draft, DAILY7_TEMPLATE_ID } from "./daily7-service";
+import { DraftConflictError } from "./db/drafts";
+import { generate } from "./engine";
+import { bangkokTodayISO, bangkokDayOfWeek, bangkokMinutesOfDay, hhmmToMinutes } from "./lib/time";
+
+const HHMM = /^([01]\d|2[0-3]):([0-5]\d)$/;
+// ตรงกับ daily7.tsx FONT_PATH (render ต้องใช้ — precheck เช็คก่อนจ่าย Gemini)
+const FONT_PATH = join(process.cwd(), "assets", "fonts", "NotoSansThai-Bold.ttf");
+const td = sql`json_extract(${contentPosts.inputData}, '$.targetDate')`;
+
+export interface GenConfig {
+  /** วันที่ gen (0=อาทิตย์..6=เสาร์) ; default ทุกวัน */
+  days: number[];
+  /** gen เมื่อถึง/เลยเวลานี้ของวัน (Bangkok) ; default "00:00" = ของวันนี้ gen ได้ทันทีที่ขึ้นวันใหม่ */
+  slot: string;
+}
+
+/** อ่าน gen config — fail-closed (config ผิด → throw, worker ไม่ start) [เหมือน getScheduleConfig] */
+export function getGenConfig(): GenConfig {
+  const days = (process.env.CONTENT_GEN_DAYS ?? "0,1,2,3,4,5,6").split(",").map((s) => Number(s.trim()));
+  if (days.some((n) => !Number.isInteger(n) || n < 0 || n > 6)) {
+    throw new Error(`CONTENT_GEN_DAYS ผิด (ต้อง 0-6 คั่นด้วย ,): ${process.env.CONTENT_GEN_DAYS}`);
+  }
+  const slot = (process.env.CONTENT_GEN_SLOT ?? "00:00").trim();
+  if (!HHMM.test(slot)) throw new Error(`CONTENT_GEN_SLOT ผิด (ต้อง HH:mm): ${process.env.CONTENT_GEN_SLOT}`);
+  return { days, slot };
+}
+
+/**
+ * precheck ก่อนจ่าย Gemini (gen 7 คำทำนาย = paid) [ตู๋ P1.4]: CTA/brand/bg/font ต้องพร้อม
+ * ไม่งั้น gen จะไป FAIL ตอน engine.generate (CTA ว่าง) หรือ render (bg/font หาย) — เสีย Gemini cost ฟรี.
+ */
+export function precheckGenReady(db: ContentDb): { ok: boolean; reason?: string } {
+  const brand = getBrandProfile(db);
+  if (!brand.ctaUrl.trim()) return { ok: false, reason: "CTA ว่าง — ตั้ง ctaUrl ใน Settings ก่อน (engine บังคับ CTA)" };
+  try {
+    if (loadManifest().length === 0) return { ok: false, reason: "bg pool ว่าง (manifest ไม่มี entry)" };
+  } catch (e) {
+    return { ok: false, reason: `bg manifest โหลดไม่ได้: ${e instanceof Error ? e.message : String(e)}` };
+  }
+  if (!existsSync(FONT_PATH)) return { ok: false, reason: `font ไม่พบ: ${FONT_PATH}` };
+  return { ok: true };
+}
+
+/** daily-7 ของ targetDate ที่ยังไม่ถูกยกเลิก (fence การันตี ≤1 row) — null ถ้ายังไม่มี */
+export function findDaily7ByTargetDate(db: ContentDb, targetDate: string): { id: string; status: ContentStatus } | null {
+  const row = db
+    .select({ id: contentPosts.id, status: contentPosts.status })
+    .from(contentPosts)
+    .where(and(eq(contentPosts.templateId, DAILY7_TEMPLATE_ID), ne(contentPosts.status, "CANCELED"), sql`${td} = ${targetDate}`))
+    .orderBy(asc(contentPosts.createdAt))
+    .limit(1)
+    .get();
+  return row ?? null;
+}
+
+export interface GenTickDeps {
+  config: GenConfig;
+  /** inject สำหรับ test ; default = ตอนนี้จริง */
+  now?: Date;
+}
+
+export interface GenTickResult {
+  today: string;
+  window: "closed-day" | "closed-time" | "open";
+  action: "none" | "skip-precheck" | "skip-exists" | "skip-failed" | "resumed" | "generated" | "gen-failed";
+  status?: ContentStatus;
+  note: string;
+}
+
+/**
+ * reconcile 1 รอบ: gen daily-7 ของวันนี้ถ้ายังไม่มี (idempotent). ไม่แตะ FB.
+ */
+export async function runGenTick(db: ContentDb, deps: GenTickDeps): Promise<GenTickResult> {
+  const now = deps.now ?? new Date();
+  const today = bangkokTodayISO(now);
+
+  // gate: วัน + เวลา (Bangkok) — reconcile, ไม่ fire-at-slot เป๊ะ (เลยเวลาแล้วก็ยัง gen ให้)
+  if (!deps.config.days.includes(bangkokDayOfWeek(now))) {
+    return { today, window: "closed-day", action: "none", note: "วันนี้ไม่อยู่ใน gen days" };
+  }
+  if (bangkokMinutesOfDay(now) < hhmmToMinutes(deps.config.slot)) {
+    return { today, window: "closed-time", action: "none", note: `ยังไม่ถึง gen slot (${deps.config.slot})` };
+  }
+
+  // precheck ก่อนจ่าย Gemini [ตู๋ P1.4]
+  const pc = precheckGenReady(db);
+  if (!pc.ok) return { today, window: "open", action: "skip-precheck", note: pc.reason ?? "precheck ไม่ผ่าน" };
+
+  // มี daily-7 ของวันนี้แล้วหรือยัง (fence → ≤1 row)
+  const existing = findDaily7ByTargetDate(db, today);
+  if (existing) {
+    if (existing.status === "PENDING") {
+      // resume: เคยสร้าง post แต่ gen ค้าง (worker ตายก่อน gen เสร็จ) → gen ต่อ
+      const gen = await generate(db, existing.id);
+      const status = statusOf(db, existing.id);
+      return { today, window: "open", action: gen.ok ? "resumed" : "gen-failed", status, note: gen.ok ? "resume gen สำเร็จ" : `resume gen ล้ม: ${gen.error ?? gen.status}` };
+    }
+    if (existing.status === "FAILED") {
+      // ไม่ retry ใน tick loop (กัน burn) — surface ให้ฟีมจัดการมือ [ตู๋ P2]
+      return { today, window: "open", action: "skip-failed", status: "FAILED", note: "auto-gen วันนี้ FAILED — ต้อง manual resolve (ยกเลิก/regen เอง)" };
+    }
+    // GENERATED / APPROVED / PUBLISHING / POSTED → มีของวันนี้แล้ว
+    return { today, window: "open", action: "skip-exists", status: existing.status, note: `daily-7 วันนี้มีแล้ว (${existing.status})` };
+  }
+
+  // ยังไม่มี → create draft (gen 7) → finalize (สร้าง contentPost) → generate (รูป+caption)
+  const draft = await createDaily7Draft(db, `auto-daily7-${today}`, today);
+  if (draft.status === "FAILED") {
+    return { today, window: "open", action: "gen-failed", note: `draft gen FAILED: ${draft.error ?? "unknown"}` };
+  }
+  const bgId = loadManifest()[0].id; // precheck การันตีว่า manifest ไม่ว่างแล้ว
+  let contentPostId: string;
+  try {
+    contentPostId = finalizeDaily7Draft(db, draft.id, `auto-finalize-${today}`, draft.revision, bgId).contentPostId;
+  } catch (e) {
+    // race: manual/auto path อื่นสร้าง daily-7 วันนี้ระหว่าง findExisting→finalize → fence ชน → idempotent skip
+    if (e instanceof DraftConflictError) {
+      const ex = findDaily7ByTargetDate(db, today);
+      return { today, window: "open", action: "skip-exists", status: ex?.status, note: "daily-7 วันนี้ถูกสร้างไปแล้ว (race) — skip" };
+    }
+    throw e;
+  }
+  const gen = await generate(db, contentPostId);
+  const status = statusOf(db, contentPostId);
+  return { today, window: "open", action: gen.ok ? "generated" : "gen-failed", status, note: gen.ok ? "gen สำเร็จ → GENERATED รอโพสต์เอง" : `gen ล้ม: ${gen.error ?? gen.status}` };
+}
+
+function statusOf(db: ContentDb, id: string): ContentStatus | undefined {
+  return db.select({ status: contentPosts.status }).from(contentPosts).where(eq(contentPosts.id, id)).get()?.status;
+}

--- a/ecosystem.gen.config.cjs
+++ b/ecosystem.gen.config.cjs
@@ -1,0 +1,26 @@
+// pm2 config สำหรับ daily-7 AUTO-GEN worker [Phase 2b]
+// รัน: pm2 start ecosystem.gen.config.cjs ; persist: pm2 save && pm2 startup
+//
+// ⚠️ worker นี้ไม่แตะ Facebook — gen daily-7 ทิ้งไว้ GENERATED ให้ฟีมโพสต์เอง (manual workflow)
+// publish-worker เดิม (ecosystem.daily7.config.cjs) = LEGACY ไม่ใช้แล้ว — อย่า start คู่กัน
+//
+// env ที่ต้องมี: CONTENT_DB_PATH (sqlite จริง path เต็ม) + Gemini key (ผ่าน --env-file=.env.local)
+//   optional: CONTENT_GEN_DAYS="0,1,2,3,4,5,6", CONTENT_GEN_SLOT="00:00", CONTENT_GEN_TICK_MS=600000
+//   ❌ ไม่ต้องมี CONTENT_FB_PAGE_ID / CONTENT_FB_PAGE_ACCESS_TOKEN (gen-only ไม่ยิง FB)
+module.exports = {
+  apps: [
+    {
+      name: "mmv-daily7-gen",
+      script: "scripts/gen-worker.ts",
+      cwd: __dirname, // รันจาก project root → CONTENT_DB_PATH default + FONT_PATH (assets/fonts) + bg manifest ตรง
+      interpreter: "node",
+      interpreter_args: "--import tsx --env-file=.env.local",
+      autorestart: true,
+      max_restarts: 20,
+      env: {
+        NODE_ENV: "production",
+        // CONTENT_DB_PATH: "/abs/path/content.db",
+      },
+    },
+  ],
+};

--- a/scripts/gen-worker.ts
+++ b/scripts/gen-worker.ts
@@ -1,0 +1,35 @@
+/**
+ * gen-worker [Phase 2b] — pm2 worker เรียก runGenTick เป็นระยะ → auto-gen daily-7 ของวันนี้
+ *
+ * ไม่แตะ Facebook เลย (ต่างจาก publish-worker เดิมที่ legacy/ไม่ใช้แล้ว) — ใช้แค่:
+ *   CONTENT_DB_PATH (sqlite path เต็ม) + Gemini key (gen 7 คำทำนาย + caption ผ่าน .env.local)
+ * ไม่ต้องมี CONTENT_FB_* — gen เสร็จได้ GENERATED รอฟีมโพสต์ FB เอง.
+ *
+ * tick ไม่ overlap: in-process running flag (worker เดียว process เดียว) — กัน tick ซ้อนจ่าย gen ซ้ำ.
+ */
+import { getContentDb } from "../content-creator/db/client";
+import { runGenTick, getGenConfig } from "../content-creator/gen-scheduler";
+
+const INTERVAL_MS = Number(process.env.CONTENT_GEN_TICK_MS ?? 10 * 60 * 1000); // default 10 นาที
+let running = false;
+
+async function tick(): Promise<void> {
+  if (running) {
+    console.log("[gen-worker] tick ก่อนยังไม่เสร็จ — skip (กัน gen ซ้อน)");
+    return;
+  }
+  running = true;
+  try {
+    const result = await runGenTick(getContentDb(), { config: getGenConfig() });
+    console.log(`[gen-worker] ${new Date().toISOString()} ${JSON.stringify(result)}`);
+  } catch (e) {
+    console.error("[gen-worker] tick error:", e instanceof Error ? e.message : e);
+  } finally {
+    running = false;
+  }
+}
+
+// getGenConfig() เรียกตอน start ด้วย → config ผิด = throw = worker ไม่ start (fail-closed)
+console.log(`[gen-worker] started — tick ทุก ${INTERVAL_MS}ms · config ${JSON.stringify(getGenConfig())}`);
+void tick(); // tick แรกทันที
+setInterval(() => void tick(), INTERVAL_MS);

--- a/scripts/gen-worker.ts
+++ b/scripts/gen-worker.ts
@@ -8,9 +8,9 @@
  * tick ไม่ overlap: in-process running flag (worker เดียว process เดียว) — กัน tick ซ้อนจ่าย gen ซ้ำ.
  */
 import { getContentDb } from "../content-creator/db/client";
-import { runGenTick, getGenConfig } from "../content-creator/gen-scheduler";
+import { runGenTick, getGenConfig, getGenTickMs } from "../content-creator/gen-scheduler";
 
-const INTERVAL_MS = Number(process.env.CONTENT_GEN_TICK_MS ?? 10 * 60 * 1000); // default 10 นาที
+const INTERVAL_MS = getGenTickMs(); // fail-closed: ผิด → throw → worker ไม่ start [ตู๋ P2.2]
 let running = false;
 
 async function tick(): Promise<void> {


### PR DESCRIPTION
## สรุป
**Phase 2b** บนฐาน fence (PR#101). pivot: ไม่ auto-publish → **auto-GENERATE อย่างเดียว ไม่แตะ FB** → ไม่ติด Meta App Review (no-company). worker ตื่นทุก ~10 นาที → วันนี้ยังไม่มี daily-7? → gen ทิ้งไว้ **GENERATED** ให้ฟีมโพสต์ FB เอง (ผ่าน manual workflow PR#100).

**reconcile model:** เปิดเครื่องเช้า worker ตื่น gen ของวันนี้ให้ — ไม่ต้อง caffeinate ทั้งคืน. ถ้าไม่เปิดเครื่อง = วันนั้นไม่ gen (semi-manual อยู่แล้ว).

## เปลี่ยนอะไร
| ไฟล์ | เปลี่ยน |
|---|---|
| `content-creator/gen-scheduler.ts` (ใหม่) | `runGenTick` (gate→precheck→findExisting→create/finalize/generate) + getGenConfig + precheckGenReady + findDaily7ByTargetDate |
| `scripts/gen-worker.ts` (ใหม่) | pm2 worker — ไม่มี FB token, in-process flag กัน tick ซ้อน |
| `ecosystem.gen.config.cjs` (ใหม่) | pm2 config แยก (gen-only) — publish-worker เดิม legacy อย่า start คู่ |
| `api/daily/status` + `page.tsx` | FAILED visibility (banner) |

## ทำตาม design P1.3/P1.4/P2 (P1.1/P1.2 = fence ใน PR#101 แล้ว)
- **P1.3** gen-worker = process แยก ไม่มี `CONTENT_FB_*` (gen-only) ; ecosystem ไม่ reference publish-worker (legacy)
- **P1.4** precheck CTA/brand/bg(manifest)/font **ก่อน** createDaily7Draft → กัน burn Gemini 7 คำทำนายถ้า gen จะ FAIL
- **P2** FAILED วันนี้ → status route + UI banner (ไม่เงียบ) ; ไม่ retry ใน tick loop (skip-failed → ฟีม manual)

## idempotent วันละ 1
- DB fence (PR#101) + deterministic key (`auto-daily7-<today>`) + findExisting + `DraftConflictError` catch (race manual/auto finalize) → skip ไม่จ่าย gen ซ้ำ

## ✅ Real-path verified (ไม่ใช่แค่ mock)
tests mock `generate` (orchestration) — แต่ผมรัน **runGenTick จริงผ่าน tsx (เหมือน worker เป๊ะ)**:
```
RESULT: {"action":"generated","status":"GENERATED","note":"gen สำเร็จ → GENERATED รอโพสต์เอง"}
POST: GENERATED | img exists: true | caption: "สวัสดีค่าทุกคน 💖 วันที่ 17 มิ.ย. 69 ... พี่มี่ ..."
```
พิสูจน์ full integration: next/og render + Gemini + fence ทำงานจริง (ไม่ใช่ spike — เคยได้ฟีนิกซ์แทนแมว)

## ตรงไหนควรตรวจเป็นพิเศษ
1. `runGenTick` race catch (findExisting→finalize → DraftConflictError → skip) — idempotent ถูกไหม
2. precheck ครอบ failure modes ของ generate ครบไหม (CTA/manifest/font)
3. resume PENDING path (worker ตายก่อน gen เสร็จ → gen ต่อ)
4. `CONTENT_GEN_SLOT="00:00"` default = gen ของวันนี้ทันทีที่ tick — เหมาะกับ "เที่ยงคืน" ที่ฟีมอยากได้ไหม

## Test (15 ใหม่)
gate (closed-day/time) · precheck skip ไม่จ่าย Gemini · create→gen · idempotent 2ticks=1post · resume PENDING · skip-failed (ไม่ loop) · skip-exists (GENERATED/POSTED) · CANCELED ไม่บล็อก · gen-failed · getGenConfig fail-closed
- regression 0 (เหลือ 7 fail pre-existing) · typecheck ✅ · real-path ✅

🤖 ตอบโดย goo จาก [ฟีม] → goo-oracle