### PR TITLE
feat(content-creator): random-cards scene library (D2+D6 — gen→approve→wire) [PR2]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ next-env.d.ts
 # Oracle Framework
 content-creator/*.db*
 content-creator/media/
+
+# scene library runtime-gen images (เก็บ .gitkeep)
+content-creator/brand/scenes/*.png

--- a/app/content-creator/api/cards/draft/[id]/finalize/route.ts
+++ b/app/content-creator/api/cards/draft/[id]/finalize/route.ts
@@ -31,6 +31,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
   }
 
   const db = getContentDb();
+  // preflight (no approved scene → 409 draft READY) อยู่ใน finalizeRandomCardsDraft → throw DraftConflictError → draftErrorStatus 409
   let contentPostId: string;
   try {
     contentPostId = finalizeRandomCardsDraft(db, id, body.finalizeKey, body.expectedRevision).contentPostId;

--- a/app/content-creator/api/scenes/[id]/image/route.ts
+++ b/app/content-creator/api/scenes/[id]/image/route.ts
@@ -1,0 +1,25 @@
+/** GET /content-creator/api/scenes/:id/image — serve scene png (lookup id→imagePath ใน DB) [PR#105 ก้อน3] */
+import { NextResponse } from "next/server";
+import { readFileSync } from "node:fs";
+import { eq } from "drizzle-orm";
+import { getContentDb } from "@/content-creator/db/client";
+import { isContentCreatorEnabled } from "@/content-creator/lib/enabled";
+import { sceneLibrary } from "@/content-creator/db/schema";
+import { safeResolveUnderRoot } from "@/content-creator/lib/safe-path";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(_request: Request, ctx: { params: Promise<{ id: string }> }) {
+  if (!isContentCreatorEnabled()) return new NextResponse(null, { status: 404 });
+  const { id } = await ctx.params;
+  const row = getContentDb().select().from(sceneLibrary).where(eq(sceneLibrary.id, id)).get();
+  if (!row) return new NextResponse(null, { status: 404 });
+  // imagePath มาจาก DB (ไม่ใช่ client) แต่ safeResolve กัน traversal/symlink อีกชั้น
+  const full = safeResolveUnderRoot(process.cwd(), row.imagePath);
+  if (!full) return new NextResponse(null, { status: 404 });
+  return new NextResponse(new Uint8Array(readFileSync(full)), {
+    status: 200,
+    headers: { "Content-Type": "image/png", "Cache-Control": "no-store" },
+  });
+}

--- a/app/content-creator/api/scenes/[id]/route.ts
+++ b/app/content-creator/api/scenes/[id]/route.ts
@@ -1,0 +1,22 @@
+/** POST /content-creator/api/scenes/:id {action: approve|reject|retire} — status transition [PR#105 ก้อน3] */
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getContentDb } from "@/content-creator/db/client";
+import { isContentCreatorEnabled } from "@/content-creator/lib/enabled";
+import { approveScene, rejectScene, retireScene } from "@/content-creator/scene-pool";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+const Body = z.object({ action: z.enum(["approve", "reject", "retire"]) });
+
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  if (!isContentCreatorEnabled()) return new NextResponse(null, { status: 404 });
+  const { id } = await params;
+  let action: "approve" | "reject" | "retire";
+  try { action = Body.parse(await request.json()).action; } catch { return NextResponse.json({ ok: false, error: "invalid action" }, { status: 400 }); }
+  const db = getContentDb();
+  const fn = { approve: approveScene, reject: rejectScene, retire: retireScene }[action];
+  const ok = fn(db, id);
+  if (!ok) return NextResponse.json({ ok: false, error: `scene ไม่อยู่สถานะที่ ${action} ได้ (อาจถูกจัดการไปแล้ว)` }, { status: 409 });
+  return NextResponse.json({ ok: true, id, action });
+}

--- a/app/content-creator/api/scenes/gen-batch/route.ts
+++ b/app/content-creator/api/scenes/gen-batch/route.ts
@@ -1,0 +1,24 @@
+/** POST /content-creator/api/scenes/gen-batch {count?} — gen N scenes → PENDING [PR#105 ก้อน2]
+ *  ช้า (Gemini × N) — admin tool local รอได้. fail loud (ไม่ fallback). */
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getContentDb } from "@/content-creator/db/client";
+import { isContentCreatorEnabled } from "@/content-creator/lib/enabled";
+import { genSceneBatch } from "@/content-creator/scene-pool";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 800; // gen หลายภาพ ใช้เวลานาน
+const Body = z.object({ count: z.number().int().min(1).max(24).optional() });
+
+export async function POST(request: Request) {
+  if (!isContentCreatorEnabled()) return new NextResponse(null, { status: 404 });
+  let count = 8;
+  try { count = Body.parse(await request.json().catch(() => ({}))).count ?? 8; } catch { /* default */ }
+  try {
+    const r = await genSceneBatch(getContentDb(), count);
+    return NextResponse.json({ ok: true, ...r });
+  } catch (e) {
+    return NextResponse.json({ ok: false, error: e instanceof Error ? e.message : String(e) }, { status: 500 });
+  }
+}

--- a/app/content-creator/api/scenes/route.ts
+++ b/app/content-creator/api/scenes/route.ts
@@ -1,0 +1,19 @@
+/** GET /content-creator/api/scenes?status=PENDING — list scenes สำหรับ Gallery [PR#105 ก้อน3] */
+import { NextResponse } from "next/server";
+import { getContentDb } from "@/content-creator/db/client";
+import { isContentCreatorEnabled } from "@/content-creator/lib/enabled";
+import { listScenes, countApproved } from "@/content-creator/scene-pool";
+import type { SceneStatus } from "@/content-creator/db/schema";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+const STATUSES = ["PENDING", "APPROVED", "REJECTED", "RETIRED"];
+
+export async function GET(request: Request) {
+  if (!isContentCreatorEnabled()) return new NextResponse(null, { status: 404 });
+  const sp = new URL(request.url).searchParams.get("status");
+  const status = sp && STATUSES.includes(sp) ? (sp as SceneStatus) : undefined;
+  const db = getContentDb();
+  const scenes = listScenes(db, status).map((s) => ({ id: s.id, theme: s.theme, status: s.status, genBatch: s.genBatch }));
+  return NextResponse.json({ ok: true, scenes, approvedCount: countApproved(db) });
+}

--- a/app/content-creator/page.tsx
+++ b/app/content-creator/page.tsx
@@ -123,6 +123,12 @@ export default function ContentCreatorPage() {
             + สร้างใหม่
           </Link>
           <Link
+            href="/content-creator/scenes"
+            className="rounded-lg border px-3 py-1.5 text-sm hover:bg-gray-50"
+          >
+            🎴 Scenes
+          </Link>
+          <Link
             href="/content-creator/settings"
             className="rounded-lg border px-3 py-1.5 text-sm hover:bg-gray-50"
           >

--- a/app/content-creator/scenes/page.tsx
+++ b/app/content-creator/scenes/page.tsx
@@ -1,0 +1,109 @@
+"use client";
+/**
+ * /content-creator/scenes — Scene Library Gallery [PR#105 ก้อน3]
+ * gen batch → PENDING grid (✓approve/✗reject) → APPROVED (retire เก่าได้). human gate กันแมวหาย/crop.
+ * route guard middleware (404 ถ้า feature ไม่เปิด/production)
+ */
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+
+type Scene = { id: string; theme: string; status: string; genBatch: string };
+
+export default function ScenesPage() {
+  const [pending, setPending] = useState<Scene[]>([]);
+  const [approved, setApproved] = useState<Scene[]>([]);
+  const [approvedCount, setApprovedCount] = useState(0);
+  const [busy, setBusy] = useState(false);
+  const [genBusy, setGenBusy] = useState(false);
+  const [err, setErr] = useState("");
+
+  const load = useCallback(async () => {
+    setErr("");
+    try {
+      const [p, a] = await Promise.all([
+        fetch("/content-creator/api/scenes?status=PENDING", { cache: "no-store" }).then((r) => r.json()),
+        fetch("/content-creator/api/scenes?status=APPROVED", { cache: "no-store" }).then((r) => r.json()),
+      ]);
+      if (p.ok) setPending(p.scenes);
+      if (a.ok) { setApproved(a.scenes); setApprovedCount(a.approvedCount); }
+    } catch (e) { setErr(String(e)); }
+  }, []);
+  useEffect(() => { load(); }, [load]);
+
+  const act = useCallback(async (id: string, action: "approve" | "reject" | "retire") => {
+    setBusy(true); setErr("");
+    try {
+      const res = await fetch(`/content-creator/api/scenes/${id}`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ action }) });
+      const d = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(d.error ?? `${action} ไม่สำเร็จ (${res.status})`);
+      await load();
+    } catch (e) { setErr(e instanceof Error ? e.message : String(e)); } finally { setBusy(false); }
+  }, [load]);
+
+  const genBatch = useCallback(async () => {
+    if (!window.confirm("gen scene ชุดใหม่ 8 ภาพ? (ใช้ Gemini ~2-3 นาที)")) return;
+    setGenBusy(true); setErr("");
+    try {
+      const res = await fetch("/content-creator/api/scenes/gen-batch", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ count: 8 }) });
+      const d = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(d.error ?? `gen batch ล้ม (${res.status})`);
+      await load();
+    } catch (e) { setErr(e instanceof Error ? e.message : String(e)); } finally { setGenBusy(false); }
+  }, [load]);
+
+  return (
+    <main className="mx-auto max-w-4xl px-4 py-8">
+      <header className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Scene Library 🎴</h1>
+          <p className="text-sm text-gray-500">approve ฉากที่มีแมว ไม่ crop → random-cards สุ่มใช้ (APPROVED {approvedCount})</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Link href="/content-creator" className="rounded-lg border px-3 py-1.5 text-sm hover:bg-gray-50">← กลับ</Link>
+          <button onClick={genBatch} disabled={genBusy} className="rounded-lg bg-violet-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-violet-700 disabled:opacity-50">
+            {genBusy ? "กำลัง gen… (~2-3 นาที)" : "+ gen ชุดใหม่ (8)"}
+          </button>
+          <button onClick={load} disabled={busy} className="rounded-lg border px-3 py-1.5 text-sm hover:bg-gray-50">รีเฟรช</button>
+        </div>
+      </header>
+
+      {err && <div className="mb-4 rounded-lg bg-red-50 px-4 py-3 text-sm text-red-700">{err}</div>}
+      {genBusy && <div className="mb-4 rounded-lg bg-amber-50 px-4 py-3 text-sm text-amber-700">⏳ กำลัง gen scene… อย่าปิดหน้านี้ (Gemini ทีละภาพ)</div>}
+
+      <section>
+        <h2 className="mb-2 text-sm font-semibold text-gray-500">รอ approve (PENDING {pending.length})</h2>
+        {pending.length === 0 && <p className="rounded-lg bg-gray-50 px-4 py-6 text-center text-sm text-gray-500">ไม่มีฉากรอ approve — กด &quot;gen ชุดใหม่&quot;</p>}
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+          {pending.map((s) => (
+            <article key={s.id} className="overflow-hidden rounded-xl border shadow-sm">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={`/content-creator/api/scenes/${s.id}/image`} alt={s.theme} className="aspect-square w-full bg-gray-100 object-cover" />
+              <div className="space-y-2 p-2">
+                <p className="truncate text-xs text-gray-400">{s.theme}</p>
+                <div className="flex gap-2">
+                  <button onClick={() => act(s.id, "approve")} disabled={busy} className="flex-1 rounded-lg bg-emerald-600 px-2 py-1.5 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50">✓</button>
+                  <button onClick={() => act(s.id, "reject")} disabled={busy} className="flex-1 rounded-lg border border-red-300 px-2 py-1.5 text-sm text-red-700 hover:bg-red-50 disabled:opacity-50">✗</button>
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      {approved.length > 0 && (
+        <section className="mt-8">
+          <h2 className="mb-2 text-sm font-semibold text-gray-500">ใช้งานอยู่ (APPROVED {approved.length})</h2>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            {approved.map((s) => (
+              <article key={s.id} className="overflow-hidden rounded-xl border border-emerald-200 shadow-sm">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img src={`/content-creator/api/scenes/${s.id}/image`} alt={s.theme} className="aspect-square w-full bg-gray-100 object-cover" />
+                <button onClick={() => act(s.id, "retire")} disabled={busy} className="w-full px-2 py-1.5 text-xs text-gray-500 hover:bg-gray-50 disabled:opacity-50">🗄 retire</button>
+              </article>
+            ))}
+          </div>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/content-creator/__tests__/random-cards-engine.test.ts
+++ b/content-creator/__tests__/random-cards-engine.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { eq } from "drizzle-orm";
+
+// mock lib/gemini ทั้งหมด — เช็คว่า genCaption ไม่ถูกเรียกเมื่อไม่มี approved scene [ตู๋/บอง P1b]
+const mockGenCaption = vi.hoisted(() => vi.fn());
+vi.mock("../lib/gemini", () => ({
+  genCaption: mockGenCaption,
+  genObject: vi.fn(),
+  genImage: vi.fn(),
+  genImageWithRef: vi.fn(),
+}));
+
+import { createContentDb, type ContentDb } from "../db/client";
+import { contentPosts, sceneLibrary } from "../db/schema";
+import { updateBrandProfile } from "../db/brand";
+import { generate } from "../engine";
+import { drawCards } from "../lib/card-pool";
+
+let db: ContentDb;
+beforeEach(() => {
+  db = createContentDb(":memory:");
+  mockGenCaption.mockReset().mockResolvedValue("cap https://maemormimi.com/");
+  updateBrandProfile(db, { ctaUrl: "https://maemormimi.com/", refImagePath: "content-creator/brand/mimi-reference.png" });
+});
+
+function insertRcPost(id: string) {
+  const cardIds = drawCards(id, 3).map((c) => c.id);
+  db.insert(contentPosts).values({ id, requestKey: `rk-${id}`, templateId: "random-cards", inputData: { cardIds, quote: "q", body: "b" }, status: "PENDING" }).run();
+}
+
+describe("engine hybrid — pickApprovedScene ก่อน genCaption [ตู๋/บอง PR#105 P1b]", () => {
+  it("ไม่มี approved scene → FAILED + **ไม่เรียก genCaption** (ไม่เสีย paid caption)", async () => {
+    insertRcPost("rc");
+    const r = await generate(db, "rc"); // sceneLibrary ว่าง → pickApprovedScene throw ก่อน genCaption
+    expect(r.status).toBe("FAILED");
+    expect(mockGenCaption).not.toHaveBeenCalled();
+    expect(db.select().from(contentPosts).where(eq(contentPosts.id, "rc")).get()?.status).toBe("FAILED");
+  });
+
+  it("มี approved scene → ผ่าน pickApprovedScene → ถึง genCaption (เรียก 1 ครั้ง)", async () => {
+    db.insert(sceneLibrary).values({ id: "s1", theme: "t", imagePath: "content-creator/brand/mimi-reference.png", status: "APPROVED", genBatch: "b" }).run();
+    insertRcPost("rc2");
+    await generate(db, "rc2");
+    expect(mockGenCaption).toHaveBeenCalled(); // pick ผ่าน → ถึง genCaption (ตรงข้ามเคสไม่มี scene)
+  });
+});

--- a/content-creator/__tests__/random-cards-service.test.ts
+++ b/content-creator/__tests__/random-cards-service.test.ts
@@ -8,6 +8,7 @@ import { createContentDb, type ContentDb } from "../db/client";
 import { contentPosts, sceneLibrary } from "../db/schema";
 import { getDraft } from "../db/drafts";
 import { createRandomCardsDraft, regenRandomCardsDraft, finalizeRandomCardsDraft } from "../random-cards-service";
+import { countApproved } from "../scene-pool";
 
 const reading = () => ({ quote: "เปลี่ยนแปลงสู่สิ่งที่ดี", body: "ช่วงนี้มีพลังบวกเข้ามา จงเชื่อมั่น" });
 // finalize ต้องมี approved scene (preflight) — helper เพิ่ม 1 ใบ
@@ -83,5 +84,19 @@ describe("regen + finalize", () => {
     expect(replay.contentPostId).toBe(first.contentPostId);
     expect(replay.replay).toBe(true);
     expect(db.select().from(contentPosts).all()).toHaveLength(1); // ไม่มี post ซ้ำ
+  });
+
+  it("[ตู๋ re-review] finalize สำเร็จ → retire approved scenes หมด (count=0) → replay key เดิ่ม คืน post เดิม ไม่ 409", async () => {
+    const d = await createRandomCardsDraft(db, "rk");
+    approveScene(db);
+    const first = finalizeRandomCardsDraft(db, d.id, "fk", d.revision); // สำเร็จ
+    // จำลอง: scenes ทั้งหมดถูก retire → count=0 (response finalize หาย + reload)
+    db.update(sceneLibrary).set({ status: "RETIRED" }).run();
+    expect(countApproved(db)).toBe(0);
+    // replay key เดิม → fast-path คืน post เดิม **ก่อน** preflight (ไม่ 409, ไม่สร้างซ้ำ)
+    const replay = finalizeRandomCardsDraft(db, d.id, "fk", d.revision);
+    expect(replay.contentPostId).toBe(first.contentPostId);
+    expect(replay.replay).toBe(true);
+    expect(db.select().from(contentPosts).all()).toHaveLength(1);
   });
 });

--- a/content-creator/__tests__/random-cards-service.test.ts
+++ b/content-creator/__tests__/random-cards-service.test.ts
@@ -5,11 +5,14 @@ const mockGenObject = vi.hoisted(() => vi.fn());
 vi.mock("../lib/gemini", () => ({ genObject: mockGenObject }));
 
 import { createContentDb, type ContentDb } from "../db/client";
-import { contentPosts } from "../db/schema";
+import { contentPosts, sceneLibrary } from "../db/schema";
 import { getDraft } from "../db/drafts";
 import { createRandomCardsDraft, regenRandomCardsDraft, finalizeRandomCardsDraft } from "../random-cards-service";
 
 const reading = () => ({ quote: "เปลี่ยนแปลงสู่สิ่งที่ดี", body: "ช่วงนี้มีพลังบวกเข้ามา จงเชื่อมั่น" });
+// finalize ต้องมี approved scene (preflight) — helper เพิ่ม 1 ใบ
+const approveScene = (db: ContentDb) =>
+  db.insert(sceneLibrary).values({ id: crypto.randomUUID(), theme: "t", imagePath: "content-creator/brand/mimi-reference.png", status: "APPROVED", genBatch: "b" }).run();
 
 let db: ContentDb;
 beforeEach(() => {
@@ -52,8 +55,16 @@ describe("regen + finalize", () => {
     expect(mockGenObject).toHaveBeenCalledTimes(2);
   });
 
+  it("[ตู๋/บอง P1] no approved scene → finalize throw (DraftConflictError) + draft คง READY + ไม่สร้าง contentPost", async () => {
+    const d = await createRandomCardsDraft(db, "rk"); // ไม่มี approved scene
+    expect(() => finalizeRandomCardsDraft(db, d.id, "fk", d.revision)).toThrow(/approved scene|scenes/);
+    expect(getDraft(db, d.id)!.status).toBe("READY"); // ไม่ lock
+    expect(db.select().from(contentPosts).all()).toHaveLength(0); // ไม่สร้าง post (ไม่จ่าย caption/image)
+  });
+
   it("finalize → contentPost PENDING + persist cardIds/quote/body", async () => {
     const d = await createRandomCardsDraft(db, "rk");
+    approveScene(db);
     const res = finalizeRandomCardsDraft(db, d.id, "fk", d.revision);
     const post = db.select().from(contentPosts).where(eq(contentPosts.id, res.contentPostId)).get();
     expect(post?.status).toBe("PENDING");
@@ -65,6 +76,7 @@ describe("regen + finalize", () => {
 
   it("[ตู๋ P1 reload] finalize replay (finalizeKey เดิม หลัง FINALIZED) → contentPost เดิม ไม่สร้างซ้ำ", async () => {
     const d = await createRandomCardsDraft(db, "rk");
+    approveScene(db);
     const first = finalizeRandomCardsDraft(db, d.id, "fk", d.revision);
     // จำลอง reload → POST finalize ซ้ำด้วย key เดิม (draft FINALIZED แล้ว) → ต้องคืน post เดิม (idempotent)
     const replay = finalizeRandomCardsDraft(db, d.id, "fk", d.revision);

--- a/content-creator/__tests__/scene-pool.test.ts
+++ b/content-creator/__tests__/scene-pool.test.ts
@@ -3,6 +3,7 @@ import { eq } from "drizzle-orm";
 import { createContentDb, type ContentDb } from "../db/client";
 import { sceneLibrary } from "../db/schema";
 import { approveScene, rejectScene, retireScene, pickApprovedScene, listScenes, countApproved } from "../scene-pool";
+import { buildImageProviderOptions } from "../lib/gemini";
 
 const REF = "content-creator/brand/mimi-reference.png"; // ไฟล์จริง readable (สำหรับ pick อ่าน bytes)
 function insertScene(db: ContentDb, id: string, status: string, imagePath = REF) {
@@ -64,12 +65,26 @@ describe("pickApprovedScene [ก้อน 4 — exclude RETIRED/PENDING/REJECTED
 });
 
 describe("list / count", () => {
-  it("listScenes(status) filter + countApproved", () => {
+  it("listScenes(status) filter + countApproved count(*) เฉพาะ APPROVED (exclude RETIRED) [P2]", () => {
     insertScene(db, "p1", "PENDING");
     insertScene(db, "p2", "PENDING");
     insertScene(db, "a1", "APPROVED");
+    insertScene(db, "a2", "APPROVED");
+    insertScene(db, "ret", "RETIRED");
     expect(listScenes(db, "PENDING")).toHaveLength(2);
-    expect(listScenes(db)).toHaveLength(3);
-    expect(countApproved(db)).toBe(1);
+    expect(listScenes(db)).toHaveLength(5);
+    expect(countApproved(db)).toBe(2); // นับเฉพาะ APPROVED — RETIRED ไม่นับ
+  });
+});
+
+describe("[P2] genImageWithRef aspectRatio — backward-compat", () => {
+  it("ไม่ส่ง aspectRatio → providerOptions.google ไม่มี imageConfig (behavior เดิม)", () => {
+    const o = buildImageProviderOptions();
+    expect(o.google.responseModalities).toEqual(["TEXT", "IMAGE"]);
+    expect("imageConfig" in o.google).toBe(false);
+  });
+  it("ส่ง '1:1' → imageConfig.aspectRatio = '1:1'", () => {
+    const o = buildImageProviderOptions("1:1") as { google: { imageConfig?: { aspectRatio: string } } };
+    expect(o.google.imageConfig?.aspectRatio).toBe("1:1");
   });
 });

--- a/content-creator/__tests__/scene-pool.test.ts
+++ b/content-creator/__tests__/scene-pool.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { eq } from "drizzle-orm";
+import { createContentDb, type ContentDb } from "../db/client";
+import { sceneLibrary } from "../db/schema";
+import { approveScene, rejectScene, retireScene, pickApprovedScene, listScenes, countApproved } from "../scene-pool";
+
+const REF = "content-creator/brand/mimi-reference.png"; // ไฟล์จริง readable (สำหรับ pick อ่าน bytes)
+function insertScene(db: ContentDb, id: string, status: string, imagePath = REF) {
+  db.insert(sceneLibrary).values({ id, theme: "t", imagePath, status: status as never, genBatch: "b1" }).run();
+}
+const statusOf = (db: ContentDb, id: string) => db.select().from(sceneLibrary).where(eq(sceneLibrary.id, id)).get()?.status;
+
+let db: ContentDb;
+beforeEach(() => { db = createContentDb(":memory:"); });
+
+describe("scene-pool status transitions [PR#105 ก้อน1-4]", () => {
+  it("approve PENDING→APPROVED (+approvedAt) ; reject PENDING→REJECTED", () => {
+    insertScene(db, "p", "PENDING");
+    expect(approveScene(db, "p")).toBe(true);
+    const row = db.select().from(sceneLibrary).where(eq(sceneLibrary.id, "p")).get();
+    expect(row?.status).toBe("APPROVED");
+    expect(row?.approvedAt).not.toBeNull();
+    insertScene(db, "r", "PENDING");
+    expect(rejectScene(db, "r")).toBe(true);
+    expect(statusOf(db, "r")).toBe("REJECTED");
+  });
+
+  it("retire APPROVED→RETIRED (+retiredAt) ; เก็บไฟล์ (Nothing is Deleted)", () => {
+    insertScene(db, "a", "APPROVED");
+    expect(retireScene(db, "a")).toBe(true);
+    const row = db.select().from(sceneLibrary).where(eq(sceneLibrary.id, "a")).get();
+    expect(row?.status).toBe("RETIRED");
+    expect(row?.retiredAt).not.toBeNull();
+    expect(row?.imagePath).toBe(REF); // ไฟล์ยังอยู่
+  });
+
+  it("transition guard: ไม่กลับทาง — approve non-PENDING / retire non-APPROVED → false (ไม่เปลี่ยน)", () => {
+    insertScene(db, "a", "APPROVED");
+    expect(approveScene(db, "a")).toBe(false); // APPROVED แล้ว approve ซ้ำไม่ได้
+    expect(rejectScene(db, "a")).toBe(false); // reject ได้เฉพาะ PENDING
+    insertScene(db, "p", "PENDING");
+    expect(retireScene(db, "p")).toBe(false); // retire ได้เฉพาะ APPROVED
+    expect(statusOf(db, "p")).toBe("PENDING"); // ไม่ถูกแตะ
+    insertScene(db, "ret", "RETIRED");
+    expect(retireScene(db, "ret")).toBe(false); // RETIRED terminal
+  });
+});
+
+describe("pickApprovedScene [ก้อน 4 — exclude RETIRED/PENDING/REJECTED]", () => {
+  it("สุ่มจาก APPROVED เท่านั้น — มี RETIRED/PENDING/REJECTED ปนก็ไม่หยิบ", () => {
+    insertScene(db, "approved", "APPROVED");
+    insertScene(db, "retired", "RETIRED");
+    insertScene(db, "pending", "PENDING");
+    insertScene(db, "rejected", "REJECTED");
+    // pick 10 รอบ → ต้องได้ bytes (จาก approved ตัวเดียว) ทุกรอบ ไม่ throw
+    for (let i = 0; i < 10; i++) expect(pickApprovedScene(db).length).toBeGreaterThan(1000);
+  });
+
+  it("ไม่มี APPROVED (มีแต่ RETIRED/PENDING) → throw fail loud 'gen batch first'", () => {
+    insertScene(db, "retired", "RETIRED");
+    insertScene(db, "pending", "PENDING");
+    expect(() => pickApprovedScene(db)).toThrow(/approved scene|gen batch/);
+  });
+});
+
+describe("list / count", () => {
+  it("listScenes(status) filter + countApproved", () => {
+    insertScene(db, "p1", "PENDING");
+    insertScene(db, "p2", "PENDING");
+    insertScene(db, "a1", "APPROVED");
+    expect(listScenes(db, "PENDING")).toHaveLength(2);
+    expect(listScenes(db)).toHaveLength(3);
+    expect(countApproved(db)).toBe(1);
+  });
+});

--- a/content-creator/db/migrations/0009_scene_library.sql
+++ b/content-creator/db/migrations/0009_scene_library.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `scene_library` (
+	`id` text PRIMARY KEY NOT NULL,
+	`theme` text NOT NULL,
+	`image_path` text NOT NULL,
+	`status` text DEFAULT 'PENDING' NOT NULL,
+	`gen_batch` text NOT NULL,
+	`created_at` integer NOT NULL,
+	`approved_at` integer,
+	`retired_at` integer
+);

--- a/content-creator/db/migrations/meta/_journal.json
+++ b/content-creator/db/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1781800000000,
       "tag": "0008_daily7_active_fence",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1781900000000,
+      "tag": "0009_scene_library",
+      "breakpoints": true
     }
   ]
 }

--- a/content-creator/db/schema.ts
+++ b/content-creator/db/schema.ts
@@ -127,3 +127,26 @@ export const contentDrafts = sqliteTable("content_drafts", {
 
 export type ContentDraft = typeof contentDrafts.$inferSelect;
 export type NewContentDraft = typeof contentDrafts.$inferInsert;
+
+/** scene library [PR#105 D2/D6] — AI scene ที่ gen ไว้ล่วงหน้า + ฟีม approve ด้วยตา (human gate กันแมวหาย/crop 100%) */
+export const SCENE_STATUSES = [
+  "PENDING", // เพิ่ง gen รอฟีม approve
+  "APPROVED", // ฟีมอนุมัติ — random-cards สุ่มใช้ได้
+  "REJECTED", // ฟีมปฏิเสธ (แมวหาย/crop/ไม่สวย)
+  "RETIRED", // เคย APPROVED แต่เลิกใช้ (เก็บไฟล์ — Nothing is Deleted)
+] as const;
+export type SceneStatus = (typeof SCENE_STATUSES)[number];
+
+export const sceneLibrary = sqliteTable("scene_library", {
+  id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),
+  theme: text("theme").notNull(),
+  imagePath: text("image_path").notNull(),
+  status: text("status").$type<SceneStatus>().notNull().default("PENDING"),
+  genBatch: text("gen_batch").notNull(), // จัดกลุ่ม gen รอบเดียวกัน (retire เป็น batch ได้)
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull().$defaultFn(() => new Date()),
+  approvedAt: integer("approved_at", { mode: "timestamp" }),
+  retiredAt: integer("retired_at", { mode: "timestamp" }),
+});
+
+export type SceneRow = typeof sceneLibrary.$inferSelect;
+export type NewScene = typeof sceneLibrary.$inferInsert;

--- a/content-creator/engine.ts
+++ b/content-creator/engine.ts
@@ -138,12 +138,11 @@ export async function generate(db: ContentDb, id: string): Promise<GenerateResul
           })
         : await genImage({ prompt: themeWithStyle });
     } else {
-      // hybrid [random-cards PR#103 → PR#105 scene library]: caption → pick scene ที่ฟีม approve แล้ว → composite
-      // [ก้อน 4] เลิก gen AI scene live → สุ่มจาก scene library (status APPROVED, exclude RETIRED)
-      // = human gate กันแมวหาย/crop 100% (ฟีม approve ด้วยตาแล้ว) + AI cost เกิดครั้งเดียวตอน gen batch
-      caption = await generateCaption(template.buildCaptionPrompt(parsed), brand, recentCaptions);
-      // ไม่มี approved scene → throw → FAILED (fail loud: ฟีมต้อง gen batch + approve ก่อน) [ตู๋ no-fallback]
+      // hybrid [random-cards PR#103 → PR#105 scene library]: pick scene (approved) → caption → composite
+      // [ก้อน 4] สุ่มจาก scene library (APPROVED, exclude RETIRED) = human gate กันแมวหาย/crop 100%
+      // **pick ก่อน generateCaption** [ตู๋ PR#105 P1]: ไม่มี approved scene → throw ก่อนจ่าย caption (fail loud ไม่เสีย paid)
       const scene = pickApprovedScene(db);
+      caption = await generateCaption(template.buildCaptionPrompt(parsed), brand, recentCaptions);
       // scene = in-memory ; final composed image คือ artifact เดียว (cleanup ใน catch) [ตู๋ P1]
       bytes = await template.renderComposite(parsed, { brand, seed: id }, scene);
     }

--- a/content-creator/engine.ts
+++ b/content-creator/engine.ts
@@ -14,6 +14,7 @@ import { contentPosts, type BrandProfile } from "./db/schema";
 import { getBrandProfile } from "./db/brand";
 import { claimForGenerate, markGenerated, releaseGenerate } from "./db/transition";
 import { genCaption, genImage, genImageWithRef } from "./lib/gemini";
+import { pickApprovedScene } from "./scene-pool";
 import { buildCaptionRequest, validateCaption, normalizeBrandTerms } from "./lib/caption";
 import { safeResolveUnderRoot } from "./lib/safe-path";
 import { getTemplate } from "./templates";
@@ -137,21 +138,13 @@ export async function generate(db: ContentDb, id: string): Promise<GenerateResul
           })
         : await genImage({ prompt: themeWithStyle });
     } else {
-      // hybrid [random-cards PR#103]: caption → AI scene (ref แมว, NO text/cards) → renderComposite วางไพ่จริง+ข้อความ
-      // explicit pipeline [ตู๋ P1]: ไพ่ถูก draw+persist ใน inputData ตั้งแต่ draft (ก่อน paid) → renderComposite อ่าน cardIds เดิม
-      const refImage = brand.refImagePath ? loadBrandRef(brand.refImagePath) : null;
-      if (!refImage) throw new Error("hybrid template ต้องมี brand ref image (ตั้ง refImagePath ใน Settings ก่อน gen)");
+      // hybrid [random-cards PR#103 → PR#105 scene library]: caption → pick scene ที่ฟีม approve แล้ว → composite
+      // [ก้อน 4] เลิก gen AI scene live → สุ่มจาก scene library (status APPROVED, exclude RETIRED)
+      // = human gate กันแมวหาย/crop 100% (ฟีม approve ด้วยตาแล้ว) + AI cost เกิดครั้งเดียวตอน gen batch
       caption = await generateCaption(template.buildCaptionPrompt(parsed), brand, recentCaptions);
-      const basePrompt = template.buildImagePrompt(parsed); // ฉาก AI (no text/cards)
-      const themeWithStyle = brand.stylePrompt ? `${basePrompt}\n\nสไตล์ภาพ: ${brand.stylePrompt}` : basePrompt;
-      // AI scene fail → throw → FAILED (ไม่มี composition fallback — final ขึ้นกับ brand visual) [ตู๋ P1]
-      const scene = await genImageWithRef({
-        prompt: `${refDirective(themeWithStyle)}\n\n${NO_TEXT_DIRECTIVE}`,
-        refImage,
-        model: brand.imageModel ?? undefined,
-      });
-      // scene = in-memory (ไม่เขียน temp → ไม่มี temp artifact ต้อง cleanup) ; final image คือ artifact เดียว (cleanup ใน catch)
-      // compose fail หลัง paid scene → throw → catch ลบ final artifact ที่ persist (ถ้ามี) [ตู๋ P1]
+      // ไม่มี approved scene → throw → FAILED (fail loud: ฟีมต้อง gen batch + approve ก่อน) [ตู๋ no-fallback]
+      const scene = pickApprovedScene(db);
+      // scene = in-memory ; final composed image คือ artifact เดียว (cleanup ใน catch) [ตู๋ P1]
       bytes = await template.renderComposite(parsed, { brand, seed: id }, scene);
     }
     attemptPath = persistImage(id, token, bytes); // fence เดิม (token-scoped) ครอบทั้ง 2 path

--- a/content-creator/lib/gemini.ts
+++ b/content-creator/lib/gemini.ts
@@ -75,6 +75,8 @@ export interface ImageWithRefInput {
   refImage: Uint8Array;
   /** model override (default REF_IMAGE_MODEL = nano banana) */
   model?: string;
+  /** aspect ratio เช่น "1:1" — **optional** (ไม่ส่ง = behavior เดิม) backward-compat caller อื่น [PR#105 ก้อน2] */
+  aspectRatio?: string;
 }
 
 /**
@@ -86,7 +88,13 @@ export interface ImageWithRefInput {
 export async function genImageWithRef(input: ImageWithRefInput): Promise<Uint8Array> {
   const result = await generateText({
     model: google(input.model ?? REF_IMAGE_MODEL),
-    providerOptions: { google: { responseModalities: ["TEXT", "IMAGE"] } },
+    providerOptions: {
+      google: {
+        responseModalities: ["TEXT", "IMAGE"],
+        // imageConfig.aspectRatio: ส่งเฉพาะเมื่อ caller ระบุ (ไม่ระบุ = ไม่ใส่ = behavior เดิม) [PR#105]
+        ...(input.aspectRatio ? { imageConfig: { aspectRatio: input.aspectRatio } } : {}),
+      },
+    },
     messages: [
       {
         role: "user",

--- a/content-creator/lib/gemini.ts
+++ b/content-creator/lib/gemini.ts
@@ -85,16 +85,23 @@ export interface ImageWithRefInput {
  * ส่ง ref ใน messages + responseModalities IMAGE, image output ที่ result.files[].uint8Array.
  * @throws ถ้า model ไม่คืน image
  */
+/**
+ * providerOptions.google สำหรับ ref-image gen [PR#105] — pure/testable.
+ * aspectRatio: ใส่ imageConfig เฉพาะเมื่อระบุ (ไม่ระบุ = ไม่มี imageConfig = behavior เดิม → backward-compat)
+ */
+export function buildImageProviderOptions(aspectRatio?: string) {
+  return {
+    google: {
+      responseModalities: ["TEXT", "IMAGE"],
+      ...(aspectRatio ? { imageConfig: { aspectRatio } } : {}),
+    },
+  };
+}
+
 export async function genImageWithRef(input: ImageWithRefInput): Promise<Uint8Array> {
   const result = await generateText({
     model: google(input.model ?? REF_IMAGE_MODEL),
-    providerOptions: {
-      google: {
-        responseModalities: ["TEXT", "IMAGE"],
-        // imageConfig.aspectRatio: ส่งเฉพาะเมื่อ caller ระบุ (ไม่ระบุ = ไม่ใส่ = behavior เดิม) [PR#105]
-        ...(input.aspectRatio ? { imageConfig: { aspectRatio: input.aspectRatio } } : {}),
-      },
-    },
+    providerOptions: buildImageProviderOptions(input.aspectRatio),
     messages: [
       {
         role: "user",

--- a/content-creator/random-cards-service.ts
+++ b/content-creator/random-cards-service.ts
@@ -5,9 +5,10 @@
  */
 import { z } from "zod";
 import type { ContentDb } from "./db/client";
-import { createDraft, completeDraftGen, failDraftGen, claimRegen, finalizeDraft, getDraft, DraftStaleError, type ContentDraft, type FinalizeResult } from "./db/drafts";
+import { createDraft, completeDraftGen, failDraftGen, claimRegen, finalizeDraft, getDraft, DraftStaleError, DraftConflictError, type ContentDraft, type FinalizeResult } from "./db/drafts";
 import { genObject } from "./lib/gemini";
 import { drawCards, selectCardById } from "./lib/card-pool";
+import { countApproved } from "./scene-pool";
 import { randomCardsSchema, RANDOM_CARDS_TEMPLATE_ID } from "./templates/random-cards";
 
 export { RANDOM_CARDS_TEMPLATE_ID };
@@ -65,10 +66,15 @@ export async function regenRandomCardsDraft(db: ContentDb, id: string, attemptKe
   return getDraft(db, id)!;
 }
 
-/** finalize → สร้าง contentPost (persist cardIds+quote+body). ไม่มี backgroundId (hybrid ใช้ AI scene) */
+/** finalize → สร้าง contentPost (persist cardIds+quote+body). ไม่มี backgroundId (hybrid ใช้ scene library) */
 export function finalizeRandomCardsDraft(db: ContentDb, id: string, finalizeKey: string, expectedRevision: number): FinalizeResult {
   const draft = getDraft(db, id);
   if (!draft) throw new DraftStaleError(`ไม่พบ draft: ${id}`);
+  // preflight [ตู๋/บอง PR#105 P1]: ไม่มี approved scene → throw **ก่อน** finalizeDraft → draft คง READY (ไม่ lock,
+  // ไม่สร้าง contentPost, ไม่จ่าย caption/image ตอน generate). DraftConflictError → route map 409.
+  if (countApproved(db) === 0) {
+    throw new DraftConflictError("ยังไม่มี approved scene — gen batch + approve ที่ /content-creator/scenes ก่อน finalize");
+  }
   const finalInput = randomCardsSchema.parse(draft.draftData ?? {}); // strict: 3 ใบ unique + quote/body
   return finalizeDraft(db, id, finalizeKey, expectedRevision, finalInput, RANDOM_CARDS_TEMPLATE_ID);
 }

--- a/content-creator/random-cards-service.ts
+++ b/content-creator/random-cards-service.ts
@@ -70,8 +70,13 @@ export async function regenRandomCardsDraft(db: ContentDb, id: string, attemptKe
 export function finalizeRandomCardsDraft(db: ContentDb, id: string, finalizeKey: string, expectedRevision: number): FinalizeResult {
   const draft = getDraft(db, id);
   if (!draft) throw new DraftStaleError(`ไม่พบ draft: ${id}`);
-  // preflight [ตู๋/บอง PR#105 P1]: ไม่มี approved scene → throw **ก่อน** finalizeDraft → draft คง READY (ไม่ lock,
-  // ไม่สร้าง contentPost, ไม่จ่าย caption/image ตอน generate). DraftConflictError → route map 409.
+  // fast-path replay [ตู๋ PR#105 re-review]: finalize สำเร็จแล้ว (response หาย+reload) → คืน post เดิม **ก่อน** preflight
+  // (ไม่งั้น scene ถูก retire จน count=0 → reload จะ 409 แทน replay → ฟีมค้าง classify status จริงไม่ได้)
+  if (draft.finalizeKey === finalizeKey && draft.contentPostId) {
+    return { contentPostId: draft.contentPostId, replay: true };
+  }
+  // preflight (fresh finalize เท่านั้น) [ตู๋/บอง P1]: ไม่มี approved scene → throw ก่อน finalizeDraft →
+  // draft คง READY (ไม่ lock/ไม่สร้าง contentPost/ไม่จ่าย caption). DraftConflictError → route map 409.
   if (countApproved(db) === 0) {
     throw new DraftConflictError("ยังไม่มี approved scene — gen batch + approve ที่ /content-creator/scenes ก่อน finalize");
   }

--- a/content-creator/scene-pool.ts
+++ b/content-creator/scene-pool.ts
@@ -1,0 +1,103 @@
+/**
+ * scene library [PR#105 D2/D6] — gen AI scene (แมว Mimi) ล่วงหน้าเป็น batch → ฟีม approve ด้วยตา
+ * → random-cards สุ่มใช้จาก APPROVED (human gate กันแมวหาย/crop 100%). ไม่ fallback (fail loud).
+ *
+ * status machine: PENDING ─approve→ APPROVED ─retire→ RETIRED | PENDING ─reject→ REJECTED (เก็บไฟล์ทั้งหมด — Nothing is Deleted)
+ */
+import { mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { and, eq, sql } from "drizzle-orm";
+import type { ContentDb } from "./db/client";
+import { sceneLibrary, type SceneRow } from "./db/schema";
+import { getBrandProfile } from "./db/brand";
+import { genImageWithRef } from "./lib/gemini";
+import { safeResolveUnderRoot } from "./lib/safe-path";
+
+export const SCENES_DIR = "content-creator/brand/scenes"; // relative (commit .gitkeep ; .png runtime gitignored)
+
+/** anti-ฟีนิกซ์ + cat-only (tighten ตาม ก้อน 2: แมว subject เดียว ห้ามคน) */
+const SCENE_DIRECTIVE =
+  "ใช้ตัวละคร 'แมว' จากภาพอ้างอิงให้เหมือนเป๊ะ — เป็นแมวตัวเดียวกัน (สี/หน้าตา/ผ้าโพกหัว/เครื่องประดับตรงกันทุกจุด) เป็น subject เดียวของภาพ. " +
+  "**ห้ามมีคน/มนุษย์/มือคนในภาพ ห้ามเปลี่ยนเป็นสัตว์อื่น (ห้ามนก/ฟีนิกซ์)**. ";
+const SCENE_NO_TEXT = "ห้ามมีตัวอักษร ข้อความ ไพ่ทาโรต์ หรือลายน้ำใด ๆ บนภาพ (no text/letters/cards/watermark).";
+
+/** ธีมฉากหลากหลาย (gen variety) — แมวในบรรยากาศ tarot ต่างๆ */
+const SCENE_THEMES = [
+  "เช้าอบอุ่นแสงนุ่ม", "ค่ำคืนใต้แสงดาว", "สวนดอกไม้พาสเทล", "ห้องคริสตัลเรืองแสง",
+  "โต๊ะไม้มีเทียนหลายเล่ม", "ม่านลูกไม้ชมพู", "ควันธูปลอยอ้อยอิ่ง", "ดอกไม้แห้งสีพีช",
+  "แสงทองยามเย็น", "ลูกแก้วพยากรณ์", "ผลึกหินสีม่วง", "บรรยากาศมินิมอลโทนครีม",
+];
+
+/** prompt 1 scene — แมวในบรรยากาศ tarot (no person/text/cards) + ธีม + เว้นที่กลาง-ล่างสำหรับ composition */
+function buildScenePrompt(theme: string): string {
+  return (
+    `${SCENE_DIRECTIVE}สร้างฉากโต๊ะดูดวงทาโรต์ บรรยากาศ cozy mystic ธีม: ${theme}. ` +
+    "โทนพีช-ชมพู-ลาเวนเดอร์ นุ่มนวล digital illustration soft painterly สวยงาม. " +
+    "วางแมวมุมบน (ขนาดพอเห็นชัดเป็นแบรนด์ ไม่ล้ำลงกลาง/ล่าง). ครึ่งกลาง-ล่างเป็นพื้นโต๊ะโล่งเรียบ. " +
+    `ภาพจัตุรัส 1:1. ${SCENE_NO_TEXT}`
+  );
+}
+
+function persistScene(id: string, bytes: Uint8Array): string {
+  mkdirSync(SCENES_DIR, { recursive: true });
+  const rel = `${SCENES_DIR}/${id}.png`;
+  writeFileSync(rel, bytes);
+  return rel;
+}
+
+export interface GenBatchResult { batch: string; count: number; ids: string[] }
+
+/**
+ * gen N scenes (default 12) → save + insert PENDING row (genBatch เดียวกัน). fail loud (ไม่ skip/fallback).
+ * ใช้ aspectRatio 1:1 (กัน crop) + ref แมว. ต้องมี brand.refImagePath ไม่งั้น throw.
+ */
+export async function genSceneBatch(db: ContentDb, count = 12): Promise<GenBatchResult> {
+  const brand = getBrandProfile(db);
+  if (!brand.refImagePath) throw new Error("scene batch: ต้องตั้ง brand ref image (refImagePath) ก่อน");
+  const refReal = safeResolveUnderRoot(process.cwd(), brand.refImagePath);
+  if (!refReal) throw new Error(`scene batch: brand ref ไม่พบ/ไม่ปลอดภัย: ${brand.refImagePath}`);
+  const refImage = new Uint8Array(readFileSync(refReal));
+
+  const batch = `batch-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
+  const ids: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const theme = SCENE_THEMES[i % SCENE_THEMES.length];
+    const bytes = await genImageWithRef({ prompt: buildScenePrompt(theme), refImage, aspectRatio: "1:1", model: brand.imageModel ?? undefined });
+    const id = crypto.randomUUID();
+    const imagePath = persistScene(id, bytes);
+    db.insert(sceneLibrary).values({ id, theme, imagePath, status: "PENDING", genBatch: batch }).run();
+    ids.push(id);
+  }
+  return { batch, count: ids.length, ids };
+}
+
+/** atomic transition — คืน true ถ้าเปลี่ยนสำเร็จ (false = row ไม่อยู่ state ที่คาด → stale/ผิดทาง) */
+function transition(db: ContentDb, id: string, from: SceneRow["status"], to: SceneRow["status"], patch: Partial<SceneRow> = {}): boolean {
+  const res = db.update(sceneLibrary).set({ status: to, ...patch }).where(and(eq(sceneLibrary.id, id), eq(sceneLibrary.status, from))).run();
+  return res.changes === 1;
+}
+
+export const approveScene = (db: ContentDb, id: string) => transition(db, id, "PENDING", "APPROVED", { approvedAt: new Date() });
+export const rejectScene = (db: ContentDb, id: string) => transition(db, id, "PENDING", "REJECTED");
+export const retireScene = (db: ContentDb, id: string) => transition(db, id, "APPROVED", "RETIRED", { retiredAt: new Date() });
+
+/** list scenes ตาม status (gallery) */
+export function listScenes(db: ContentDb, status?: SceneRow["status"]): SceneRow[] {
+  const q = db.select().from(sceneLibrary);
+  return (status ? q.where(eq(sceneLibrary.status, status)) : q).all();
+}
+export function countApproved(db: ContentDb): number {
+  return db.select({ id: sceneLibrary.id }).from(sceneLibrary).where(eq(sceneLibrary.status, "APPROVED")).all().length;
+}
+
+/**
+ * สุ่ม 1 scene จาก APPROVED (exclude RETIRED/PENDING/REJECTED) → bytes. [ก้อน 4]
+ * ไม่มี APPROVED → throw (fail loud — ฟีมต้อง gen batch + approve ก่อน). ใช้โดย engine hybrid.
+ */
+export function pickApprovedScene(db: ContentDb): Uint8Array {
+  const row = db.select().from(sceneLibrary).where(eq(sceneLibrary.status, "APPROVED")).orderBy(sql`RANDOM()`).limit(1).get();
+  if (!row) throw new Error("ยังไม่มี approved scene — gen batch + approve ที่ /content-creator/scenes ก่อน");
+  const real = safeResolveUnderRoot(process.cwd(), row.imagePath);
+  if (!real) throw new Error(`scene ไม่พบ/ไม่ปลอดภัย: ${row.imagePath}`);
+  return new Uint8Array(readFileSync(real));
+}

--- a/content-creator/scene-pool.ts
+++ b/content-creator/scene-pool.ts
@@ -87,7 +87,8 @@ export function listScenes(db: ContentDb, status?: SceneRow["status"]): SceneRow
   return (status ? q.where(eq(sceneLibrary.status, status)) : q).all();
 }
 export function countApproved(db: ContentDb): number {
-  return db.select({ id: sceneLibrary.id }).from(sceneLibrary).where(eq(sceneLibrary.status, "APPROVED")).all().length;
+  const r = db.select({ n: sql<number>`count(*)` }).from(sceneLibrary).where(eq(sceneLibrary.status, "APPROVED")).get();
+  return r?.n ?? 0;
 }
 
 /**


### PR DESCRIPTION
## สรุป
PR2 ของแผน random-cards-scene-library (บอง) — **ก้อน 1-4**. แก้ **D2 (แมวหาย) + D6 (crop) ให้ 100%** ด้วย:
- **gen scene ล่วงหน้าเป็น batch** + **ฟีม approve ด้วยตา** (human gate — เห็นแมว ไม่ crop ค่อยอนุมัติ)
- **aspectRatio 1:1** (กัน crop ตั้งแต่ gen)
- random-cards สุ่มใช้จาก **APPROVED** แทน gen AI live (cost เกิดครั้งเดียว)

## ก้อน 1-4
| ก้อน | สิ่งที่ทำ |
|---|---|
| 1 | `scene_library` table (migration 0009 + drizzle schema + `SCENE_STATUSES` PENDING/APPROVED/REJECTED/RETIRED) + `brand/scenes/` |
| 2 | `scene-pool.genSceneBatch` (N=8 default, theme variety, fail loud) · `genImageWithRef` + `aspectRatio` **optional** (backward-compat) · SCENE_DIRECTIVE แมว subject เดียว ห้ามคน/ฟีนิกซ์ |
| 3 | `/content-creator/scenes` Gallery (PENDING ✓/✗ · APPROVED retire) + routes (list/gen-batch/[id] action/[id]/image) + nav link |
| 4 | engine hybrid → `pickApprovedScene` (random APPROVED, exclude RETIRED) ; ไม่มี approved → fail loud |

## ⚠️ backward-compat (ตามที่บองสั่ง)
`genImageWithRef` aspectRatio = **optional param** (ไม่ส่ง = behavior เดิม). callers: finance(ai) ไม่ส่ง → unchanged · daily7 = composition ไม่ใช้ genImageWithRef เลย → ไม่กระทบ. เช็ค usage ครบแล้ว.

## verify
- tsc 0 · 6 scene-pool tests (transition guards ไม่กลับทาง + pick exclude RETIRED/PENDING/REJECTED + count) · regression 0 (content-creator 326 ผ่าน ; เหลือ scheduler date-dependent เดิม)
- **real-path e2e:** gen batch 2 → **dims 1024×1024 (1:1 ไม่ crop ✅ — aspectRatio ทำงานจริง)** → approve 1 → random-cards gen → pick approved → **final 1080² (แมว Mimi ชัด ไม่ crop + ไพ่สม่ำเสมอ + ข้อความครบ)** (ดูภาพยืนยันแล้ว)

## review brief (ตามแผน — พื้นที่เสี่ยง)
- status-transition: PENDING→APPROVED/REJECTED ไม่กลับทาง · RETIRED terminal · pick exclude ครบ ✅ (tested)
- migration backward-compat: scene_library = table ใหม่ (additive) ไม่กระทบ contentPost เดิม · verified incremental บน prod-copy
- genImageWithRef aspect: optional ไม่กระทบ caller อื่น ✅
- random-pick: ORDER BY RANDOM() — ไม่ unique แต่ไม่ bias (ยอมรับได้ตามแผน)

🤖 ตอบโดย goo จาก [ฟีม] → goo-oracle