### PR TITLE
fix(content-creator): harden local draft recovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,13 @@ SLIPOK_API_BASE_URL="http://localhost:3999"
 SLIPOK_VERIFY_LOG="false"
 
 DISCORD_WEBHOOK_URL=""
+
+# content-creator local admin tool (local only; never enable in production)
+CONTENT_CREATOR_ENABLED="true"
+CONTENT_DB_PATH="content-creator/content.db"
+CONTENT_MEDIA_DIR="content-creator/media"
+CONTENT_TEXT_MODEL="gemini-2.5-flash"
+CONTENT_IMAGE_MODEL="gemini-2.5-flash-image"
+CONTENT_REF_IMAGE_MODEL="gemini-2.5-flash-image"
+CONTENT_FB_PAGE_ID=""
+CONTENT_FB_PAGE_ACCESS_TOKEN=""

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ erDiagram
 
 ### Prerequisites
 
-- Node.js 20+
+- Node.js 22.18.0 (see `.nvmrc`; content-creator uses native SQLite modules)
 - npm 10+
 - PostgreSQL database
 - LINE developer credentials

--- a/app/content-creator/api/cards/draft/[id]/regenerate/route.ts
+++ b/app/content-creator/api/cards/draft/[id]/regenerate/route.ts
@@ -8,6 +8,7 @@ import { getContentDb } from "@/content-creator/db/client";
 import { isContentCreatorEnabled } from "@/content-creator/lib/enabled";
 import { regenRandomCardsDraft } from "@/content-creator/random-cards-service";
 import { draftErrorStatus } from "@/content-creator/daily7-service";
+import { draftRouteResponse } from "@/content-creator/lib/draft-route-response";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -25,7 +26,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
   }
   try {
     const draft = await regenRandomCardsDraft(getContentDb(), id, body.attemptKey, body.expectedRevision);
-    return NextResponse.json({ ok: draft.status !== "FAILED", draft }, { status: 200 });
+    return draftRouteResponse(draft);
   } catch (e) {
     const { status, error } = draftErrorStatus(e);
     return NextResponse.json({ ok: false, error }, { status });

--- a/app/content-creator/api/cards/draft/route.ts
+++ b/app/content-creator/api/cards/draft/route.ts
@@ -8,6 +8,7 @@ import { getContentDb } from "@/content-creator/db/client";
 import { isContentCreatorEnabled } from "@/content-creator/lib/enabled";
 import { createRandomCardsDraft } from "@/content-creator/random-cards-service";
 import { draftErrorStatus } from "@/content-creator/daily7-service";
+import { draftRouteResponse } from "@/content-creator/lib/draft-route-response";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -24,7 +25,7 @@ export async function POST(request: Request) {
   }
   try {
     const draft = await createRandomCardsDraft(getContentDb(), body.requestKey);
-    return NextResponse.json({ ok: draft.status !== "FAILED", draft }, { status: 200 });
+    return draftRouteResponse(draft);
   } catch (e) {
     const { status, error } = draftErrorStatus(e);
     return NextResponse.json({ ok: false, error }, { status });

--- a/app/content-creator/api/daily/draft/[id]/regenerate/route.ts
+++ b/app/content-creator/api/daily/draft/[id]/regenerate/route.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 import { getContentDb } from "@/content-creator/db/client";
 import { isContentCreatorEnabled } from "@/content-creator/lib/enabled";
 import { regenDaily7Draft, draftErrorStatus } from "@/content-creator/daily7-service";
+import { draftRouteResponse } from "@/content-creator/lib/draft-route-response";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -25,7 +26,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
   }
   try {
     const draft = await regenDaily7Draft(getContentDb(), id, body.attemptKey, body.expectedRevision);
-    return NextResponse.json({ ok: draft.status !== "FAILED", draft }, { status: 200 });
+    return draftRouteResponse(draft);
   } catch (e) {
     const { status, error } = draftErrorStatus(e);
     return NextResponse.json({ ok: false, error }, { status });

--- a/app/content-creator/api/daily/draft/route.ts
+++ b/app/content-creator/api/daily/draft/route.ts
@@ -10,6 +10,7 @@ import { getContentDb } from "@/content-creator/db/client";
 import { isContentCreatorEnabled } from "@/content-creator/lib/enabled";
 import { createDaily7Draft, draftErrorStatus } from "@/content-creator/daily7-service";
 import { isValidIsoDate } from "@/content-creator/templates/daily7";
+import { draftRouteResponse } from "@/content-creator/lib/draft-route-response";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -30,7 +31,7 @@ export async function POST(request: Request) {
   }
   try {
     const draft = await createDaily7Draft(getContentDb(), body.requestKey, body.targetDate);
-    return NextResponse.json({ ok: draft.status !== "FAILED", draft }, { status: 200 });
+    return draftRouteResponse(draft);
   } catch (e) {
     const { status, error } = draftErrorStatus(e);
     return NextResponse.json({ ok: false, error }, { status });

--- a/app/content-creator/new/Daily7Authoring.tsx
+++ b/app/content-creator/new/Daily7Authoring.tsx
@@ -5,7 +5,7 @@
  * recovery lifecycle: lib/daily7-session (pure, test ครบ) ; preview = POST+blob (robust)
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { parseSession, freshSession, reduceDraft, mountAction, regenAttemptKey, createButtonMode, reduceFinalize, type Session, type DraftView } from "@/content-creator/lib/daily7-session";
+import { parseSession, freshSession, reduceDraft, mountAction, restoreAction, regenAttemptKey, createButtonMode, reduceFinalize, type Session, type DraftView } from "@/content-creator/lib/daily7-session";
 
 const WEEKDAYS = ["จันทร์", "อังคาร", "พุธ", "พฤหัสบดี", "ศุกร์", "เสาร์", "อาทิตย์"] as const;
 type Day = { day: string; fortune: string };
@@ -41,7 +41,10 @@ export default function Daily7Authoring({ onFinalized }: { onFinalized: () => vo
     try {
       const res = await fetch(url, { method, headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
       const data = await res.json();
-      if (!res.ok) { setErr(`${res.status}: ${data.error ?? "error"}${res.status === 409 ? " (ข้อมูลเปลี่ยน — โหลด/เริ่มใหม่)" : ""}`); return null; }
+      if (!res.ok || data.ok === false) {
+        setErr(`${res.status}: ${data.error ?? data.draft?.error ?? "error"}${res.status === 409 ? " (ข้อมูลเปลี่ยน — โหลด/เริ่มใหม่)" : ""}`);
+        return data.draft ? data : null;
+      }
       return data as { draft?: DraftView; contentPostId?: string; status?: string };
     } catch (e) { setErr(String(e)); return null; }
     finally { setBusy(false); }
@@ -53,6 +56,31 @@ export default function Daily7Authoring({ onFinalized }: { onFinalized: () => vo
     setRevision(r.revision); setStatus(r.status); setDays(r.days); setSavedKey(daysKey(r.days));
     persist(r.session);
   }, [persist]);
+
+  const replayFinalize = useCallback(async (sess: Session, rev: number, backgroundIdOverride?: string) => {
+    if (!sess.draftId) return;
+    const selectedBackgroundId = backgroundIdOverride || sess.backgroundId;
+    if (!selectedBackgroundId) {
+      setErr("ยังไม่มีพื้นหลังสำหรับเช็คผล finalize เดิม — เลือกพื้นหลังแล้วกดเช็คอีกครั้ง");
+      return;
+    }
+    setBusy(true); setErr("");
+    try {
+      const res = await fetch(`/content-creator/api/daily/draft/${sess.draftId}/finalize`, {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ finalizeKey: sess.finalizeKey, expectedRevision: rev, backgroundId: selectedBackgroundId }),
+      });
+      const o = reduceFinalize(await res.json());
+      if (o.kind === "queue") { persist(null); onFinalized(); return; }
+      if (o.kind === "processing") {
+        const next = { ...sess, backgroundId: selectedBackgroundId };
+        setSession(next); setRevision(rev); setStatus("FINALIZED"); persist(next);
+      } else {
+        persist(null); setStatus(""); setDays([]); setSavedKey(""); setErr(o.message);
+      }
+    } catch (e) { setErr(String(e)); }
+    finally { setBusy(false); }
+  }, [persist, onFinalized]);
 
   // bg pool (surface error)
   useEffect(() => {
@@ -66,16 +94,21 @@ export default function Daily7Authoring({ onFinalized }: { onFinalized: () => vo
     const s = parseSession(localStorage.getItem(SKEY));
     if (!s) return;
     setSession(s); setTargetDate(s.targetDate);
+    if (s.backgroundId) setBackgroundId(s.backgroundId);
     const act = mountAction(s);
     (async () => {
       if (act.kind === "restore") {
         const res = await fetch(`/content-creator/api/daily/draft/${act.draftId}`);
-        if (res.ok) onDraft((await res.json()).draft, s);
+        if (!res.ok) return;
+        const draft = (await res.json()).draft as DraftView;
+        const ra = restoreAction(draft);
+        if (ra.kind === "replay-finalize") await replayFinalize(s, ra.revision, s.backgroundId);
+        else onDraft(draft, s);
       } else if (act.kind === "resume") {
         onDraft((await send("/content-creator/api/daily/draft", { requestKey: act.requestKey, targetDate: act.targetDate }))?.draft, s);
       }
     })();
-  }, [onDraft, send]);
+  }, [onDraft, send, replayFinalize]);
 
   const dirty = useMemo(() => status === "READY" && daysKey(days) !== savedKey, [status, days, savedKey]);
   const previewBody = useMemo(
@@ -130,20 +163,9 @@ export default function Daily7Authoring({ onFinalized }: { onFinalized: () => vo
     if (!session?.draftId || !backgroundId) return;
     let rev = revision;
     if (dirty) { const saved = await save(); if (!saved) return; rev = saved.revision; }
-    // ไม่ใช้ send() (ที่ทิ้ง body เมื่อ non-2xx) — finalize ต้องอ่าน body ที่ 202/502 ด้วย [ตู๋ P1]
-    setBusy(true); setErr("");
-    try {
-      const res = await fetch(`/content-creator/api/daily/draft/${session.draftId}/finalize`, {
-        method: "POST", headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ finalizeKey: session.finalizeKey, expectedRevision: rev, backgroundId }),
-      });
-      // หลัง finalize draft ถูก lock = FINALIZED แล้ว → client ต้องไม่ถือ READY/editor ต่อ [ตู๋ P1]
-      const o = reduceFinalize(await res.json());
-      if (o.kind === "queue") { persist(null); onFinalized(); return; }
-      if (o.kind === "processing") { setStatus("FINALIZED"); } // lock — panel โชว์ ; keep session ให้ retry replay
-      else { persist(null); setStatus(""); setDays([]); setSavedKey(""); setErr(o.message); } // failed → reset เริ่มใหม่
-    } catch (e) { setErr(String(e)); }
-    finally { setBusy(false); }
+    const finalizedSession = { ...session, backgroundId };
+    persist(finalizedSession);
+    await replayFinalize(finalizedSession, rev, backgroundId);
   };
 
   const canEdit = status === "READY";

--- a/app/content-creator/new/RandomCardsAuthoring.tsx
+++ b/app/content-creator/new/RandomCardsAuthoring.tsx
@@ -26,12 +26,15 @@ export default function RandomCardsAuthoring({ onFinalized }: { onFinalized: () 
     else localStorage.removeItem(SKEY);
   }, []);
 
-  const send = useCallback(async (url: string, body: object): Promise<{ draft?: DraftView } | null> => {
+  const send = useCallback(async (url: string, body: object): Promise<{ draft?: DraftView; error?: string } | null> => {
     setBusy(true); setErr("");
     try {
       const res = await fetch(url, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
       const d = await res.json();
-      if (!res.ok || d.ok === false) { setErr(`${res.status}: ${d.error ?? "error"}${res.status === 409 ? " (ข้อมูลเปลี่ยน — เริ่มใหม่)" : ""}`); return null; }
+      if (!res.ok || d.ok === false) {
+        setErr(`${res.status}: ${d.error ?? d.draft?.error ?? "error"}${res.status === 409 ? " (ข้อมูลเปลี่ยน — เริ่มใหม่)" : ""}`);
+        return d.draft ? d : null;
+      }
       return d;
     } catch (e) { setErr(String(e)); return null; } finally { setBusy(false); }
   }, []);

--- a/content-creator/README.md
+++ b/content-creator/README.md
@@ -62,13 +62,18 @@ caption ที่ gen ต้อง: **ฟันธงสั้น (≤ `captionM
 ## ▶️ วิธีรัน (runnable target)
 
 ```bash
+npm run content-creator:preflight # ตรวจ Node/env/local DB โดยไม่ยิง Gemini/Facebook
 npm run content-creator:dev      # = CONTENT_CREATOR_ENABLED=true next dev
 # เปิด http://localhost:3000/content-creator
 ```
 
 ต้องมีใน `.env.local`:
+- `DATABASE_URL` — ต้องชี้ local Postgres (เช่น `postgresql://postgres:postgres@localhost:5432/mmv_tarots_dev`) เพราะ app shell/auth route ใช้ DB หลัก แม้ content-creator เก็บงานใน SQLite
+- `CONTENT_CREATOR_ENABLED=true` — เปิดเฉพาะ local dev; production fail-closed
 - `CONTENT_DB_PATH` — path ของ SQLite file (default `content-creator/content.db`, persistent บนเครื่อง, gitignored)
-- `GOOGLE_GENERATIVE_AI_API_KEY`, `CONTENT_FB_PAGE_ID`, `CONTENT_FB_PAGE_ACCESS_TOKEN` (สำหรับ gen/post)
+- `CONTENT_MEDIA_DIR` — directory สำหรับไฟล์ภาพที่ gen
+- `GOOGLE_GENERATIVE_AI_API_KEY`, `CONTENT_TEXT_MODEL`, `CONTENT_IMAGE_MODEL`, `CONTENT_REF_IMAGE_MODEL` (สำหรับ gen)
+- `CONTENT_FB_PAGE_ID`, `CONTENT_FB_PAGE_ACCESS_TOKEN` (สำหรับ post จริง; publish tests ต้อง mock เท่านั้น)
 
 > **Node 22** เท่านั้น (`.nvmrc`) — better-sqlite3 เป็น native module (ABI ผูกกับ Node version)
 > Windows: ตั้ง env ผ่าน `.env.local` หรือ cross-env (inline env ใน script เป็น mac/linux)

--- a/content-creator/__tests__/daily-draft-route.test.ts
+++ b/content-creator/__tests__/daily-draft-route.test.ts
@@ -53,6 +53,19 @@ describe("POST /api/daily/draft regression [ตู๋ P1.1/P1.3]", () => {
     expect(mockGenObject).toHaveBeenCalledTimes(1); // retry ไม่ gen ซ้ำ
   });
 
+  it("Gemini ล้ม → 200 ok:false + definitive FAILED + draft/error เพื่อให้ UI recover ได้", async () => {
+    mockGenObject.mockRejectedValue(new Error("API key missing"));
+    const res = await createDraft(req({ requestKey: "rk-fail", targetDate: "2026-06-15" }));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(false);
+    expect(body.definitive).toBe(true);
+    expect(body.status).toBe("FAILED");
+    expect(body.error).toContain("API key missing");
+    expect(body.draft.status).toBe("FAILED");
+    expect(body.draft.error).toContain("API key missing");
+  });
+
   it("key เดิ่ม + targetDate ต่าง → 409 (key reuse, ไม่ idempotent ผิด ๆ)", async () => {
     await createDraft(req({ requestKey: "rk", targetDate: "2026-06-15" }));
     const res = await createDraft(req({ requestKey: "rk", targetDate: "2026-12-31" }));

--- a/content-creator/__tests__/daily7-session.test.ts
+++ b/content-creator/__tests__/daily7-session.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseSession, freshSession, reduceDraft, mountAction, regenAttemptKey, createButtonMode, reduceFinalize, type Session, type DraftView } from "../lib/daily7-session";
+import { parseSession, freshSession, reduceDraft, mountAction, restoreAction, regenAttemptKey, createButtonMode, reduceFinalize, type Session, type DraftView } from "../lib/daily7-session";
 
 const S: Session = { requestKey: "rk", targetDate: "2026-06-15", finalizeKey: "fk" };
 
@@ -12,10 +12,11 @@ describe("parseSession guard [ตู๋ P2]", () => {
     expect(parseSession("{not json")).toBeNull();
     expect(parseSession(JSON.stringify({ requestKey: "x" }))).toBeNull(); // ขาด targetDate/finalizeKey
   });
-  it("draftId/pendingAttemptKey optional restore", () => {
-    const s = parseSession(JSON.stringify({ ...S, draftId: "d1", pendingAttemptKey: "a1" }));
+  it("draftId/pendingAttemptKey/backgroundId optional restore", () => {
+    const s = parseSession(JSON.stringify({ ...S, draftId: "d1", pendingAttemptKey: "a1", backgroundId: "bg-1" }));
     expect(s?.draftId).toBe("d1");
     expect(s?.pendingAttemptKey).toBe("a1");
+    expect(s?.backgroundId).toBe("bg-1");
   });
 });
 
@@ -39,13 +40,22 @@ describe("reduceDraft [ตู๋ P1 finalize-restore]", () => {
     expect(r.session?.draftId).toBe("d1");
     expect(r.postId).toBeNull();
   });
-  it("FINALIZED → อ่าน contentPostId + clear session (กัน finalize-response หายแล้วค้าง)", () => {
+  it("FINALIZED → อ่าน contentPostId + keep session/finalizeKey ไว้ replay classify หลัง reload", () => {
     const r = reduceDraft({ ...base, status: "FINALIZED", contentPostId: "post-9" }, { ...S, draftId: "d1" });
     expect(r.postId).toBe("post-9");
-    expect(r.session).toBeNull();
+    expect(r.session?.draftId).toBe("d1");
+    expect(r.session?.finalizeKey).toBe("fk");
   });
   it("GENERATING → keep session (รอ/reclaim)", () => {
     expect(reduceDraft({ ...base, status: "GENERATING" }, S).session?.draftId).toBe("d1");
+  });
+});
+
+describe("restoreAction [ตู๋ P1 finalize reload]", () => {
+  it("FINALIZED → replay-finalize ; READY/FAILED → show-draft", () => {
+    expect(restoreAction({ id: "d", revision: 3, status: "FINALIZED", contentPostId: "p" })).toEqual({ kind: "replay-finalize", revision: 3 });
+    expect(restoreAction({ id: "d", revision: 1, status: "READY" })).toEqual({ kind: "show-draft" });
+    expect(restoreAction({ id: "d", revision: 2, status: "FAILED" })).toEqual({ kind: "show-draft" });
   });
 });
 

--- a/content-creator/__tests__/random-cards-draft-route.test.ts
+++ b/content-creator/__tests__/random-cards-draft-route.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const mockGenObject = vi.hoisted(() => vi.fn());
+const dbHolder = vi.hoisted(() => ({ db: null as unknown }));
+
+vi.mock("@/content-creator/lib/gemini", () => ({ genObject: mockGenObject }));
+vi.mock("@/content-creator/db/client", async (orig) => {
+  const actual = await orig<typeof import("@/content-creator/db/client")>();
+  return { ...actual, getContentDb: () => dbHolder.db };
+});
+
+import { createContentDb } from "@/content-creator/db/client";
+import { POST as createDraft } from "@/app/content-creator/api/cards/draft/route";
+
+const req = (body: unknown) =>
+  new Request("http://t/content-creator/api/cards/draft", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
+
+beforeEach(() => {
+  process.env.CONTENT_CREATOR_ENABLED = "true";
+  dbHolder.db = createContentDb(":memory:");
+  mockGenObject.mockReset().mockResolvedValue({ quote: "เปลี่ยนแปลงสู่สิ่งที่ดี", body: "ช่วงนี้มีพลังบวกเข้ามา จงเชื่อมั่น" });
+});
+
+describe("POST /api/cards/draft regression [failed draft recovery]", () => {
+  it("Gemini ล้ม → 200 ok:false + definitive FAILED + draft/error เพื่อให้ UI recover ได้", async () => {
+    mockGenObject.mockRejectedValue(new Error("API key missing"));
+    const res = await createDraft(req({ requestKey: "rk-fail" }));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(false);
+    expect(body.definitive).toBe(true);
+    expect(body.status).toBe("FAILED");
+    expect(body.error).toContain("API key missing");
+    expect(body.draft.status).toBe("FAILED");
+    expect(body.draft.error).toContain("API key missing");
+  });
+});

--- a/content-creator/__tests__/scheduler.test.ts
+++ b/content-creator/__tests__/scheduler.test.ts
@@ -90,11 +90,12 @@ describe("scheduler reconcile tick [S4b]", () => {
 });
 
 // insert PUBLISHING row ที่ค้าง (จำลอง worker ตาย) — คุม publishStartedAt + feedAttemptedAt
-function stuckPublishing(targetDate: string, opts: { feedAttempted: boolean; startedAgoMs: number }): string {
+function stuckPublishing(targetDate: string, opts: { feedAttempted: boolean; startedAgoMs: number; now?: Date }): string {
   const id = `pub-${n++}`;
+  const base = opts.now ?? new Date();
   db.insert(contentPosts).values({
     id, templateId: "daily-7", inputData: { targetDate, days: [] }, status: "PUBLISHING", caption: "cap", imagePath: "/m/y.png", mediaFbid: "m1",
-    publishStartedAt: new Date(Date.now() - opts.startedAgoMs), feedAttemptedAt: opts.feedAttempted ? new Date(Date.now() - opts.startedAgoMs) : null,
+    publishStartedAt: new Date(base.getTime() - opts.startedAgoMs), feedAttemptedAt: opts.feedAttempted ? new Date(base.getTime() - opts.startedAgoMs) : null,
   }).run();
   return id;
 }
@@ -121,7 +122,7 @@ describe("reconcile stuck PUBLISHING [S4b ตู๋ P1]", () => {
   });
 
   it("integration: tick reconcile pre-PONR stuck → release → publish ในรอบเดียว (resume)", async () => {
-    const id = stuckPublishing("2026-06-16", { feedAttempted: false, startedAgoMs: 20 * 60 * 1000 });
+    const id = stuckPublishing("2026-06-16", { feedAttempted: false, startedAgoMs: 20 * 60 * 1000, now: new Date(AFTER_SLOT) });
     const r = await runSchedulerTick(db, deps(AFTER_SLOT));
     expect(r.reclaimedStuck).toBe(1);
     expect(r.published?.id).toBe(id);

--- a/content-creator/lib/daily7-session.ts
+++ b/content-creator/lib/daily7-session.ts
@@ -4,7 +4,7 @@
  * จุดประสงค์: recovery จาก lost-response/reload ให้ใช้ backend idempotency จริง (ไม่จ่าย Gemini ซ้ำ):
  *  - persist {requestKey, finalizeKey, targetDate, draftId?, pendingAttemptKey?} (localStorage)
  *  - mount: มี draftId → restore (GET) ; มี requestKey แต่ยังไม่มี draftId → resume (POST key เดิม)
- *  - reduceDraft: FINALIZED → อ่าน contentPostId + clear session (กัน finalize-response หาย แล้วค้าง)
+ *  - reduceDraft: FINALIZED → keep session เพื่อ replay finalize แล้ว classify contentPost จริง
  *  - regen reuse pendingAttemptKey (retry response หาย) ; "เริ่มใหม่" = key ชุดใหม่ (intentional)
  */
 export type Session = {
@@ -13,6 +13,7 @@ export type Session = {
   finalizeKey: string;
   draftId?: string;
   pendingAttemptKey?: string;
+  backgroundId?: string;
 };
 
 export interface DraftView {
@@ -21,6 +22,7 @@ export interface DraftView {
   status: string;
   draftData?: { days?: { day: string; fortune: string }[] };
   contentPostId?: string | null;
+  error?: string | null;
 }
 
 /** parse session แบบกัน corrupt (JSON เสีย/ขาด field) → null [ตู๋ P2] */
@@ -35,6 +37,7 @@ export function parseSession(raw: string | null): Session | null {
         finalizeKey: s.finalizeKey,
         draftId: typeof s.draftId === "string" ? s.draftId : undefined,
         pendingAttemptKey: typeof s.pendingAttemptKey === "string" ? s.pendingAttemptKey : undefined,
+        backgroundId: typeof s.backgroundId === "string" ? s.backgroundId : undefined,
       };
     }
     return null;
@@ -52,7 +55,7 @@ export interface Reduced {
   status: string;
   days: { day: string; fortune: string }[];
   postId: string | null;
-  /** session ที่ต้อง persist (null = clear — เช่น FINALIZED แล้ว) */
+  /** session ที่ต้อง persist (null = clear เฉพาะ finalize success/failed หลัง classify แล้ว) */
   session: Session | null;
 }
 
@@ -60,9 +63,14 @@ export interface Reduced {
 export function reduceDraft(draft: DraftView, session: Session): Reduced {
   const days = draft.draftData?.days ?? [];
   if (draft.status === "FINALIZED") {
-    return { revision: draft.revision, status: "FINALIZED", days, postId: draft.contentPostId ?? null, session: null };
+    return { revision: draft.revision, status: "FINALIZED", days, postId: draft.contentPostId ?? null, session: { ...session, draftId: draft.id } };
   }
   return { revision: draft.revision, status: draft.status, days, postId: null, session: { ...session, draftId: draft.id } };
+}
+
+export type RestoreAction = { kind: "replay-finalize"; revision: number } | { kind: "show-draft" };
+export function restoreAction(draft: DraftView): RestoreAction {
+  return draft.status === "FINALIZED" ? { kind: "replay-finalize", revision: draft.revision } : { kind: "show-draft" };
 }
 
 export type MountAction =

--- a/content-creator/lib/draft-route-response.ts
+++ b/content-creator/lib/draft-route-response.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import type { ContentDraft } from "@/content-creator/db/schema";
+
+export function draftRouteResponse(draft: ContentDraft) {
+  if (draft.status === "FAILED") {
+    return NextResponse.json(
+      {
+        ok: false,
+        definitive: true,
+        status: "FAILED",
+        error: draft.error ?? "draft generation failed",
+        draft,
+      },
+      { status: 200 },
+    );
+  }
+  return NextResponse.json({ ok: true, status: draft.status, draft }, { status: 200 });
+}

--- a/content-creator/lib/random-cards-session.ts
+++ b/content-creator/lib/random-cards-session.ts
@@ -19,6 +19,7 @@ export interface DraftView {
   status: string;
   draftData?: { cardIds?: string[]; quote?: string; body?: string };
   contentPostId?: string | null;
+  error?: string | null;
 }
 
 /** parse session กัน corrupt → null */

--- a/docs/LOCAL_DEV.md
+++ b/docs/LOCAL_DEV.md
@@ -71,6 +71,22 @@ It seeds master data, then adds a local dev user and a completed reading:
 npm run dev
 ```
 
+For content-creator, use the dedicated target. It runs a local-only preflight first and does not call Gemini or Facebook:
+
+```bash
+npm run content-creator:preflight
+npm run content-creator:dev
+```
+
+Content-creator also requires these `.env.local` values:
+
+- `CONTENT_CREATOR_ENABLED=true`
+- `CONTENT_DB_PATH` and `CONTENT_MEDIA_DIR`
+- `GOOGLE_GENERATIVE_AI_API_KEY`
+- `CONTENT_TEXT_MODEL`, `CONTENT_IMAGE_MODEL`, `CONTENT_REF_IMAGE_MODEL`
+
+Keep `DATABASE_URL` pointed at local Postgres. The content-creator SQLite DB is separate, but the app shell/auth routes still use the main local DB.
+
 ## 6. Issue a dev session
 
 Open this route in the same browser:

--- a/next.config.ts
+++ b/next.config.ts
@@ -9,7 +9,7 @@ const nextConfig: NextConfig = {
   // daily-7 composition อ่าน bg pool + font ผ่าน "dynamic path" (จาก manifest) — Next file-tracing
   // ตรวจไม่เจอ → ต้อง force-include ไม่งั้น lambda บน Vercel หา asset ไม่เจอ (local อ่านได้แต่ prod พัง) [S6b]
   outputFileTracingIncludes: {
-    "/content-creator/**": ["./content-creator/assets/**", "./assets/fonts/**"],
+    "/content-creator/**": ["./content-creator/assets/**", "./content-creator/brand/**", "./content-creator/db/migrations/**", "./assets/fonts/**"],
   },
   images: {
     remotePatterns: [

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "seed:dev": "node --env-file=.env.local node_modules/tsx/dist/cli.mjs prisma/seed.ts",
     "db:snapshot-prod": "chmod +x scripts/neon-snapshot-rotate.sh && ./scripts/neon-snapshot-rotate.sh",
     "migrate:safe": "node scripts/prisma-safety-check.js && prisma migrate deploy",
-    "content-creator:dev": "CONTENT_CREATOR_ENABLED=true next dev",
+    "content-creator:preflight": "node scripts/content-creator-preflight.js",
+    "content-creator:dev": "npm run content-creator:preflight && CONTENT_CREATOR_ENABLED=true next dev",
     "postinstall": "patch-package"
   },
   "dependencies": {

--- a/scripts/content-creator-preflight.js
+++ b/scripts/content-creator-preflight.js
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs");
+const net = require("node:net");
+const path = require("node:path");
+
+const root = process.cwd();
+const envPath = path.join(root, ".env.local");
+const nvmrcPath = path.join(root, ".nvmrc");
+const errors = [];
+const warnings = [];
+
+function parseEnvFile(file) {
+  const out = {};
+  if (!fs.existsSync(file)) return out;
+  for (const line of fs.readFileSync(file, "utf8").split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const match = trimmed.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    if (!match) continue;
+    let value = match[2].trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    out[match[1]] = value;
+  }
+  return out;
+}
+
+function fail(message) {
+  errors.push(message);
+}
+
+function warn(message) {
+  warnings.push(message);
+}
+
+function isLocalHost(hostname) {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+}
+
+function checkPort(hostname, port) {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ host: hostname, port, timeout: 1200 }, () => {
+      socket.end();
+      resolve(true);
+    });
+    socket.on("timeout", () => {
+      socket.destroy();
+      resolve(false);
+    });
+    socket.on("error", () => resolve(false));
+  });
+}
+
+async function main() {
+  const requiredNode = fs.existsSync(nvmrcPath) ? fs.readFileSync(nvmrcPath, "utf8").trim() : "22";
+  const major = Number(process.versions.node.split(".")[0]);
+  if (major !== 22) {
+    fail(`Node ${process.version} is active, but content-creator native deps are pinned to ${requiredNode}. Run with Node 22 before starting dev.`);
+  }
+
+  try {
+    require("better-sqlite3");
+  } catch (e) {
+    fail(`better-sqlite3 failed to load: ${e instanceof Error ? e.message : String(e)}`);
+  }
+
+  if (!fs.existsSync(envPath)) {
+    fail(".env.local is missing. Copy .env.example and fill local content-creator values.");
+  }
+
+  const localEnv = parseEnvFile(envPath);
+  const rootEnv = parseEnvFile(path.join(root, ".env"));
+
+  if (localEnv.CONTENT_CREATOR_ENABLED !== "true") fail("CONTENT_CREATOR_ENABLED=true is required in .env.local.");
+  for (const key of ["CONTENT_DB_PATH", "CONTENT_MEDIA_DIR", "GOOGLE_GENERATIVE_AI_API_KEY"]) {
+    if (!localEnv[key]) fail(`${key} is required in .env.local.`);
+  }
+  if (!localEnv.CONTENT_TEXT_MODEL) warn("CONTENT_TEXT_MODEL is not set; engine default will be used.");
+  if (!localEnv.CONTENT_IMAGE_MODEL) warn("CONTENT_IMAGE_MODEL is not set; engine default will be used.");
+  if (localEnv.GOOGLE_GENERATIVE_AI_API_KEY && /^(local-|your-|change-me|placeholder)/i.test(localEnv.GOOGLE_GENERATIVE_AI_API_KEY)) {
+    fail("GOOGLE_GENERATIVE_AI_API_KEY in .env.local looks like a placeholder.");
+  }
+
+  if (!localEnv.DATABASE_URL) fail("DATABASE_URL is required in .env.local for the app/auth shell.");
+  else {
+    try {
+      const dbUrl = new URL(localEnv.DATABASE_URL);
+      if (!isLocalHost(dbUrl.hostname)) fail("DATABASE_URL in .env.local must point to local Postgres for local content-creator work.");
+      const port = Number(dbUrl.port || 5432);
+      if (isLocalHost(dbUrl.hostname) && !(await checkPort(dbUrl.hostname, port))) {
+        fail(`local Postgres is not reachable at ${dbUrl.hostname}:${port}. Run npm run db:up before starting dev.`);
+      }
+    } catch {
+      fail("DATABASE_URL in .env.local is not a valid URL.");
+    }
+  }
+  if (rootEnv.DATABASE_URL && !rootEnv.DATABASE_URL.includes("localhost")) {
+    warn(".env appears to point at a non-local database; Next should use .env.local overrides during local dev.");
+  }
+
+  const contentDbPath = localEnv.CONTENT_DB_PATH || "content-creator/content.db";
+  const resolvedContentDbPath = path.isAbsolute(contentDbPath) ? contentDbPath : path.join(root, contentDbPath);
+  if (!fs.existsSync(path.dirname(resolvedContentDbPath))) fail(`CONTENT_DB_PATH directory does not exist: ${path.dirname(resolvedContentDbPath)}`);
+
+  const mediaDir = localEnv.CONTENT_MEDIA_DIR;
+  if (mediaDir) {
+    const resolvedMediaDir = path.isAbsolute(mediaDir) ? mediaDir : path.join(root, mediaDir);
+    if (!fs.existsSync(resolvedMediaDir)) warn(`CONTENT_MEDIA_DIR does not exist yet: ${resolvedMediaDir}`);
+  }
+
+  for (const message of warnings) console.warn(`WARN ${message}`);
+  if (errors.length) {
+    for (const message of errors) console.error(`FAIL ${message}`);
+    process.exit(1);
+  }
+  console.log("PASS content-creator preflight: Node 22, native SQLite, local env, and local Postgres are ready.");
+}
+
+main().catch((e) => {
+  console.error(e instanceof Error ? e.message : String(e));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

This PR hardens the local content-creator workflow after the random-cards template surfaced `200: error` and local boot was sensitive to runtime/env drift.

## What changed

- Standardized daily/random draft create + regenerate responses through `draftRouteResponse()`.
  - A generated draft with `status=FAILED` now returns a clear body: `ok:false`, `definitive:true`, `status:FAILED`, `error`, and the `draft` itself.
  - This keeps idempotent retry semantics while giving the UI enough information to recover instead of dropping the draft.
- Updated random-cards and daily-7 authoring clients to keep failed drafts when the response includes a draft.
  - The UI now persists the draft id and shows the failed state instead of looping on the same request key with only `200: error`.
- Brought daily-7 finalize recovery closer to random-cards.
  - `FINALIZED` daily drafts keep the local session so reload/lost-response can replay finalize and classify the content post state.
  - The selected `backgroundId` is persisted because the finalize route requires it for replay.
- Added `scripts/content-creator-preflight.js` and `npm run content-creator:preflight`.
  - Checks Node 22, `better-sqlite3`, `.env.local`, local `DATABASE_URL`, content creator env, and local Postgres reachability.
  - Does not call Gemini or Facebook and does not print secrets.
- Documented content-creator local env requirements in `.env.example`, `content-creator/README.md`, and `docs/LOCAL_DEV.md`; aligned root README to Node 22.
- Added Next file tracing includes for content-creator brand assets and Drizzle migrations.
- Fixed a date-sensitive scheduler test by anchoring the stuck-publishing fixture to the simulated scheduler time.

## Why

The observed random-cards failure was not a Postgres/Neon issue. The route could return HTTP 200 with `ok:false` for a failed draft, but the random-cards UI treated that as fatal and discarded the returned draft. That left localStorage with a pending request key but no draft id, so retries reused the same failed key and surfaced an unhelpful `200: error`.

Separately, local readiness was fragile because content-creator depends on Node 22 native SQLite modules and the app shell still needs local Postgres for auth routes even though content-creator data is stored in SQLite.

## Verification

All commands were run with Node 22.18.0 from `.nvmrc`.

- `npx vitest run content-creator/__tests__/daily7-session.test.ts content-creator/__tests__/random-cards-session.test.ts content-creator/__tests__/daily-draft-route.test.ts content-creator/__tests__/random-cards-draft-route.test.ts content-creator/__tests__/random-cards-service.test.ts content-creator/__tests__/daily7-service.test.ts` PASS: 57/57
- `npx tsc --noEmit` PASS
- `npm run content-creator:preflight` PASS
  - Expected warning: root `.env` points non-local, while `.env.local` overrides for local dev.
- `npx vitest run content-creator/__tests__` PASS: 381/381
- `git diff --check` PASS

No Gemini, Facebook, or production database mutation was performed during verification.