### PR TITLE
Add Reading Notes to prediction history

### DIFF
--- a/__tests__/api/predict-jobId-adapter-integration.test.ts
+++ b/__tests__/api/predict-jobId-adapter-integration.test.ts
@@ -99,6 +99,27 @@ describe('GET /api/predict/[jobId] - Adapter Integration', () => {
     expect(data.jobId).toBe('test-job-123')
   })
 
+  it('does not expose private notes on the public prediction status route', async () => {
+    const mockPrediction = {
+      id: 'prediction-1',
+      jobId: 'test-job-123',
+      status: 'COMPLETED',
+      question: 'What does my future hold?',
+      notes: 'private owner note',
+      createdAt: new Date(),
+      finalReading: null
+    }
+
+    vi.mocked(db.prediction.findFirst).mockResolvedValue(mockPrediction)
+
+    const request = new Request('http://localhost:3000/api/predict/test-job-123')
+    const response = await GET(request, { params: mockParams })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).not.toHaveProperty('notes')
+  })
+
   it('should handle adapter returning null (invalid data)', async () => {
     // Mock database response with invalid wrapper format
     const mockPrediction = {

--- a/__tests__/api/prediction-notes-route.test.ts
+++ b/__tests__/api/prediction-notes-route.test.ts
@@ -18,6 +18,7 @@ vi.mock("@/lib/server/db", () => ({
 }));
 
 import {
+  GET,
   PATCH,
   MAX_READING_NOTES_LENGTH,
 } from "@/app/api/predictions/[id]/notes/route";
@@ -67,6 +68,7 @@ describe("PATCH /api/predictions/[id]/notes", () => {
         id: true,
         jobId: true,
         userIdentifier: true,
+        notes: true,
       },
     });
     expect(db.prediction.update).toHaveBeenCalledWith({
@@ -75,6 +77,7 @@ describe("PATCH /api/predictions/[id]/notes", () => {
       select: {
         id: true,
         jobId: true,
+        userIdentifier: true,
         notes: true,
       },
     });
@@ -120,7 +123,60 @@ describe("PATCH /api/predictions/[id]/notes", () => {
       params: Promise.resolve({ id: "job-123-abcdefghi" }),
     });
 
-    expect(response.status).toBe(422);
+    expect(response.status).toBe(400);
+    expect(db.prediction.update).not.toHaveBeenCalled();
+  });
+
+  it("clears missing or null notes without crashing", async () => {
+    vi.mocked(db.prediction.update).mockResolvedValue({
+      id: "prediction_uuid",
+      jobId: "job-123-abcdefghi",
+      userIdentifier: "user_001",
+      notes: null,
+    } as any);
+
+    for (const body of [{}, { notes: null }]) {
+      vi.mocked(db.prediction.update).mockClear();
+
+      const request = new Request(
+        "http://localhost/api/predictions/job-123-abcdefghi/notes",
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        },
+      );
+
+      const response = await PATCH(request as any, {
+        params: Promise.resolve({ id: "job-123-abcdefghi" }),
+      });
+      const responseBody = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(responseBody.prediction.notes).toBe("");
+      expect(db.prediction.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { notes: null },
+        }),
+      );
+    }
+  });
+
+  it("returns 400 for non-string note values", async () => {
+    const request = new Request(
+      "http://localhost/api/predictions/job-123-abcdefghi/notes",
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ notes: 123 }),
+      },
+    );
+
+    const response = await PATCH(request as any, {
+      params: Promise.resolve({ id: "job-123-abcdefghi" }),
+    });
+
+    expect(response.status).toBe(400);
     expect(db.prediction.update).not.toHaveBeenCalled();
   });
 
@@ -172,5 +228,47 @@ describe("PATCH /api/predictions/[id]/notes", () => {
 
     expect(response.status).toBe(401);
     expect(db.prediction.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("returns owner notes through authenticated GET", async () => {
+    vi.mocked(db.prediction.findFirst).mockResolvedValue({
+      id: "prediction_uuid",
+      jobId: "job-123-abcdefghi",
+      userIdentifier: "user_001",
+      notes: "โน้ตส่วนตัว",
+    } as any);
+
+    const request = new Request(
+      "http://localhost/api/predictions/job-123-abcdefghi/notes",
+      { method: "GET" },
+    );
+
+    const response = await GET(request as any, {
+      params: Promise.resolve({ id: "job-123-abcdefghi" }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.prediction.notes).toBe("โน้ตส่วนตัว");
+  });
+
+  it("returns 403 for non-owner notes GET", async () => {
+    vi.mocked(db.prediction.findFirst).mockResolvedValue({
+      id: "prediction_uuid",
+      jobId: "job-123-abcdefghi",
+      userIdentifier: "other_user",
+      notes: "ห้ามหลุด",
+    } as any);
+
+    const request = new Request(
+      "http://localhost/api/predictions/job-123-abcdefghi/notes",
+      { method: "GET" },
+    );
+
+    const response = await GET(request as any, {
+      params: Promise.resolve({ id: "job-123-abcdefghi" }),
+    });
+
+    expect(response.status).toBe(403);
   });
 });

--- a/__tests__/api/prediction-notes-route.test.ts
+++ b/__tests__/api/prediction-notes-route.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/server/auth", () => ({
+  auth: {
+    api: {
+      getSession: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/server/db", () => ({
+  db: {
+    prediction: {
+      findFirst: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+import {
+  PATCH,
+  MAX_READING_NOTES_LENGTH,
+} from "@/app/api/predictions/[id]/notes/route";
+import { auth } from "@/lib/server/auth";
+import { db } from "@/lib/server/db";
+
+describe("PATCH /api/predictions/[id]/notes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(auth.api.getSession).mockResolvedValue({
+      user: { id: "user_001" },
+    } as any);
+    vi.mocked(db.prediction.findFirst).mockResolvedValue({
+      id: "prediction_uuid",
+      jobId: "job-123-abcdefghi",
+      userIdentifier: "user_001",
+    } as any);
+    vi.mocked(db.prediction.update).mockResolvedValue({
+      id: "prediction_uuid",
+      jobId: "job-123-abcdefghi",
+      notes: "จำไว้ว่ารอบนี้เน้นงาน",
+    } as any);
+  });
+
+  it("updates notes for the owner", async () => {
+    const request = new Request(
+      "http://localhost/api/predictions/job-123-abcdefghi/notes",
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ notes: "จำไว้ว่ารอบนี้เน้นงาน" }),
+      },
+    );
+
+    const response = await PATCH(request as any, {
+      params: Promise.resolve({ id: "job-123-abcdefghi" }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.prediction.notes).toBe("จำไว้ว่ารอบนี้เน้นงาน");
+    expect(db.prediction.findFirst).toHaveBeenCalledWith({
+      where: {
+        OR: [{ jobId: "job-123-abcdefghi" }],
+      },
+      select: {
+        id: true,
+        jobId: true,
+        userIdentifier: true,
+      },
+    });
+    expect(db.prediction.update).toHaveBeenCalledWith({
+      where: { id: "prediction_uuid" },
+      data: { notes: "จำไว้ว่ารอบนี้เน้นงาน" },
+      select: {
+        id: true,
+        jobId: true,
+        notes: true,
+      },
+    });
+  });
+
+  it("returns 403 for non-owner predictions", async () => {
+    vi.mocked(db.prediction.findFirst).mockResolvedValue({
+      id: "prediction_uuid",
+      jobId: "job-123-abcdefghi",
+      userIdentifier: "other_user",
+    } as any);
+
+    const request = new Request(
+      "http://localhost/api/predictions/job-123-abcdefghi/notes",
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ notes: "ห้ามแก้ของคนอื่น" }),
+      },
+    );
+
+    const response = await PATCH(request as any, {
+      params: Promise.resolve({ id: "job-123-abcdefghi" }),
+    });
+
+    expect(response.status).toBe(403);
+    expect(db.prediction.update).not.toHaveBeenCalled();
+  });
+
+  it("validates notes length", async () => {
+    const request = new Request(
+      "http://localhost/api/predictions/job-123-abcdefghi/notes",
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          notes: "x".repeat(MAX_READING_NOTES_LENGTH + 1),
+        }),
+      },
+    );
+
+    const response = await PATCH(request as any, {
+      params: Promise.resolve({ id: "job-123-abcdefghi" }),
+    });
+
+    expect(response.status).toBe(422);
+    expect(db.prediction.update).not.toHaveBeenCalled();
+  });
+
+  it("clears whitespace-only notes to null", async () => {
+    vi.mocked(db.prediction.update).mockResolvedValue({
+      id: "prediction_uuid",
+      jobId: "job-123-abcdefghi",
+      notes: null,
+    } as any);
+
+    const request = new Request(
+      "http://localhost/api/predictions/job-123-abcdefghi/notes",
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ notes: "   " }),
+      },
+    );
+
+    const response = await PATCH(request as any, {
+      params: Promise.resolve({ id: "job-123-abcdefghi" }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.prediction.notes).toBe("");
+    expect(db.prediction.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { notes: null },
+      }),
+    );
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValue(null as any);
+
+    const request = new Request(
+      "http://localhost/api/predictions/job-123-abcdefghi/notes",
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ notes: "anything" }),
+      },
+    );
+
+    const response = await PATCH(request as any, {
+      params: Promise.resolve({ id: "job-123-abcdefghi" }),
+    });
+
+    expect(response.status).toBe(401);
+    expect(db.prediction.findFirst).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/reading-notes-editor.test.tsx
+++ b/__tests__/components/reading-notes-editor.test.tsx
@@ -55,11 +55,10 @@ import {
   ReadingNotesEditor,
 } from "@/app/history/[id]/history-detail-view";
 
-const completedReading = (notes = "") => ({
+const completedReading = () => ({
   jobId: "job-owner-reading",
   status: "COMPLETED" as const,
   question: "งานนี้ควรไปต่อยังไง",
-  notes,
   createdAt: "2026-06-26T00:00:00.000Z",
   completedAt: "2026-06-26T00:01:00.000Z",
   result: {
@@ -325,16 +324,26 @@ describe("HistoryDetailView reading notes", () => {
 
   it("shows the owner reading and lets the owner edit notes", async () => {
     const user = userEvent.setup();
-    apiMocks.checkJobStatus.mockResolvedValue(completedReading("โน้ตเจ้าของ"));
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(
-        JSON.stringify({ prediction: { notes: "โน้ตเจ้าของที่แก้แล้ว" } }),
+    apiMocks.checkJobStatus.mockResolvedValue(completedReading());
+    const fetchMock = vi.fn().mockImplementation(async (_url, init) => {
+      if ((init as RequestInit | undefined)?.method === "PATCH") {
+        return new Response(
+          JSON.stringify({ prediction: { notes: "โน้ตเจ้าของที่แก้แล้ว" } }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      return new Response(
+        JSON.stringify({ prediction: { notes: "โน้ตเจ้าของ" } }),
         {
           status: 200,
           headers: { "Content-Type": "application/json" },
         },
-      ),
-    );
+      );
+    });
     vi.stubGlobal("fetch", fetchMock);
 
     render(<HistoryDetailView id="job-owner-reading" />);
@@ -344,7 +353,7 @@ describe("HistoryDetailView reading notes", () => {
       screen.getByText("คำทำนายสำหรับเจ้าของ reading"),
     ).toBeInTheDocument();
     const textarea = screen.getByLabelText("โน้ตส่วนตัว");
-    expect(textarea).toHaveValue("โน้ตเจ้าของ");
+    await waitFor(() => expect(textarea).toHaveValue("โน้ตเจ้าของ"));
 
     await user.clear(textarea);
     await user.type(textarea, "โน้ตเจ้าของที่แก้แล้ว");

--- a/__tests__/components/reading-notes-editor.test.tsx
+++ b/__tests__/components/reading-notes-editor.test.tsx
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
+
+const apiMocks = vi.hoisted(() => ({
+  checkJobStatus: vi.fn(),
+}));
 
 vi.mock("@/components", () => ({
   GlassCard: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
@@ -42,12 +46,52 @@ vi.mock("@/lib/client/providers/navigation-provider", () => ({
   useNavigation: () => ({ setCurrentPage: vi.fn() }),
 }));
 
-import { ReadingNotesEditor } from "@/app/history/[id]/history-detail-view";
+vi.mock("@/lib/client/api", () => ({
+  checkJobStatus: apiMocks.checkJobStatus,
+}));
+
+import {
+  HistoryDetailView,
+  ReadingNotesEditor,
+} from "@/app/history/[id]/history-detail-view";
+
+const completedReading = (notes = "") => ({
+  jobId: "job-owner-reading",
+  status: "COMPLETED" as const,
+  question: "งานนี้ควรไปต่อยังไง",
+  notes,
+  createdAt: "2026-06-26T00:00:00.000Z",
+  completedAt: "2026-06-26T00:01:00.000Z",
+  result: {
+    selectedCards: [],
+    analysis: {},
+    reading: {
+      header: "ไพ่บอกให้ค่อยๆ ดู",
+      cards_reading: [
+        {
+          position: 0,
+          name_th: "ผู้เริ่มต้น",
+          name_en: "The Fool",
+          arcana: "Major Arcana",
+          keywords: ["เริ่ม", "ทดลอง"],
+          interpretation: "เริ่มจากหลักฐานจริง",
+          image: "/cards/fool.png",
+        },
+      ],
+      reading: "คำทำนายสำหรับเจ้าของ reading",
+      suggestions: [],
+      next_questions: [],
+      final_summary: "",
+      disclaimer: "",
+    },
+  },
+});
 
 describe("ReadingNotesEditor", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    apiMocks.checkJobStatus.mockReset();
   });
 
   it("renders an empty note editor", () => {
@@ -129,5 +173,192 @@ describe("ReadingNotesEditor", () => {
     expect(
       screen.getByRole("button", { name: "บันทึกโน้ต" }),
     ).not.toBeDisabled();
+  });
+
+  it("persists saved, edited, and cleared notes across reload-style remounts", async () => {
+    const user = userEvent.setup();
+    let serverNotes = "";
+    const fetchMock = vi.fn().mockImplementation(async (_url, init) => {
+      const payload = JSON.parse(String((init as RequestInit).body));
+      serverNotes = payload.notes.trim().length > 0 ? payload.notes : "";
+      return new Response(
+        JSON.stringify({ prediction: { notes: serverNotes } }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const renderEditor = () =>
+      render(
+        <ReadingNotesEditor
+          predictionId="job-owner-reading"
+          initialNotes={serverNotes}
+        />,
+      );
+
+    let view = renderEditor();
+    const firstNote = "บทเรียนแรก: save แล้ว reload ต้องยังอยู่";
+    await user.type(screen.getByLabelText("โน้ตส่วนตัว"), firstNote);
+    await user.click(screen.getByRole("button", { name: "บันทึกโน้ต" }));
+    expect(await screen.findByText("บันทึกแล้ว")).toBeInTheDocument();
+
+    view.unmount();
+    view = renderEditor();
+    expect(screen.getByLabelText("โน้ตส่วนตัว")).toHaveValue(firstNote);
+
+    const editedNote = "บทเรียนที่แก้แล้ว: reload ต้องเห็นเวอร์ชันล่าสุด";
+    await user.clear(screen.getByLabelText("โน้ตส่วนตัว"));
+    await user.type(screen.getByLabelText("โน้ตส่วนตัว"), editedNote);
+    await user.click(screen.getByRole("button", { name: "บันทึกโน้ต" }));
+    expect(await screen.findByText("บันทึกแล้ว")).toBeInTheDocument();
+
+    view.unmount();
+    view = renderEditor();
+    expect(screen.getByLabelText("โน้ตส่วนตัว")).toHaveValue(editedNote);
+
+    await user.clear(screen.getByLabelText("โน้ตส่วนตัว"));
+    await user.click(screen.getByRole("button", { name: "บันทึกโน้ต" }));
+    expect(await screen.findByText("บันทึกแล้ว")).toBeInTheDocument();
+
+    view.unmount();
+    renderEditor();
+    expect(screen.getByLabelText("โน้ตส่วนตัว")).toHaveValue("");
+    expect(
+      screen.getByText("ยังไม่มีโน้ตสำหรับ reading นี้"),
+    ).toBeInTheDocument();
+  });
+
+  it("saves special characters, emoji, and multiline notes exactly", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ prediction: { notes: "" } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const note = "บรรทัด 1\n<>&\"' /? 🔮💡 emoji + symbols";
+
+    render(
+      <ReadingNotesEditor predictionId="job-owner-reading" initialNotes="" />,
+    );
+
+    fireEvent.change(screen.getByLabelText("โน้ตส่วนตัว"), {
+      target: { value: note },
+    });
+    await user.click(screen.getByRole("button", { name: "บันทึกโน้ต" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/predictions/job-owner-reading/notes",
+        expect.objectContaining({
+          body: JSON.stringify({ notes: note }),
+        }),
+      );
+    });
+  });
+
+  it("blocks over-limit notes before save", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <ReadingNotesEditor predictionId="job-owner-reading" initialNotes="" />,
+    );
+
+    fireEvent.change(screen.getByLabelText("โน้ตส่วนตัว"), {
+      target: { value: "x".repeat(5001) },
+    });
+
+    expect(screen.getByText("5001/5000")).toBeInTheDocument();
+    const saveButton = screen.getByRole("button", { name: "บันทึกโน้ต" });
+    expect(saveButton).toBeDisabled();
+    await user.click(saveButton);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("disables save while a note is being saved", async () => {
+    const user = userEvent.setup();
+    let resolveSave: (response: Response) => void = () => {};
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveSave = resolve;
+          }),
+      ),
+    );
+
+    render(
+      <ReadingNotesEditor predictionId="job-owner-reading" initialNotes="" />,
+    );
+
+    await user.type(screen.getByLabelText("โน้ตส่วนตัว"), "กำลังบันทึก");
+    const saveButton = screen.getByRole("button", { name: "บันทึกโน้ต" });
+    await user.click(saveButton);
+
+    await waitFor(() => expect(saveButton).toBeDisabled());
+
+    resolveSave(
+      new Response(JSON.stringify({ prediction: { notes: "กำลังบันทึก" } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    expect(await screen.findByText("บันทึกแล้ว")).toBeInTheDocument();
+    expect(saveButton).toBeDisabled();
+  });
+});
+
+describe("HistoryDetailView reading notes", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    apiMocks.checkJobStatus.mockReset();
+  });
+
+  it("shows the owner reading and lets the owner edit notes", async () => {
+    const user = userEvent.setup();
+    apiMocks.checkJobStatus.mockResolvedValue(completedReading("โน้ตเจ้าของ"));
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ prediction: { notes: "โน้ตเจ้าของที่แก้แล้ว" } }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<HistoryDetailView id="job-owner-reading" />);
+
+    expect(await screen.findByText("งานนี้ควรไปต่อยังไง")).toBeInTheDocument();
+    expect(
+      screen.getByText("คำทำนายสำหรับเจ้าของ reading"),
+    ).toBeInTheDocument();
+    const textarea = screen.getByLabelText("โน้ตส่วนตัว");
+    expect(textarea).toHaveValue("โน้ตเจ้าของ");
+
+    await user.clear(textarea);
+    await user.type(textarea, "โน้ตเจ้าของที่แก้แล้ว");
+    await user.click(screen.getByRole("button", { name: "บันทึกโน้ต" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/predictions/job-owner-reading/notes",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({ notes: "โน้ตเจ้าของที่แก้แล้ว" }),
+        }),
+      );
+    });
+    expect(await screen.findByText("บันทึกแล้ว")).toBeInTheDocument();
   });
 });

--- a/__tests__/components/reading-notes-editor.test.tsx
+++ b/__tests__/components/reading-notes-editor.test.tsx
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+vi.mock("@/components", () => ({
+  GlassCard: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div {...props}>{children}</div>
+  ),
+  GlassButton: ({
+    children,
+    isLoading: _isLoading,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    isLoading?: boolean;
+  }) => <button {...props}>{children}</button>,
+  ChevronLeft: () => <span data-testid="chevron-left" />,
+  Loader2: () => <span data-testid="loader" />,
+  AlertCircle: () => <span data-testid="alert" />,
+  Modal: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/reading", () => ({
+  ReadingHeader: () => null,
+  CardSpread: () => null,
+  SuggestionsList: () => null,
+  NextQuestions: () => null,
+  FinalSummary: () => null,
+  Disclaimer: () => null,
+  ShareActions: () => null,
+}));
+
+vi.mock("@/components/features/tarot", () => ({
+  TarotCardImage: () => null,
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("@/lib/client/providers/navigation-provider", () => ({
+  useNavigation: () => ({ setCurrentPage: vi.fn() }),
+}));
+
+import { ReadingNotesEditor } from "@/app/history/[id]/history-detail-view";
+
+describe("ReadingNotesEditor", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("renders an empty note editor", () => {
+    render(
+      <ReadingNotesEditor predictionId="job-123-abcdefghi" initialNotes="" />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "โน้ตส่วนตัว" }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("โน้ตส่วนตัว")).toHaveValue("");
+    expect(
+      screen.getByText("ยังไม่มีโน้ตสำหรับ reading นี้"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "บันทึกโน้ต" })).toBeDisabled();
+  });
+
+  it("saves edited notes through the PATCH endpoint", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ prediction: { notes: "โน้ตใหม่" } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <ReadingNotesEditor
+        predictionId="job-123-abcdefghi"
+        initialNotes="โน้ตเดิม"
+      />,
+    );
+
+    const textarea = screen.getByLabelText("โน้ตส่วนตัว");
+    await user.clear(textarea);
+    await user.type(textarea, "โน้ตใหม่");
+    await user.click(screen.getByRole("button", { name: "บันทึกโน้ต" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/predictions/job-123-abcdefghi/notes",
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ notes: "โน้ตใหม่" }),
+        },
+      );
+    });
+    expect(await screen.findByText("บันทึกแล้ว")).toBeInTheDocument();
+    expect(textarea).toHaveValue("โน้ตใหม่");
+    expect(screen.getByRole("button", { name: "บันทึกโน้ต" })).toBeDisabled();
+  });
+
+  it("shows save errors without clearing typed notes", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: "notes must be shorter" }), {
+          status: 422,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    render(
+      <ReadingNotesEditor predictionId="job-123-abcdefghi" initialNotes="" />,
+    );
+
+    const textarea = screen.getByLabelText("โน้ตส่วนตัว");
+    await user.type(textarea, "ยาวเกินไป");
+    await user.click(screen.getByRole("button", { name: "บันทึกโน้ต" }));
+
+    expect(
+      await screen.findByText("notes must be shorter"),
+    ).toBeInTheDocument();
+    expect(textarea).toHaveValue("ยาวเกินไป");
+    expect(
+      screen.getByRole("button", { name: "บันทึกโน้ต" }),
+    ).not.toBeDisabled();
+  });
+});

--- a/app/api/predict/[jobId]/route.ts
+++ b/app/api/predict/[jobId]/route.ts
@@ -72,7 +72,8 @@ export async function GET(
       jobId: prediction.jobId,
       status: prediction.status as 'PENDING' | 'PROCESSING' | 'COMPLETED' | 'FAILED',
       question: prediction.question,
-      createdAt: prediction.createdAt.toISOString()
+      createdAt: prediction.createdAt.toISOString(),
+      notes: prediction.notes ?? undefined
     }
 
     // Add error information if status is FAILED

--- a/app/api/predict/[jobId]/route.ts
+++ b/app/api/predict/[jobId]/route.ts
@@ -72,8 +72,7 @@ export async function GET(
       jobId: prediction.jobId,
       status: prediction.status as 'PENDING' | 'PROCESSING' | 'COMPLETED' | 'FAILED',
       question: prediction.question,
-      createdAt: prediction.createdAt.toISOString(),
-      notes: prediction.notes ?? undefined
+      createdAt: prediction.createdAt.toISOString()
     }
 
     // Add error information if status is FAILED

--- a/app/api/predictions/[id]/notes/route.ts
+++ b/app/api/predictions/[id]/notes/route.ts
@@ -4,31 +4,112 @@ import { db } from "@/lib/server/db";
 
 export const MAX_READING_NOTES_LENGTH = 5000;
 
+type PredictionNotesRecord = {
+  id: string;
+  jobId: string | null;
+  userIdentifier: string | null;
+  notes: string | null;
+};
+
 function isUuid(value: string): boolean {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
     value,
   );
 }
 
+async function findPredictionByRouteId(
+  id: string,
+): Promise<PredictionNotesRecord | null> {
+  return db.prediction.findFirst({
+    where: {
+      OR: [{ jobId: id }, ...(isUuid(id) ? [{ id }] : [])],
+    },
+    select: {
+      id: true,
+      jobId: true,
+      userIdentifier: true,
+      notes: true,
+    },
+  });
+}
+
+function serializePredictionNotes(prediction: PredictionNotesRecord) {
+  return {
+    prediction: {
+      id: prediction.id,
+      jobId: prediction.jobId,
+      notes: prediction.notes ?? "",
+    },
+  };
+}
+
+async function getOwnedPrediction(
+  request: NextRequest,
+  id: string,
+): Promise<
+  | { ok: true; prediction: PredictionNotesRecord }
+  | { ok: false; response: Response }
+> {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session?.user?.id) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 },
+      ),
+    };
+  }
+
+  if (!id?.trim()) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Prediction id is required" },
+        { status: 400 },
+      ),
+    };
+  }
+
+  const prediction = await findPredictionByRouteId(id);
+  if (!prediction) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Prediction not found" },
+        { status: 404 },
+      ),
+    };
+  }
+
+  if (prediction.userIdentifier !== session.user.id) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+    };
+  }
+
+  return { ok: true, prediction };
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  const { id } = await params;
+  const owned = await getOwnedPrediction(request, id);
+  if (!owned.ok) return owned.response;
+
+  return NextResponse.json(serializePredictionNotes(owned.prediction));
+}
+
 export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ): Promise<Response> {
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session?.user?.id) {
-    return NextResponse.json(
-      { error: "Authentication required" },
-      { status: 401 },
-    );
-  }
-
   const { id } = await params;
-  if (!id?.trim()) {
-    return NextResponse.json(
-      { error: "Prediction id is required" },
-      { status: 400 },
-    );
-  }
+  const owned = await getOwnedPrediction(request, id);
+  if (!owned.ok) return owned.response;
 
   let payload: unknown;
   try {
@@ -37,61 +118,45 @@ export async function PATCH(
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  const notes = (payload as { notes?: unknown }).notes;
-  if (typeof notes !== "string") {
+  const rawNotes =
+    payload && typeof payload === "object" && "notes" in payload
+      ? (payload as { notes?: unknown }).notes
+      : null;
+
+  if (rawNotes != null && typeof rawNotes !== "string") {
     return NextResponse.json(
-      { error: "notes must be a string" },
+      { error: "notes must be a string or null" },
       { status: 400 },
     );
   }
 
-  if (notes.length > MAX_READING_NOTES_LENGTH) {
+  if (
+    typeof rawNotes === "string" &&
+    rawNotes.length > MAX_READING_NOTES_LENGTH
+  ) {
     return NextResponse.json(
       {
         error: `notes must be ${MAX_READING_NOTES_LENGTH} characters or fewer`,
       },
-      { status: 422 },
+      { status: 400 },
     );
   }
 
-  const prediction = await db.prediction.findFirst({
-    where: {
-      OR: [{ jobId: id }, ...(isUuid(id) ? [{ id }] : [])],
-    },
-    select: {
-      id: true,
-      jobId: true,
-      userIdentifier: true,
-    },
-  });
+  const normalizedNotes =
+    typeof rawNotes === "string" && rawNotes.trim().length > 0
+      ? rawNotes
+      : null;
 
-  if (!prediction) {
-    return NextResponse.json(
-      { error: "Prediction not found" },
-      { status: 404 },
-    );
-  }
-
-  if (prediction.userIdentifier !== session.user.id) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
-
-  const normalizedNotes = notes.trim().length > 0 ? notes : null;
   const updated = await db.prediction.update({
-    where: { id: prediction.id },
+    where: { id: owned.prediction.id },
     data: { notes: normalizedNotes },
     select: {
       id: true,
       jobId: true,
+      userIdentifier: true,
       notes: true,
     },
   });
 
-  return NextResponse.json({
-    prediction: {
-      id: updated.id,
-      jobId: updated.jobId,
-      notes: updated.notes ?? "",
-    },
-  });
+  return NextResponse.json(serializePredictionNotes(updated));
 }

--- a/app/api/predictions/[id]/notes/route.ts
+++ b/app/api/predictions/[id]/notes/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/server/auth";
+import { db } from "@/lib/server/db";
+
+export const MAX_READING_NOTES_LENGTH = 5000;
+
+function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    value,
+  );
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session?.user?.id) {
+    return NextResponse.json(
+      { error: "Authentication required" },
+      { status: 401 },
+    );
+  }
+
+  const { id } = await params;
+  if (!id?.trim()) {
+    return NextResponse.json(
+      { error: "Prediction id is required" },
+      { status: 400 },
+    );
+  }
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const notes = (payload as { notes?: unknown }).notes;
+  if (typeof notes !== "string") {
+    return NextResponse.json(
+      { error: "notes must be a string" },
+      { status: 400 },
+    );
+  }
+
+  if (notes.length > MAX_READING_NOTES_LENGTH) {
+    return NextResponse.json(
+      {
+        error: `notes must be ${MAX_READING_NOTES_LENGTH} characters or fewer`,
+      },
+      { status: 422 },
+    );
+  }
+
+  const prediction = await db.prediction.findFirst({
+    where: {
+      OR: [{ jobId: id }, ...(isUuid(id) ? [{ id }] : [])],
+    },
+    select: {
+      id: true,
+      jobId: true,
+      userIdentifier: true,
+    },
+  });
+
+  if (!prediction) {
+    return NextResponse.json(
+      { error: "Prediction not found" },
+      { status: 404 },
+    );
+  }
+
+  if (prediction.userIdentifier !== session.user.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const normalizedNotes = notes.trim().length > 0 ? notes : null;
+  const updated = await db.prediction.update({
+    where: { id: prediction.id },
+    data: { notes: normalizedNotes },
+    select: {
+      id: true,
+      jobId: true,
+      notes: true,
+    },
+  });
+
+  return NextResponse.json({
+    prediction: {
+      id: updated.id,
+      jobId: updated.jobId,
+      notes: updated.notes ?? "",
+    },
+  });
+}

--- a/app/history/[id]/history-detail-view.tsx
+++ b/app/history/[id]/history-detail-view.tsx
@@ -24,9 +24,11 @@ const MAX_READING_NOTES_LENGTH = 5000;
 export function ReadingNotesEditor({
   predictionId,
   initialNotes = '',
+  loadNotes = false,
 }: {
   predictionId: string;
   initialNotes?: string;
+  loadNotes?: boolean;
 }) {
   const [notes, setNotes] = useState(initialNotes);
   const [lastSavedNotes, setLastSavedNotes] = useState(initialNotes);
@@ -40,6 +42,41 @@ export function ReadingNotesEditor({
     setError(null);
     setSaved(false);
   }, [predictionId, initialNotes]);
+
+  useEffect(() => {
+    if (!loadNotes) return;
+
+    let cancelled = false;
+
+    const fetchNotes = async () => {
+      try {
+        const response = await fetch(`/api/predictions/${encodeURIComponent(predictionId)}/notes`);
+        const body = await response.json().catch(() => ({}));
+
+        if (!response.ok) {
+          throw new Error(body.error || 'โหลดโน้ตไม่สำเร็จ');
+        }
+
+        if (cancelled) return;
+
+        const fetchedNotes = body.prediction?.notes ?? '';
+        setNotes(fetchedNotes);
+        setLastSavedNotes(fetchedNotes);
+        setError(null);
+        setSaved(false);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'โหลดโน้ตไม่สำเร็จ');
+        }
+      }
+    };
+
+    fetchNotes();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [predictionId, loadNotes]);
 
   const isDirty = notes !== lastSavedNotes;
   const remaining = MAX_READING_NOTES_LENGTH - notes.length;
@@ -349,7 +386,7 @@ export function HistoryDetailView({ id: jobId }: { id: string }) {
                <p className="whitespace-pre-wrap text-lg font-serif">{mappedData.reading}</p>
             </GlassCard>
           )}
-          <ReadingNotesEditor predictionId={jobId} initialNotes={prediction.notes ?? ''} />
+          <ReadingNotesEditor predictionId={jobId} loadNotes />
         </div>
         <div className="mt-12 pt-8 pb-12 border-t border-border-medium flex justify-center">
           <GlassButton 
@@ -396,7 +433,7 @@ export function HistoryDetailView({ id: jobId }: { id: string }) {
           </GlassCard>
         )}
 
-        <ReadingNotesEditor predictionId={jobId} initialNotes={prediction.notes ?? ''} />
+        <ReadingNotesEditor predictionId={jobId} loadNotes />
 
         {mappedData?.suggestions && <SuggestionsList suggestions={mappedData.suggestions} />}
         {mappedData?.nextQuestions && <NextQuestions questions={mappedData.nextQuestions} />}

--- a/app/history/[id]/history-detail-view.tsx
+++ b/app/history/[id]/history-detail-view.tsx
@@ -19,6 +19,112 @@ import { mapReadingData } from '@/lib/client/reading-utils';
 import { useNavigation } from '@/lib/client/providers/navigation-provider';
 import type { CardReading } from '@/types/reading';
 
+const MAX_READING_NOTES_LENGTH = 5000;
+
+export function ReadingNotesEditor({
+  predictionId,
+  initialNotes = '',
+}: {
+  predictionId: string;
+  initialNotes?: string;
+}) {
+  const [notes, setNotes] = useState(initialNotes);
+  const [lastSavedNotes, setLastSavedNotes] = useState(initialNotes);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    setNotes(initialNotes);
+    setLastSavedNotes(initialNotes);
+    setError(null);
+    setSaved(false);
+  }, [predictionId, initialNotes]);
+
+  const isDirty = notes !== lastSavedNotes;
+  const remaining = MAX_READING_NOTES_LENGTH - notes.length;
+
+  const handleSave = async () => {
+    if (!isDirty || saving) return;
+
+    setSaving(true);
+    setError(null);
+    setSaved(false);
+
+    try {
+      const response = await fetch(`/api/predictions/${encodeURIComponent(predictionId)}/notes`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ notes }),
+      });
+
+      const body = await response.json().catch(() => ({}));
+
+      if (!response.ok) {
+        throw new Error(body.error || 'บันทึกโน้ตไม่สำเร็จ');
+      }
+
+      const savedNotes = body.prediction?.notes ?? '';
+      setNotes(savedNotes);
+      setLastSavedNotes(savedNotes);
+      setSaved(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'บันทึกโน้ตไม่สำเร็จ');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <GlassCard className="p-6 bg-glass-mimi">
+      <div className="space-y-4">
+        <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-2">
+          <div>
+            <h2 className="text-xl font-serif text-foreground">โน้ตส่วนตัว</h2>
+            <p className="text-sm text-muted-foreground">เก็บความคิดหลังอ่านคำทำนายนี้ เห็นเฉพาะคุณ</p>
+          </div>
+          <span className={remaining < 0 ? 'text-sm text-destructive' : 'text-sm text-muted-foreground'}>
+            {notes.length}/{MAX_READING_NOTES_LENGTH}
+          </span>
+        </div>
+
+        <textarea
+          aria-label="โน้ตส่วนตัว"
+          value={notes}
+          onChange={(event) => {
+            setNotes(event.target.value);
+            setError(null);
+            setSaved(false);
+          }}
+          placeholder="ยังไม่มีโน้ต ลองจดสิ่งที่อยากจำจาก reading นี้..."
+          rows={5}
+          maxLength={MAX_READING_NOTES_LENGTH + 1}
+          className="w-full rounded-2xl border border-border-subtle bg-surface-card/70 px-4 py-3 text-foreground placeholder:text-muted-foreground/60 outline-none transition focus:border-accent/50 focus:ring-2 focus:ring-accent/20"
+        />
+
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <div className="min-h-5 text-sm" aria-live="polite">
+            {error && <span className="text-destructive">{error}</span>}
+            {!error && saved && <span className="text-success">บันทึกแล้ว</span>}
+            {!error && !saved && !notes.trim() && (
+              <span className="text-muted-foreground">ยังไม่มีโน้ตสำหรับ reading นี้</span>
+            )}
+          </div>
+          <GlassButton
+            type="button"
+            onClick={handleSave}
+            isLoading={saving}
+            disabled={!isDirty || saving || remaining < 0}
+            className="sm:min-w-[140px]"
+          >
+            บันทึกโน้ต
+          </GlassButton>
+        </div>
+      </div>
+    </GlassCard>
+  );
+}
+
 export function HistoryDetailView({ id: jobId }: { id: string }) {
   const router = useRouter();
   const { setCurrentPage } = useNavigation();
@@ -243,6 +349,7 @@ export function HistoryDetailView({ id: jobId }: { id: string }) {
                <p className="whitespace-pre-wrap text-lg font-serif">{mappedData.reading}</p>
             </GlassCard>
           )}
+          <ReadingNotesEditor predictionId={jobId} initialNotes={prediction.notes ?? ''} />
         </div>
         <div className="mt-12 pt-8 pb-12 border-t border-border-medium flex justify-center">
           <GlassButton 
@@ -288,6 +395,8 @@ export function HistoryDetailView({ id: jobId }: { id: string }) {
             </p>
           </GlassCard>
         )}
+
+        <ReadingNotesEditor predictionId={jobId} initialNotes={prediction.notes ?? ''} />
 
         {mappedData?.suggestions && <SuggestionsList suggestions={mappedData.suggestions} />}
         {mappedData?.nextQuestions && <NextQuestions questions={mappedData.nextQuestions} />}

--- a/lib/client/api.ts
+++ b/lib/client/api.ts
@@ -19,7 +19,6 @@ const GetPredictResponseSchema = z.object({
   jobId: z.string(),
   status: z.enum(['PENDING', 'PROCESSING', 'COMPLETED', 'FAILED']),
   question: z.string(),
-  notes: z.string().optional(),
   createdAt: z.string(),
   completedAt: z.string().optional(),
   error: z.object({

--- a/lib/client/api.ts
+++ b/lib/client/api.ts
@@ -19,6 +19,7 @@ const GetPredictResponseSchema = z.object({
   jobId: z.string(),
   status: z.enum(['PENDING', 'PROCESSING', 'COMPLETED', 'FAILED']),
   question: z.string(),
+  notes: z.string().optional(),
   createdAt: z.string(),
   completedAt: z.string().optional(),
   error: z.object({

--- a/prisma/migrations/20260626062303_add_prediction_notes/migration.sql
+++ b/prisma/migrations/20260626062303_add_prediction_notes/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "predictions" ADD COLUMN     "notes" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -121,6 +121,7 @@ model Prediction {
   analysisResult Json?     @map("analysis_result")
   selectedCards  Json?     @map("selected_cards")
   finalReading   Json?     @map("final_reading")
+  notes          String?   @map("notes")
   failureCode    String?   @map("failure_code")
   failureReason  String?   @map("failure_reason")
   createdAt      DateTime  @default(now()) @map("created_at")

--- a/types/api.ts
+++ b/types/api.ts
@@ -49,7 +49,6 @@ export interface GetPredictResponse {
   jobId: string
   status: 'PENDING' | 'PROCESSING' | 'COMPLETED' | 'FAILED'
   question: string
-  notes?: string
   result?: PredictionResult
   error?: {
     code: string

--- a/types/api.ts
+++ b/types/api.ts
@@ -49,6 +49,7 @@ export interface GetPredictResponse {
   jobId: string
   status: 'PENDING' | 'PROCESSING' | 'COMPLETED' | 'FAILED'
   question: string
+  notes?: string
   result?: PredictionResult
   error?: {
     code: string


### PR DESCRIPTION
## Summary
- Add nullable `Prediction.notes` via additive Prisma migration.
- Add owner-only `PATCH /api/predictions/[id]/notes` with length validation.
- Add personal notes editor to history detail and include `notes` in prediction status response.
- Add focused Vitest API + component coverage.

## Contract / Source of Truth
Prediction ownership is `prediction.userIdentifier === session.user.id`; history detail uses jobId from `/history/[id]` and `GET /api/predict/[jobId]` as the reload source of truth.

## Red Baseline
Intentional red baseline: no · Expected-green owner: builder

## Layers Touched
- src: API route + history detail UI + client/type schemas
- tests: API + component Vitest
- db: additive nullable Prisma migration
- docs: n/a
- deploy: n/a

## Verification (verify-real-context = CLAUDE.md hard rule)
- normal path: `npm run test -- __tests__/api/prediction-notes-route.test.ts __tests__/components/reading-notes-editor.test.tsx` → 8/8 PASS
- exact bug reproduction: n/a new feature
- failure/empty path: tests cover non-owner 403, unauth 401, long-note 422, whitespace clear to null, UI save error
- real runtime verified: `prisma generate` + `prisma migrate deploy` + `next build` using `.env.local` parsed without echoing secrets → PASS

## Safety
- no-op/preserve: empty notes persist as null and return empty string to UI
- backup-rollback: migration is additive nullable only (`ALTER TABLE predictions ADD COLUMN notes TEXT`)
- operator-owned deploy? yes

## Not Done
Browser/mobile truth and prod migration deploy are left for team/operator flow.