### PR TITLE
feat(content-creator): add local readiness panel

### DIFF
--- a/app/content-creator/api/readiness/route.ts
+++ b/app/content-creator/api/readiness/route.ts
@@ -1,0 +1,37 @@
+/**
+ * GET /content-creator/api/readiness — local readiness summary before paid generation.
+ * Read-only: no Gemini/Facebook calls and no DB/FS mutation.
+ */
+import { NextResponse } from "next/server";
+import { getContentDb } from "@/content-creator/db/client";
+import { isContentCreatorEnabled } from "@/content-creator/lib/enabled";
+import { inspectContentCreatorReadiness } from "@/content-creator/readiness";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  if (!isContentCreatorEnabled()) return new NextResponse(null, { status: 404 });
+  try {
+    return NextResponse.json(inspectContentCreatorReadiness(getContentDb()));
+  } catch (e) {
+    return NextResponse.json(
+      {
+        ok: false,
+        status: "fail",
+        checkedAt: new Date().toISOString(),
+        summary: { pass: 0, warn: 0, fail: 1 },
+        checks: [
+          {
+            id: "readiness",
+            label: "Readiness check",
+            status: "fail",
+            detail: e instanceof Error ? e.message : String(e),
+          },
+        ],
+        facts: { templateCount: 0, approvedScenes: 0, textModel: "", imageModel: "", refImageModel: "" },
+      },
+      { status: 200 },
+    );
+  }
+}

--- a/app/content-creator/page.tsx
+++ b/app/content-creator/page.tsx
@@ -20,6 +20,13 @@ type Post = {
   updatedAt: string;
 };
 
+type Readiness = {
+  status: "pass" | "warn" | "fail";
+  checkedAt: string;
+  summary: { pass: number; warn: number; fail: number };
+  checks: { id: string; label: string; status: "pass" | "warn" | "fail"; detail: string }[];
+};
+
 const STATUS_STYLE: Record<string, string> = {
   PENDING: "bg-gray-200 text-gray-700",
   GENERATING: "bg-amber-100 text-amber-800",
@@ -30,6 +37,16 @@ const STATUS_STYLE: Record<string, string> = {
   CANCELED: "bg-gray-300 text-gray-600",
   FAILED: "bg-red-100 text-red-800",
 };
+const READINESS_STYLE: Record<Readiness["status"], string> = {
+  pass: "border-emerald-200 bg-emerald-50 text-emerald-900",
+  warn: "border-amber-200 bg-amber-50 text-amber-900",
+  fail: "border-red-200 bg-red-50 text-red-900",
+};
+const READINESS_DOT: Record<Readiness["status"], string> = {
+  pass: "bg-emerald-500",
+  warn: "bg-amber-500",
+  fail: "bg-red-500",
+};
 
 export default function ContentCreatorPage() {
   const [posts, setPosts] = useState<Post[]>([]);
@@ -37,6 +54,7 @@ export default function ContentCreatorPage() {
   const [error, setError] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [readiness, setReadiness] = useState<Readiness | null>(null);
   // daily-7 scheduler status (modal/banner แจ้งเตือน) [S4b]
   const [d7, setD7] = useState<{ today: string; posted: boolean; pending: number; staleCanceled: number; stuckPublishing: number; failedToday: number } | null>(null);
   const [d7Dismissed, setD7Dismissed] = useState(false);
@@ -48,10 +66,21 @@ export default function ContentCreatorPage() {
       .catch(() => {});
   }, []);
 
+  const loadReadiness = useCallback(async () => {
+    try {
+      const res = await fetch("/content-creator/api/readiness", { cache: "no-store" });
+      if (!res.ok) return;
+      const data = await res.json();
+      setReadiness(data);
+    } catch {
+      setReadiness(null);
+    }
+  }, []);
+
   const load = useCallback(async () => {
     setError(null);
     try {
-      const res = await fetch("/content-creator/api/posts", { cache: "no-store" });
+      const [res] = await Promise.all([fetch("/content-creator/api/posts", { cache: "no-store" }), loadReadiness()]);
       if (!res.ok) throw new Error(`โหลดไม่สำเร็จ (${res.status})`);
       const data = await res.json();
       setPosts(data.posts ?? []);
@@ -60,7 +89,7 @@ export default function ContentCreatorPage() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [loadReadiness]);
 
   useEffect(() => {
     load();
@@ -160,6 +189,32 @@ export default function ContentCreatorPage() {
       {error && (
         <div className="mb-4 rounded-lg bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
       )}
+
+      {readiness && (
+        <section className={`mb-4 rounded-lg border px-4 py-3 text-sm ${READINESS_STYLE[readiness.status]}`}>
+          <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+            <div className="flex items-center gap-2 font-semibold">
+              <span className={`h-2.5 w-2.5 rounded-full ${READINESS_DOT[readiness.status]}`} />
+              Local readiness: {readiness.status.toUpperCase()}
+            </div>
+            <div className="text-xs opacity-80">
+              pass {readiness.summary.pass} · warn {readiness.summary.warn} · fail {readiness.summary.fail}
+            </div>
+          </div>
+          <div className="grid gap-1 md:grid-cols-2">
+            {readiness.checks.map((c) => (
+              <div key={c.id} className="flex gap-2">
+                <span className={`mt-1.5 h-2 w-2 shrink-0 rounded-full ${READINESS_DOT[c.status]}`} />
+                <div>
+                  <div className="font-medium">{c.label}</div>
+                  <div className="text-xs opacity-80">{c.detail}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
       {loading && <p className="text-gray-500">กำลังโหลด…</p>}
 
       {!loading && pending.length === 0 && (

--- a/content-creator/__tests__/readiness.test.ts
+++ b/content-creator/__tests__/readiness.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createContentDb } from "../db/client";
+import { updateBrandProfile } from "../db/brand";
+import { sceneLibrary } from "../db/schema";
+import { inspectContentCreatorReadiness } from "../readiness";
+import { GET as readinessGET } from "@/app/content-creator/api/readiness/route";
+
+const dirs: string[] = [];
+
+function tmp() {
+  const dir = mkdtempSync(join(tmpdir(), "cc-ready-"));
+  dirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  delete process.env.CONTENT_CREATOR_ENABLED;
+  delete process.env.CONTENT_DB_PATH;
+  delete process.env.CONTENT_MEDIA_DIR;
+  delete process.env.DATABASE_URL;
+  delete process.env.GOOGLE_GENERATIVE_AI_API_KEY;
+});
+
+describe("inspectContentCreatorReadiness", () => {
+  it("PASS เมื่อ local env/db/brand/media/scenes พร้อม โดยไม่ยิง provider", () => {
+    const dir = tmp();
+    const media = join(dir, "media");
+    mkdirSync(media);
+    const db = createContentDb(join(dir, "content.db"));
+    updateBrandProfile(db, { ctaUrl: "https://maemormimi.com/" });
+    db.insert(sceneLibrary).values({ id: "s1", theme: "t", imagePath: "content-creator/brand/scenes/06fdd202-39dd-4eab-9477-355b06bd27cb.png", status: "APPROVED", genBatch: "b" }).run();
+
+    const res = inspectContentCreatorReadiness(
+      db,
+      {
+        DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/mmv_tarots_dev",
+        GOOGLE_GENERATIVE_AI_API_KEY: "real-looking-key",
+        CONTENT_MEDIA_DIR: media,
+        CONTENT_TEXT_MODEL: "gemini-2.5-flash",
+        CONTENT_IMAGE_MODEL: "gemini-2.5-flash-image",
+        CONTENT_REF_IMAGE_MODEL: "gemini-2.5-flash-image",
+      },
+      process.cwd(),
+    );
+
+    expect(res.status).toBe("pass");
+    expect(res.ok).toBe(true);
+    expect(res.summary.fail).toBe(0);
+    expect(res.facts.approvedScenes).toBe(1);
+    expect(res.checks.find((c) => c.id === "google-api-key")?.detail).toBe("configured (value hidden)");
+  });
+
+  it("FAIL/WARN เมื่อ env สำคัญหรือ CTA ยังไม่พร้อม", () => {
+    const dir = tmp();
+    const db = createContentDb(join(dir, "content.db"));
+    const res = inspectContentCreatorReadiness(
+      db,
+      {
+        DATABASE_URL: "postgresql://user:pass@example.neon.tech/db",
+        GOOGLE_GENERATIVE_AI_API_KEY: "local-google-generative-ai-key",
+        CONTENT_MEDIA_DIR: join(dir, "missing", "media"),
+      },
+      process.cwd(),
+    );
+
+    expect(res.status).toBe("fail");
+    expect(res.ok).toBe(false);
+    expect(res.checks.find((c) => c.id === "app-db-url")?.status).toBe("fail");
+    expect(res.checks.find((c) => c.id === "google-api-key")?.status).toBe("fail");
+    expect(res.checks.find((c) => c.id === "brand-cta")?.status).toBe("fail");
+    expect(res.checks.find((c) => c.id === "approved-scenes")?.status).toBe("warn");
+  });
+
+  it("route เปิด feature → 200 summary, ปิด feature → 404", async () => {
+    const dir = tmp();
+    mkdirSync(join(dir, "media"));
+    process.env.CONTENT_CREATOR_ENABLED = "true";
+    process.env.CONTENT_DB_PATH = join(dir, "route.db");
+    process.env.CONTENT_MEDIA_DIR = join(dir, "media");
+    process.env.DATABASE_URL = "postgresql://postgres:postgres@localhost:5432/mmv_tarots_dev";
+    process.env.GOOGLE_GENERATIVE_AI_API_KEY = "real-looking-key";
+
+    const res = await readinessGET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.checks.map((c: { id: string }) => c.id)).toContain("content-db");
+
+    process.env.CONTENT_CREATOR_ENABLED = "false";
+    expect((await readinessGET()).status).toBe(404);
+  });
+});

--- a/content-creator/readiness.ts
+++ b/content-creator/readiness.ts
@@ -1,0 +1,177 @@
+import { accessSync, constants, existsSync, statSync } from "node:fs";
+import { dirname, isAbsolute, resolve } from "node:path";
+import { sql } from "drizzle-orm";
+import type { ContentDb } from "./db/client";
+import { contentPosts } from "./db/schema";
+import { getBrandProfile } from "./db/brand";
+import { countApproved } from "./scene-pool";
+import { listTemplateIds } from "./templates";
+import { safeResolveUnderRoot } from "./lib/safe-path";
+import { IMAGE_MODEL, REF_IMAGE_MODEL, TEXT_MODEL } from "./lib/config";
+
+export type ReadinessStatus = "pass" | "warn" | "fail";
+
+export interface ReadinessCheck {
+  id: string;
+  label: string;
+  status: ReadinessStatus;
+  detail: string;
+}
+
+export interface ContentCreatorReadiness {
+  ok: boolean;
+  status: ReadinessStatus;
+  checkedAt: string;
+  summary: { pass: number; warn: number; fail: number };
+  checks: ReadinessCheck[];
+  facts: {
+    templateCount: number;
+    approvedScenes: number;
+    textModel: string;
+    imageModel: string;
+    refImageModel: string;
+  };
+}
+
+interface EnvLike {
+  [key: string]: string | undefined;
+}
+
+function check(id: string, label: string, status: ReadinessStatus, detail: string): ReadinessCheck {
+  return { id, label, status, detail };
+}
+
+function apiKeyReady(value: string | undefined): boolean {
+  return !!value && !/^(local-|your-|change-me|placeholder)/i.test(value);
+}
+
+function isLocalDatabaseUrl(value: string | undefined): boolean {
+  if (!value) return false;
+  try {
+    const url = new URL(value);
+    return url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "::1";
+  } catch {
+    return false;
+  }
+}
+
+function mediaDirCheck(env: EnvLike, cwd: string): ReadinessCheck {
+  const configured = env.CONTENT_MEDIA_DIR || "content-creator/media";
+  const dir = isAbsolute(configured) ? configured : resolve(cwd, configured);
+  if (existsSync(dir)) {
+    try {
+      const stat = statSync(dir);
+      if (!stat.isDirectory()) return check("media-dir", "Media directory", "fail", "CONTENT_MEDIA_DIR exists but is not a directory");
+      accessSync(dir, constants.R_OK | constants.W_OK);
+      return check("media-dir", "Media directory", "pass", "media directory exists and is readable/writable");
+    } catch (e) {
+      return check("media-dir", "Media directory", "fail", `media directory is not accessible: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  try {
+    accessSync(dirname(dir), constants.R_OK | constants.W_OK);
+    return check("media-dir", "Media directory", "warn", "media directory is missing, but parent is writable and generation can create it");
+  } catch {
+    return check("media-dir", "Media directory", "fail", "media directory is missing and parent is not writable");
+  }
+}
+
+export function inspectContentCreatorReadiness(db: ContentDb, env: EnvLike = process.env, cwd = process.cwd()): ContentCreatorReadiness {
+  const checks: ReadinessCheck[] = [];
+  const templates = listTemplateIds();
+  const brand = getBrandProfile(db);
+  const approvedScenes = countApproved(db);
+
+  db.select({ n: sql<number>`count(*)` }).from(contentPosts).get();
+  checks.push(check("content-db", "Content SQLite DB", "pass", "content DB opened and schema query succeeded"));
+
+  checks.push(
+    check(
+      "app-db-url",
+      "App DATABASE_URL",
+      isLocalDatabaseUrl(env.DATABASE_URL) ? "pass" : "fail",
+      isLocalDatabaseUrl(env.DATABASE_URL) ? "DATABASE_URL points to local Postgres" : "DATABASE_URL is missing or not local",
+    ),
+  );
+
+  checks.push(
+    check(
+      "google-api-key",
+      "Gemini API key",
+      apiKeyReady(env.GOOGLE_GENERATIVE_AI_API_KEY) ? "pass" : "fail",
+      apiKeyReady(env.GOOGLE_GENERATIVE_AI_API_KEY) ? "configured (value hidden)" : "missing or placeholder",
+    ),
+  );
+
+  checks.push(
+    check(
+      "models",
+      "Content models",
+      env.CONTENT_TEXT_MODEL && env.CONTENT_IMAGE_MODEL && env.CONTENT_REF_IMAGE_MODEL ? "pass" : "warn",
+      `text=${TEXT_MODEL}, image=${IMAGE_MODEL}, ref=${REF_IMAGE_MODEL}`,
+    ),
+  );
+
+  checks.push(mediaDirCheck(env, cwd));
+
+  checks.push(
+    check(
+      "brand-cta",
+      "Brand CTA URL",
+      brand.ctaUrl.trim() ? "pass" : "fail",
+      brand.ctaUrl.trim() ? "ctaUrl is set for caption validation" : "ctaUrl is empty; generation fails before paid calls",
+    ),
+  );
+
+  checks.push(
+    check(
+      "brand-ref",
+      "Brand reference image",
+      brand.refImagePath && safeResolveUnderRoot(cwd, brand.refImagePath) ? "pass" : "warn",
+      brand.refImagePath && safeResolveUnderRoot(cwd, brand.refImagePath) ? "reference image exists and is safe" : "reference image is missing or unsafe",
+    ),
+  );
+
+  checks.push(
+    check(
+      "approved-scenes",
+      "Approved scenes",
+      approvedScenes > 0 ? "pass" : "warn",
+      approvedScenes > 0 ? `${approvedScenes} approved scene(s) available for random-cards` : "no approved scenes; random-cards finalize will fail before paid caption",
+    ),
+  );
+
+  checks.push(
+    check(
+      "templates",
+      "Templates",
+      templates.length > 0 ? "pass" : "fail",
+      `${templates.length} template(s): ${templates.join(", ")}`,
+    ),
+  );
+
+  const summary = checks.reduce(
+    (acc, c) => {
+      acc[c.status] += 1;
+      return acc;
+    },
+    { pass: 0, warn: 0, fail: 0 },
+  );
+  const status: ReadinessStatus = summary.fail > 0 ? "fail" : summary.warn > 0 ? "warn" : "pass";
+
+  return {
+    ok: status !== "fail",
+    status,
+    checkedAt: new Date().toISOString(),
+    summary,
+    checks,
+    facts: {
+      templateCount: templates.length,
+      approvedScenes,
+      textModel: TEXT_MODEL,
+      imageModel: IMAGE_MODEL,
+      refImageModel: REF_IMAGE_MODEL,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Add a read-only `/content-creator/api/readiness` endpoint that reports local Content Creator readiness before generation.
- Show a readiness panel on `/content-creator` with PASS/WARN/FAIL checks for local DB, app DB URL, Gemini key presence, configured models, media dir, brand CTA/ref image, approved scenes, and templates.
- Add focused tests for readiness success/failure and feature-gated route behavior.

## Why
Local Content Creator failures were easy to discover only after opening the UI or starting a generation flow. This panel makes the current local state visible before paid/provider paths are used, so local setup issues are caught earlier and with safer error messages.

## Safety / Scope
- Read-only endpoint and UI panel only.
- No Gemini calls.
- No Facebook calls.
- No production DB mutation.
- Does not print or return secret values; Gemini key is reported only as configured/missing.
- Does not auto-fix env, create media files, run migrations, or change prompt/model behavior.

## Checks Included
- `content-db`: SQLite DB opens and schema query succeeds.
- `app-db-url`: `DATABASE_URL` points to local Postgres.
- `google-api-key`: key exists and is not a known placeholder.
- `models`: content model env/config visibility.
- `media-dir`: content media directory is writable or parent can create it.
- `brand-cta`: CTA URL exists so generation will not fail before paid calls.
- `brand-ref`: brand reference path exists and passes safe path resolution.
- `approved-scenes`: random-cards has approved scenes available.
- `templates`: content templates are registered.

## Verification
- `npx vitest run content-creator/__tests__/readiness.test.ts content-creator/__tests__/brand.test.ts content-creator/__tests__/scene-pool.test.ts content-creator/__tests__/enabled.test.ts` -> 20/20 pass
- `npx vitest run content-creator/__tests__` -> 384/384 pass
- `npx tsc --noEmit` -> pass
- `git diff --check` -> pass
- `npm run content-creator:preflight` -> pass
- Runtime smoke on local dev server:
  - `GET /content-creator/api/readiness` -> 200, `status=pass`, summary `pass=9 warn=0 fail=0`
  - `GET /content-creator` -> 200
  - `GET /content-creator/api/posts` -> 200

## Team Protocol
Phase 2 dogfood for the team operating standard.
- Reviewer: `too`
- Runtime verifier: `toongtoong` if needed
- Paid/live policy: none used
