### PR TITLE
ci: reinclude mechanical test suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,21 +81,11 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Prepare test database
+        run: npx prisma migrate deploy
+
       - name: Test
-        run: |
-          # Prove-phase subset: exclude pre-existing CI-unready suites tracked separately.
-          # Excluded:
-          # - __tests__/app/billing-page-phase4.test.tsx: react-three/fiber mock missing extend in CI.
-          # - __tests__/app/transactions-page-phase2.test.tsx: react-three/fiber mock missing extend in CI.
-          # - __tests__/services/slip-verification-service.test.ts: env contract expects SlipOK log=true.
-          # - __tests__/app/cards-import.test.ts: requires migrated cards table before test phase.
-          # - __tests__/api/dev-local-db.test.ts: expects undefined DATABASE_URL, but CI sets local DB URL.
-          npm run test -- \
-            --exclude __tests__/app/billing-page-phase4.test.tsx \
-            --exclude __tests__/app/transactions-page-phase2.test.tsx \
-            --exclude __tests__/services/slip-verification-service.test.ts \
-            --exclude __tests__/app/cards-import.test.ts \
-            --exclude __tests__/api/dev-local-db.test.ts
+        run: npm run test
 
       - name: Build
         run: npm run build

--- a/__tests__/api/dev-local-db.test.ts
+++ b/__tests__/api/dev-local-db.test.ts
@@ -11,6 +11,7 @@ describe("Local DB Safety Guards", () => {
   beforeEach(() => {
     vi.resetModules();
     process.env = { ...originalEnv };
+    delete process.env.DATABASE_URL;
   });
 
   afterEach(() => {

--- a/__tests__/services/slip-verification-service.test.ts
+++ b/__tests__/services/slip-verification-service.test.ts
@@ -13,6 +13,7 @@ describe('slip-verification-service phase2 contract', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     process.env = { ...originalEnv };
+    process.env.SLIPOK_VERIFY_LOG = 'true';
   });
 
   afterEach(() => {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -47,6 +47,7 @@ vi.mock('@react-three/fiber', () => ({
     // Mock animation frame
     callback(Date.now() * 0.001);
   }),
+  extend: vi.fn(),
   useThree: vi.fn(() => ({
     camera: {
       position: { x: 0, y: 0, z: 5 },


### PR DESCRIPTION
## Summary
- Re-include all five suites previously excluded from the prove-phase CI gate.
- Keep fixes limited to test setup, test env control, and CI ordering.
- CI now runs full `npm run test` with no Vitest excludes.

## Contract / Source of Truth
- Test setup owns rendering/browser mocks.
- Tests own env values they assert.
- CI owns ephemeral local Postgres schema setup before DB-backed tests.

## Red Baseline
Intentional red baseline: no · Expected-green owner: builder/tester

## Layers Touched
- src: no / tests: yes / bin: no / docs: no / deploy: .github/workflows/ci.yml

## Root Cause Notes
- billing-page-phase4 + transactions-page-phase2: shared `@react-three/fiber` test mock lacked `extend`, while `mimi-avatar.tsx` calls `extend({ UnrealBloomPass })` at import time. Added `extend: vi.fn()` to setup; no product code changed.
- dev-local-db: test inherited CI step-level `DATABASE_URL`, so `isLocalDatabaseUrl(undefined)` read ambient env and returned true. Test now deletes `DATABASE_URL` in setup so each case controls env explicitly.
- cards-import: CI ran DB-backed tests before applying Prisma migrations, so `public.cards` did not exist. CI now runs `npx prisma migrate deploy` before Test against the CI-local Postgres service.
- slip-verification-service: product default `SLIPOK_VERIFY_LOG !== "false"` is correct, but test depended on ambient CI env. Test now sets `SLIPOK_VERIFY_LOG=true` itself and restores env after each test.

## Verification (verify-real-context = CLAUDE.md hard rule)
- normal path: Node 22.18.0 focused tests PASS for billing/transactions/dev-local-db/cards-import/slip.
- normal path: Node 22.18.0 full `npm run test` PASS locally against local Docker Postgres after `prisma migrate deploy`: 101 files / 708 tests.
- normal path: `npm run lint` PASS.
- normal path: `npm run build` PASS against local Docker Postgres.
- real runtime verified: PR GitHub Actions pending.

## Safety
- no-op/preserve: product code untouched / backup-rollback: revert PR / operator-owned deploy? yes
- Paid/live: no Gemini/Facebook/prod DB; local Docker Postgres and CI-local Postgres only.

## Not Done
- No product behavior changes.
- No production DB migration beyond CI-local migration application.